### PR TITLE
fix(helpdesk): show dislike count on knowledge base article cards

### DIFF
--- a/packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx
+++ b/packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx
@@ -448,6 +448,9 @@ export default function KnowledgeBasePage() {
                 <span className="flex items-center gap-1">
                   <ThumbsUp className="h-3 w-3" /> {a.helpful_count}
                 </span>
+                <span className="flex items-center gap-1">
+                  <ThumbsDown className="h-3 w-3" /> {a.not_helpful_count ?? 0}
+                </span>
                 <span>{a.author_name}</span>
               </div>
             </button>


### PR DESCRIPTION
## Summary
Closes #1435.

The Knowledge Base article cards on the list page rendered the view count and the helpful (Yes) count but never displayed the not-helpful (No) count. The article **detail** page already shows both, the server already returns `not_helpful_count` on every article row, and `ThumbsDown` is already imported in the file. The card was just missing the span.

### Root cause
[KnowledgeBasePage.tsx:444-452](packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx#L444-L452) only renders `view_count`, `helpful_count`, and `author_name`. The `not_helpful_count` field exists on the article row (column from `016_helpdesk.ts`, populated by the existing `rateArticle()` service when a user clicks No on the detail page) — it just never made it into the card markup.

### Fix
Three-line addition: a `<ThumbsDown>` icon span next to the existing `<ThumbsUp>` span. Same icon library, same styling, no schema or API changes.

```jsx
<span className="flex items-center gap-1">
  <ThumbsDown className="h-3 w-3" /> {a.not_helpful_count ?? 0}
</span>
```

## Test plan
- [ ] Open Workplace then Knowledge Base.
- [ ] On any article card, verify the three counts appear in order: views, helpful, not-helpful.
- [ ] Open the article detail page, click No, return to the list — the not-helpful count on that article's card increases by 1.
- [ ] Articles with no dislikes show `0` (not blank or `undefined`).