### PR TITLE
feat(employees): add edit modal and delete action in directory

### DIFF
--- a/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2 } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2 } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments } from "@/api/hooks";
+import { useAuthStore } from "@/lib/auth-store";
 import * as XLSX from "xlsx";
 
 // ---------------------------------------------------------------------------
@@ -93,15 +94,26 @@ function parseUploadedFile(file: File): Promise<any[]> {
 
 export default function EmployeeDirectoryPage() {
   const qc = useQueryClient();
+  const currentUser = useAuthStore((s) => s.user);
+  const canDelete = currentUser?.role === "org_admin" || currentUser?.role === "super_admin";
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [departmentId, setDepartmentId] = useState<string>("");
   const [showUpload, setShowUpload] = useState(false);
   const [uploadRows, setUploadRows] = useState<any[]>([]);
   const [uploadResult, setUploadResult] = useState<any>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
+  const [editTargetId, setEditTargetId] = useState<number | null>(null);
+  const [editError, setEditError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
   const { data: departments } = useDepartments();
+
+  const { data: locations } = useQuery({
+    queryKey: ["org-locations"],
+    queryFn: () => api.get("/organizations/me/locations").then((r) => r.data.data),
+    staleTime: 60000,
+  });
 
   const { data, isLoading } = useQuery({
     queryKey: ["employee-directory", { page, search: search || undefined, department_id: departmentId || undefined }],
@@ -129,6 +141,38 @@ export default function EmployeeDirectoryPage() {
     onSuccess: (data) => {
       setUploadResult(data);
       qc.invalidateQueries({ queryKey: ["employee-directory"] });
+    },
+  });
+
+  const deleteEmployee = useMutation({
+    mutationFn: (id: number) => api.delete(`/users/${id}`).then((r) => r.data),
+    onSuccess: () => {
+      setDeleteTarget(null);
+      qc.invalidateQueries({ queryKey: ["employee-directory"] });
+    },
+  });
+
+  const { data: editEmployee, isLoading: editLoading } = useQuery({
+    queryKey: ["employee-edit", editTargetId],
+    queryFn: () => api.get(`/employees/${editTargetId}`).then((r) => r.data.data),
+    enabled: editTargetId !== null,
+  });
+
+  const updateEmployee = useMutation({
+    mutationFn: (row: any) =>
+      api.post("/employees/bulk-update", { rows: [row] }).then((r) => r.data.data),
+    onSuccess: (data) => {
+      const detail = data?.details?.[0];
+      if (detail?.status === "error") {
+        setEditError(detail.error || "Update failed");
+        return;
+      }
+      setEditTargetId(null);
+      setEditError(null);
+      qc.invalidateQueries({ queryKey: ["employee-directory"] });
+    },
+    onError: (err: any) => {
+      setEditError(err?.response?.data?.error?.message || "Update failed");
     },
   });
 
@@ -336,6 +380,7 @@ export default function EmployeeDirectoryPage() {
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Designation</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Emp Code</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Status</th>
+              <th className="text-right text-xs font-medium text-gray-500 uppercase px-6 py-3">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
@@ -354,12 +399,13 @@ export default function EmployeeDirectoryPage() {
                     <td className="px-6 py-4"><div className="h-4 w-24 bg-gray-200 rounded" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-16 bg-gray-200 rounded" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-14 bg-gray-200 rounded-full" /></td>
+                    <td className="px-6 py-4"><div className="h-4 w-16 bg-gray-200 rounded ml-auto" /></td>
                   </tr>
                 ))}
               </>
             ) : employees.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={7} className="px-6 py-8 text-center text-gray-400">
                   No employees found
                 </td>
               </tr>
@@ -401,11 +447,266 @@ export default function EmployeeDirectoryPage() {
                       {emp.status === 1 ? "Active" : "Inactive"}
                     </span>
                   </td>
+                  <td className="px-6 py-4">
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditTargetId(emp.id);
+                          setEditError(null);
+                        }}
+                        className="inline-flex items-center justify-center h-8 w-8 rounded-lg text-gray-500 hover:bg-brand-50 hover:text-brand-600 transition-colors"
+                        title="Edit employee"
+                        aria-label={`Edit ${emp.first_name} ${emp.last_name}`}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      {canDelete && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setDeleteTarget({ id: emp.id, name: `${emp.first_name} ${emp.last_name}` })
+                          }
+                          disabled={emp.id === currentUser?.id}
+                          className="inline-flex items-center justify-center h-8 w-8 rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 transition-colors disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-gray-500"
+                          title={emp.id === currentUser?.id ? "You cannot delete your own account" : "Delete employee"}
+                          aria-label={`Delete ${emp.first_name} ${emp.last_name}`}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      )}
+                    </div>
+                  </td>
                 </tr>
               ))
             )}
           </tbody>
         </table>
+
+        {/* Edit Employee Modal */}
+        {editTargetId !== null && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={() => !updateEmployee.isPending && setEditTargetId(null)}
+          >
+            <div
+              className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">Edit Employee</h3>
+                  <p className="text-xs text-gray-400">
+                    {editLoading ? "Loading..." : editEmployee ? `${editEmployee.first_name} ${editEmployee.last_name} — ${editEmployee.email}` : ""}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => !updateEmployee.isPending && setEditTargetId(null)}
+                  className="text-gray-400 hover:text-gray-600"
+                  aria-label="Close"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+              {editLoading || !editEmployee ? (
+                <div className="flex justify-center items-center py-16">
+                  <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                </div>
+              ) : (
+                <form
+                  key={editEmployee.id}
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    setEditError(null);
+                    const fd = new FormData(e.currentTarget);
+                    const row: any = { id: editEmployee.id };
+                    for (const [key, value] of fd.entries()) {
+                      row[key] = typeof value === "string" ? value : "";
+                    }
+                    updateEmployee.mutate(row);
+                  }}
+                  className="flex flex-col overflow-hidden"
+                >
+                  <div className="flex-1 overflow-y-auto px-6 py-5">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Emp Code</label>
+                        <input name="emp_code" defaultValue={editEmployee.emp_code || ""} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Contact</label>
+                        <input name="contact_number" defaultValue={editEmployee.contact_number || ""} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">First Name <span className="text-red-500">*</span></label>
+                        <input name="first_name" defaultValue={editEmployee.first_name || ""} required className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Last Name <span className="text-red-500">*</span></label>
+                        <input name="last_name" defaultValue={editEmployee.last_name || ""} required className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div className="sm:col-span-2">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                        <input type="email" defaultValue={editEmployee.email || ""} disabled className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-gray-50 text-gray-500" />
+                        <p className="text-xs text-gray-400 mt-1">Email cannot be changed from this screen.</p>
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Designation</label>
+                        <input name="designation" defaultValue={editEmployee.designation || ""} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Department</label>
+                        <select
+                          name="department_name"
+                          defaultValue={deptList.find((d: any) => d.id === editEmployee.department_id)?.name || ""}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                        >
+                          <option value="">—</option>
+                          {deptList.map((d: any) => (
+                            <option key={d.id} value={d.name}>{d.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Location</label>
+                        <select
+                          name="location_name"
+                          defaultValue={(locations || []).find((l: any) => l.id === editEmployee.location_id)?.name || ""}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                        >
+                          <option value="">—</option>
+                          {(locations || []).map((l: any) => (
+                            <option key={l.id} value={l.name}>{l.name}</option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Employment Type</label>
+                        <select name="employment_type" defaultValue={editEmployee.employment_type || "full_time"} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+                          <option value="full_time">Full Time</option>
+                          <option value="part_time">Part Time</option>
+                          <option value="contract">Contract</option>
+                          <option value="intern">Intern</option>
+                        </select>
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Gender</label>
+                        <select name="gender" defaultValue={editEmployee.gender || ""} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+                          <option value="">—</option>
+                          <option value="male">Male</option>
+                          <option value="female">Female</option>
+                          <option value="other">Other</option>
+                        </select>
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Date of Birth</label>
+                        <input type="date" name="date_of_birth" defaultValue={formatDate(editEmployee.date_of_birth)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Date of Joining</label>
+                        <input type="date" name="date_of_joining" defaultValue={formatDate(editEmployee.date_of_joining)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none" />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
+                        <select name="role" defaultValue={editEmployee.role || "employee"} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none">
+                          <option value="employee">Employee</option>
+                          <option value="manager">Manager</option>
+                          <option value="hr_admin">HR Admin</option>
+                          <option value="org_admin">Org Admin</option>
+                        </select>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Address</label>
+                        <textarea name="address" defaultValue={editEmployee.address || ""} rows={2} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none resize-none" />
+                      </div>
+                    </div>
+                    {editError && (
+                      <div className="mt-4 p-3 rounded-lg bg-red-50 text-sm text-red-700">{editError}</div>
+                    )}
+                  </div>
+                  <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-100 bg-gray-50 rounded-b-2xl">
+                    <button
+                      type="button"
+                      onClick={() => !updateEmployee.isPending && setEditTargetId(null)}
+                      disabled={updateEmployee.isPending}
+                      className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-white disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={updateEmployee.isPending}
+                      className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50"
+                    >
+                      {updateEmployee.isPending ? (
+                        <><Loader2 className="h-4 w-4 animate-spin" /> Saving...</>
+                      ) : (
+                        "Save Changes"
+                      )}
+                    </button>
+                  </div>
+                </form>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Delete Confirmation Modal */}
+        {deleteTarget && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={() => !deleteEmployee.isPending && setDeleteTarget(null)}
+          >
+            <div
+              className="bg-white rounded-xl shadow-xl w-full max-w-md"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="px-6 py-5 border-b border-gray-100">
+                <div className="flex items-start gap-3">
+                  <div className="h-10 w-10 rounded-full bg-red-50 flex items-center justify-center flex-shrink-0">
+                    <Trash2 className="h-5 w-5 text-red-600" />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900">Delete employee</h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                      Deactivate <span className="font-medium text-gray-700">{deleteTarget.name}</span>? This will revoke their access immediately. You can reactivate them later from user management.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              {deleteEmployee.isError && (
+                <div className="mx-6 mt-4 p-3 rounded-lg bg-red-50 text-sm text-red-700">
+                  {(deleteEmployee.error as any)?.response?.data?.error?.message || "Failed to delete employee"}
+                </div>
+              )}
+              <div className="px-6 py-4 bg-gray-50 rounded-b-xl flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={() => setDeleteTarget(null)}
+                  disabled={deleteEmployee.isPending}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-white disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => deleteEmployee.mutate(deleteTarget.id)}
+                  disabled={deleteEmployee.isPending}
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+                >
+                  {deleteEmployee.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                    </>
+                  ) : (
+                    "Delete"
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Pagination */}
         {meta && meta.total_pages > 1 && (


### PR DESCRIPTION
## Summary
Adds an **Actions** column to the Employee Directory table with two icon buttons per row.

### Edit (pencil)
Opens a modal pre-filled with the employee's current details. The modal exposes exactly the 14 fields from the existing Excel bulk-update export:

| Field | Input |
|---|---|
| Emp Code | text |
| First Name * | text (required) |
| Last Name * | text (required) |
| Email | disabled (not editable here) |
| Contact | text |
| Designation | text |
| Department | dropdown (from existing departments) |
| Location | dropdown (from existing locations) |
| Employment Type | dropdown (full_time / part_time / contract / intern) |
| Gender | dropdown |
| Date of Birth | date |
| Date of Joining | date |
| Role | dropdown (employee / manager / hr_admin / org_admin) |
| Address | textarea |

- Fetches full employee details via `GET /employees/:id` when opened.
- Save posts a single-row payload to `POST /employees/bulk-update`, reusing the existing server-side validation, field mapping (dept/location names → ids), audit trail, and error handling.
- Inline server errors show in the modal.
- On success, the directory refreshes automatically via React Query.

### Delete (trash)
- Rendered only for `org_admin` / `super_admin` (matches the `requireOrgAdmin` guard on `DELETE /users/:id`).
- Confirmation modal names the specific employee before deactivating.
- Button is disabled on the current user's own row so HR cannot lock themselves out.
- Calls the existing soft-delete endpoint — users are deactivated, not hard-deleted, and can be restored later from user management.

## Test plan
- [ ] Open `/employees` as `org_admin`.
- [ ] Click pencil on any row — modal opens pre-filled with current values.
- [ ] Change Designation and Department, Save, confirm the row updates in the table.
- [ ] Open modal again, change Date of Birth, Save, confirm persistence.
- [ ] Click trash on another employee — confirmation modal shows the name.
- [ ] Confirm delete, verify the row disappears (soft-delete; user is deactivated).
- [ ] Try to click trash on your own row — button is disabled with explanatory tooltip.
- [ ] Log in as `hr_admin` and confirm trash buttons are not rendered, but pencil still is.
- [ ] Empty-string fields (e.g. blank contact number) round-trip cleanly.