### PR TITLE
feat(auth): add password visibility toggle on register page

### DIFF
--- a/packages/client/src/pages/auth/RegisterPage.tsx
+++ b/packages/client/src/pages/auth/RegisterPage.tsx
@@ -5,13 +5,14 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { registerSchema, type RegisterInput } from "@empcloud/shared";
 import { useRegister } from "@/api/hooks";
 import { useAuthStore } from "@/lib/auth-store";
-import { Building2 } from "lucide-react";
+import { Building2, Eye, EyeOff } from "lucide-react";
 
 export default function RegisterPage() {
   const navigate = useNavigate();
   const registerMutation = useRegister();
   const setAuth = useAuthStore((s) => s.login);
   const [error, setError] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
 
   const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<RegisterInput>({
     resolver: zodResolver(registerSchema),
@@ -91,7 +92,22 @@ export default function RegisterPage() {
             </div>
             <div className="col-span-2">
               <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-              <input type="password" {...register("password")} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" placeholder="Min 8 chars, upper, lower, digit, special" />
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  {...register("password")}
+                  className="w-full px-3 py-2 pr-10 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                  placeholder="Min 8 chars, upper, lower, digit, special"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
               {errors.password && <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds an eye icon toggle inside the password field on the register page.
- Clicking the icon flips the input between `password` and `text` so the user can verify what they typed.
- Uses `Eye` / `EyeOff` icons from `lucide-react` (already a dependency).
- Matches the existing pattern used on `LoginPage.tsx`.
- Adds `aria-label` for accessibility.

## Test plan
- [ ] Open `/register` and type a password.
- [ ] Click the eye icon and confirm the password becomes visible as plain text.
- [ ] Click again and confirm it hides.
- [ ] Submit the form and confirm registration still works as before.