### PR TITLE
fix(helpdesk): make Resolved Today list match dashboard count

### DIFF
--- a/packages/client/src/pages/helpdesk/HelpdeskDashboardPage.tsx
+++ b/packages/client/src/pages/helpdesk/HelpdeskDashboardPage.tsx
@@ -87,7 +87,7 @@ export default function HelpdeskDashboardPage() {
       value: stats.resolved_today,
       icon: CheckCircle2,
       color: "text-green-600 bg-green-50",
-      href: "/helpdesk/tickets?status=resolved",
+      href: "/helpdesk/tickets?resolved_date=today",
     },
   ];
 

--- a/packages/client/src/pages/helpdesk/TicketListPage.tsx
+++ b/packages/client/src/pages/helpdesk/TicketListPage.tsx
@@ -44,6 +44,7 @@ export default function TicketListPage() {
   const [priority, setPriority] = useState(searchParams.get("priority") || "");
   const [search, setSearch] = useState(searchParams.get("search") || "");
   const [searchInput, setSearchInput] = useState(searchParams.get("search") || "");
+  const [resolvedDate, setResolvedDate] = useState(searchParams.get("resolved_date") || "");
 
   // Keep the URL in sync with the active filters so the link stays shareable
   // and browser back/forward navigation restores the previous filter set.
@@ -53,10 +54,11 @@ export default function TicketListPage() {
     if (category) next.category = category;
     if (priority) next.priority = priority;
     if (search) next.search = search;
+    if (resolvedDate) next.resolved_date = resolvedDate;
     setSearchParams(next, { replace: true });
-  }, [status, category, priority, search, setSearchParams]);
+  }, [status, category, priority, search, resolvedDate, setSearchParams]);
   const { data, isLoading } = useQuery({
-    queryKey: ["helpdesk-tickets", page, status, category, priority, search],
+    queryKey: ["helpdesk-tickets", page, status, category, priority, search, resolvedDate],
     queryFn: () =>
       api
         .get("/helpdesk/tickets", {
@@ -67,6 +69,7 @@ export default function TicketListPage() {
             ...(category && { category }),
             ...(priority && { priority }),
             ...(search && { search }),
+            ...(resolvedDate && { resolved_date: resolvedDate }),
           },
         })
         .then((r) => r.data),
@@ -175,6 +178,21 @@ export default function TicketListPage() {
             ))}
           </select>
         </div>
+        {resolvedDate && (
+          <div className="mt-3 flex items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-green-50 text-green-700 text-xs font-medium">
+              Resolved {resolvedDate === "today" ? "today" : `on ${resolvedDate}`}
+              <button
+                type="button"
+                onClick={() => { setResolvedDate(""); setPage(1); }}
+                className="hover:text-green-900"
+                aria-label="Clear resolved date filter"
+              >
+                ×
+              </button>
+            </span>
+          </div>
+        )}
       </div>
 
       {/* Tickets Table */}

--- a/packages/server/src/api/routes/helpdesk.routes.ts
+++ b/packages/server/src/api/routes/helpdesk.routes.ts
@@ -128,6 +128,7 @@ router.get(
         assigned_to: filters.assigned_to,
         raised_by: filters.raised_by,
         search: filters.search,
+        resolved_date: filters.resolved_date,
       });
       sendPaginated(res, result.tickets, result.total, filters.page, filters.per_page);
     } catch (err) {

--- a/packages/server/src/services/helpdesk/helpdesk.service.ts
+++ b/packages/server/src/services/helpdesk/helpdesk.service.ts
@@ -81,6 +81,7 @@ export async function listTickets(
     assigned_to?: number;
     raised_by?: number;
     search?: string;
+    resolved_date?: string;
   }
 ) {
   const db = getDB();
@@ -89,6 +90,31 @@ export async function listTickets(
 
   let query = db("helpdesk_tickets")
     .where({ "helpdesk_tickets.organization_id": orgId });
+
+  // #1430 — "Resolved on X" filter. Matches the dashboard's resolved_today
+  // count so the list after clicking the stat card shows the same tickets,
+  // regardless of whether they've since been closed or reopened.
+  if (filters?.resolved_date) {
+    let start: Date;
+    if (filters.resolved_date === "today") {
+      start = new Date();
+      start.setHours(0, 0, 0, 0);
+    } else {
+      start = new Date(filters.resolved_date);
+      if (isNaN(start.getTime())) {
+        start = new Date();
+        start.setHours(0, 0, 0, 0);
+      } else {
+        start.setHours(0, 0, 0, 0);
+      }
+    }
+    const end = new Date(start);
+    end.setDate(end.getDate() + 1);
+    query = query
+      .whereNotNull("helpdesk_tickets.resolved_at")
+      .where("helpdesk_tickets.resolved_at", ">=", start)
+      .where("helpdesk_tickets.resolved_at", "<", end);
+  }
 
   // #1376 — Dashboard's "open ticket" count aggregates 4 statuses. When the
   // client filters by status=open, return the same set so the counts align.

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -986,6 +986,11 @@ export const helpdeskQuerySchema = paginationSchema.extend({
   assigned_to: z.coerce.number().int().positive().optional(),
   raised_by: z.coerce.number().int().positive().optional(),
   search: z.string().optional(),
+  // "today" or YYYY-MM-DD. When set, only tickets whose resolved_at falls on
+  // that date are returned — regardless of current status. Used by the
+  // "Resolved Today" stat card to avoid drifting from the dashboard count
+  // when tickets are resolved and then closed or reopened.
+  resolved_date: z.string().optional(),
 });
 
 export type CreateTicketInput = z.infer<typeof createTicketSchema>;


### PR DESCRIPTION
## Summary
Closes #1430.

The helpdesk dashboard's **Resolved Today** stat card counts tickets with `resolved_at >= today` regardless of current status, but the card used to navigate to `/helpdesk/tickets?status=resolved` which filters by `status='resolved'` with no date restriction. A ticket resolved today and then closed or reopened would be in the count but missing from the list.

## Fix
Introduces a `resolved_date` filter on the list endpoint that matches the dashboard semantics: returns tickets whose `resolved_at` falls on the given date, regardless of current status. The stat card now links to `?resolved_date=today` and the list page renders a removable filter pill so users can see what's filtered and clear it.

## Changes

### Server
- `helpdeskQuerySchema` in `packages/shared/src/validators/index.ts` gains an optional `resolved_date` string.
- `listTickets()` in `packages/server/src/services/helpdesk/helpdesk.service.ts` accepts `resolved_date` and filters by `resolved_at` in the half-open range `[start, start + 1 day)`. Accepts `"today"` or `YYYY-MM-DD`, falling back to today on an invalid value.
- Route in `packages/server/src/api/routes/helpdesk.routes.ts` passes the new filter through.

### Client
- `HelpdeskDashboardPage.tsx`: the Resolved Today stat card `href` is now `/helpdesk/tickets?resolved_date=today` instead of `?status=resolved`.
- `TicketListPage.tsx`: new `resolvedDate` state hydrated from and synced back to the URL, included in the API call. A green filter pill renders above the table when the filter is active with a `×` clear button.

## Test plan
- [ ] Resolve 2 tickets today, then close one of them.
- [ ] Helpdesk dashboard shows `Resolved Today = 2`.
- [ ] Click the card — tickets list opens and shows **both** tickets (the still-resolved one and the now-closed one).
- [ ] A green `Resolved today ×` pill is visible above the table.
- [ ] Click the `×` — filter clears, full list returns, URL loses `resolved_date` param.
- [ ] Share the filtered URL (`/helpdesk/tickets?resolved_date=today`) — loading it fresh applies the filter and shows the pill.