### PR TITLE
fix(helpdesk): order My Tickets by ticket id, not created_at

### DIFF
--- a/packages/server/src/services/helpdesk/helpdesk.service.ts
+++ b/packages/server/src/services/helpdesk/helpdesk.service.ts
@@ -558,7 +558,7 @@ export async function getMyTickets(
         `(SELECT CONCAT(u.first_name, ' ', u.last_name) FROM users u WHERE u.id = helpdesk_tickets.assigned_to) as assigned_to_name`
       )
     )
-    .orderBy("created_at", "desc")
+    .orderBy("helpdesk_tickets.id", "desc")
     .limit(perPage)
     .offset((page - 1) * perPage);
 


### PR DESCRIPTION
## Summary
Closes #1421.

The `My Tickets` list under Workplace was ordered by `created_at DESC`, but the UI displays the ticket `id` as the visible ticket number. When multiple tickets were created within the same second (common for rapid self-service submissions), the `created_at` sort became non-deterministic and the displayed ticket numbers appeared out of order.

This PR orders by `helpdesk_tickets.id DESC` instead, so the list always matches the user's mental model: newest ticket number at the top.

### Root cause
- `getMyTickets()` in `packages/server/src/services/helpdesk/helpdesk.service.ts` had `.orderBy("created_at", "desc")`
- No `ticket_number` column exists — the auto-increment `id` IS the visible ticket number
- MySQL sort on identical timestamps is not stable, so two tickets with the same `created_at` could appear in any order

### Fix
One-line change: `orderBy("helpdesk_tickets.id", "desc")`

## Test plan
- [ ] Create 5 tickets in quick succession via Self Service then Request Update.
- [ ] Navigate to Workplace then My Tickets.
- [ ] Verify the ticket ids appear strictly descending (e.g. `#42, #41, #40, #39, #38`).
- [ ] Apply status/category filters and confirm order is still by id descending within the filtered results.
- [ ] Paginate to page 2 and confirm continuation of the descending id sequence.