### PR TITLE
feat(people): merge Users page into Employees, single People view

### DIFF
--- a/packages/client/src/components/CsvImportUsersModal.tsx
+++ b/packages/client/src/components/CsvImportUsersModal.tsx
@@ -1,0 +1,516 @@
+// ============================================================================
+// CsvImportUsersModal
+// Shared Excel / CSV import modal for bulk-creating users/employees.
+// Originally lived inside pages/users/UsersPage.tsx; extracted here so the
+// Employees page (which absorbed the Users page) can reuse it.
+// Calls the existing server endpoints:
+//   POST /users/import          — parse + validate preview
+//   POST /users/import/execute  — commit the batch
+// ============================================================================
+
+import { useCallback, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  Upload,
+  Download,
+  X,
+  CheckCircle2,
+  XCircle,
+  FileSpreadsheet,
+  AlertTriangle,
+  Loader2,
+} from "lucide-react";
+import api from "@/api/client";
+import * as XLSX from "xlsx";
+
+const TEMPLATE_HEADERS = [
+  "first_name",
+  "last_name",
+  "full_name",
+  "email",
+  "password",
+  "role",
+  "emp_code",
+  "designation",
+  "department_name",
+  "location_name",
+  // Reporting manager can be given as ANY one of these three columns.
+  // Priority if multiple are set: email → code → name.
+  "reporting_manager_email",
+  "reporting_manager_code",
+  "reporting_manager_name",
+  "employment_type",
+  "date_of_joining",
+  "date_of_birth",
+  "gender",
+  "contact_number",
+  "address",
+];
+
+const TEMPLATE_SAMPLE_ROWS: Array<Record<string, string>> = [
+  {
+    first_name: "John",
+    last_name: "Doe",
+    full_name: "",
+    email: "john@company.com",
+    password: "Welcome@123",
+    role: "employee",
+    emp_code: "EMP001",
+    designation: "Software Engineer",
+    department_name: "Engineering",
+    location_name: "Bangalore",
+    reporting_manager_email: "manager@company.com",
+    reporting_manager_code: "",
+    reporting_manager_name: "",
+    employment_type: "full_time",
+    date_of_joining: "2026-01-15",
+    date_of_birth: "1995-05-10",
+    gender: "male",
+    contact_number: "+919876543210",
+    address: "12 MG Road, Bangalore",
+  },
+  {
+    first_name: "",
+    last_name: "",
+    full_name: "Aishwarya Keshav Murthy Gowda",
+    email: "aishwarya@company.com",
+    password: "",
+    role: "manager",
+    emp_code: "EMP002",
+    designation: "Product Manager",
+    department_name: "Product",
+    location_name: "Mumbai",
+    reporting_manager_email: "",
+    reporting_manager_code: "EMP010",
+    reporting_manager_name: "",
+    employment_type: "full_time",
+    date_of_joining: "01/06/2025",
+    date_of_birth: "22/11/1990",
+    gender: "female",
+    contact_number: "+919876543211",
+    address: "",
+  },
+  {
+    first_name: "Raj",
+    last_name: "Patel",
+    full_name: "",
+    email: "raj@company.com",
+    password: "Welcome@123",
+    role: "employee",
+    emp_code: "EMP003",
+    designation: "Senior Designer",
+    department_name: "Design",
+    location_name: "Bhilai",
+    reporting_manager_email: "",
+    reporting_manager_code: "",
+    reporting_manager_name: "Syamal Ghosh / Sumit Ghosh",
+    employment_type: "contract",
+    date_of_joining: "2026-03-01",
+    date_of_birth: "",
+    gender: "",
+    contact_number: "+919876543212",
+    address: "",
+  },
+];
+
+interface CsvRow {
+  first_name: string;
+  last_name: string;
+  full_name?: string;
+  email: string;
+  password?: string;
+  role?: string;
+  emp_code?: string;
+  designation?: string;
+  department_name?: string;
+  location_name?: string;
+  reporting_manager_email?: string;
+  reporting_manager_code?: string;
+  reporting_manager_name?: string;
+  employment_type?: string;
+  date_of_joining?: string;
+  date_of_birth?: string;
+  date_of_exit?: string;
+  gender?: string;
+  contact_number?: string;
+  address?: string;
+}
+
+interface ServerImportError {
+  row: number;
+  data: CsvRow;
+  errors: string[];
+}
+
+interface ServerImportPreview {
+  valid: CsvRow[];
+  errors: ServerImportError[];
+  totalRows: number;
+}
+
+interface Props {
+  onClose: () => void;
+  /** Extra React Query keys to invalidate after a successful import. */
+  invalidateKeys?: string[];
+}
+
+export default function CsvImportUsersModal({ onClose, invalidateKeys = [] }: Props) {
+  const queryClient = useQueryClient();
+  const [step, setStep] = useState<"upload" | "preview" | "importing" | "done">("upload");
+  const [preview, setPreview] = useState<ServerImportPreview | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [importResult, setImportResult] = useState<{
+    count: number;
+    createdDepartments?: string[];
+    createdLocations?: string[];
+    skipped?: Array<{ row: number; data?: Record<string, unknown>; errors: string[] }>;
+    totalRows?: number;
+  } | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback(async (file: File) => {
+    setUploadError(null);
+    setSelectedFile(file);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await api.post<{ data: ServerImportPreview }>("/users/import", form, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      setPreview(res.data.data);
+      setStep("preview");
+    } catch (err: any) {
+      const msg = err?.response?.data?.error?.message || err?.message || "Failed to parse file";
+      setUploadError(msg);
+    }
+  }, []);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const file = e.dataTransfer.files[0];
+      if (!file) return;
+      const name = file.name.toLowerCase();
+      if (name.endsWith(".xlsx") || name.endsWith(".xls") || name.endsWith(".csv")) {
+        handleFile(file);
+      }
+    },
+    [handleFile],
+  );
+
+  const downloadTemplate = () => {
+    const worksheet = XLSX.utils.json_to_sheet(TEMPLATE_SAMPLE_ROWS, {
+      header: TEMPLATE_HEADERS,
+    });
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Users");
+    XLSX.writeFile(workbook, "users_import_template.xlsx");
+  };
+
+  const validRows = preview?.valid ?? [];
+  const invalidRows = preview?.errors ?? [];
+
+  const handleImport = async () => {
+    if (!selectedFile) return;
+    setStep("importing");
+    try {
+      const form = new FormData();
+      form.append("file", selectedFile);
+      const res = await api.post<{
+        data: {
+          count: number;
+          createdDepartments?: string[];
+          createdLocations?: string[];
+          skipped?: Array<{ row: number; data?: Record<string, unknown>; errors: string[] }>;
+          totalRows?: number;
+        };
+      }>("/users/import/execute", form, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+      setImportResult(res.data.data);
+      // Invalidate both the users and employee-directory caches so either
+      // page reflects the newly-created rows immediately.
+      queryClient.invalidateQueries({ queryKey: ["users"] });
+      queryClient.invalidateQueries({ queryKey: ["employee-directory"] });
+      for (const key of invalidateKeys) {
+        queryClient.invalidateQueries({ queryKey: [key] });
+      }
+      setStep("done");
+    } catch (err: any) {
+      const msg =
+        err?.response?.data?.error?.message ||
+        err?.response?.data?.message ||
+        err?.message ||
+        "Import failed";
+      setUploadError(msg);
+      setStep("preview");
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl max-h-[85vh] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center gap-3">
+            <FileSpreadsheet className="h-5 w-5 text-brand-600" />
+            <h2 className="text-lg font-semibold text-gray-900">
+              Import Employees from Excel / CSV
+            </h2>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {step === "upload" && (
+            <div className="space-y-5">
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={downloadTemplate}
+                  className="flex items-center gap-2 text-sm font-medium text-brand-600 hover:text-brand-700 border border-brand-200 px-4 py-2 rounded-lg hover:bg-brand-50"
+                >
+                  <Download className="h-4 w-4" /> Download Template
+                </button>
+                <span className="text-sm text-gray-500">
+                  Download a sample Excel file with the correct headers.
+                </span>
+              </div>
+
+              <div
+                className={`border-2 border-dashed rounded-xl p-10 text-center transition-colors cursor-pointer ${
+                  dragOver ? "border-brand-500 bg-brand-50" : "border-gray-300 hover:border-gray-400"
+                }`}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragOver(true);
+                }}
+                onDragLeave={() => setDragOver(false)}
+                onDrop={onDrop}
+                onClick={() => fileRef.current?.click()}
+              >
+                <Upload className="h-10 w-10 text-gray-400 mx-auto mb-3" />
+                <p className="text-sm font-medium text-gray-700">
+                  Drag & drop your Excel or CSV file here
+                </p>
+                <p className="text-xs text-gray-400 mt-1">or click to browse</p>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept=".xlsx,.xls,.csv"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) handleFile(file);
+                  }}
+                />
+              </div>
+
+              {uploadError && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+                  {uploadError}
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === "preview" && preview && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-4 text-sm">
+                <span className="flex items-center gap-1 text-green-700">
+                  <CheckCircle2 className="h-4 w-4" /> {validRows.length} valid
+                </span>
+                {invalidRows.length > 0 && (
+                  <span className="flex items-center gap-1 text-red-600">
+                    <XCircle className="h-4 w-4" /> {invalidRows.length} invalid
+                  </span>
+                )}
+                <span className="text-gray-400">|</span>
+                <span className="text-gray-500">{preview.totalRows} total rows</span>
+                <button
+                  onClick={() => {
+                    setStep("upload");
+                    setPreview(null);
+                    setSelectedFile(null);
+                  }}
+                  className="ml-auto text-sm text-gray-500 hover:text-gray-700 underline"
+                >
+                  Upload different file
+                </button>
+              </div>
+
+              {uploadError && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+                  {uploadError}
+                </div>
+              )}
+
+              {invalidRows.length > 0 && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+                  <div className="flex items-center gap-2 text-red-700 font-medium text-sm mb-2">
+                    <AlertTriangle className="h-4 w-4" /> Rows with errors (fix your file and re-upload)
+                  </div>
+                  <div className="space-y-1 max-h-40 overflow-y-auto">
+                    {invalidRows.map((err, i) => (
+                      <p key={i} className="text-xs text-red-600">
+                        <span className="font-medium">Row {err.row}:</span> {err.errors.join("; ")}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {validRows.length > 0 && (
+                <div className="border border-gray-200 rounded-lg overflow-x-auto max-h-[40vh]">
+                  <table className="min-w-full text-xs">
+                    <thead className="bg-gray-50 sticky top-0">
+                      <tr>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">First Name</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Last Name</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Email</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Password</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Role</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Emp Code</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Designation</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Department</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Location</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Manager</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Type</th>
+                        <th className="px-3 py-2 text-left font-medium text-gray-500">Joining</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100">
+                      {validRows.map((row, i) => (
+                        <tr key={i}>
+                          <td className="px-3 py-2">{row.first_name}</td>
+                          <td className="px-3 py-2">{row.last_name}</td>
+                          <td className="px-3 py-2">{row.email}</td>
+                          <td className="px-3 py-2 text-gray-400">
+                            {row.password ? "••••••••" : <em className="text-gray-400">invite</em>}
+                          </td>
+                          <td className="px-3 py-2">{row.role || "employee"}</td>
+                          <td className="px-3 py-2">{row.emp_code}</td>
+                          <td className="px-3 py-2">{row.designation}</td>
+                          <td className="px-3 py-2">{row.department_name}</td>
+                          <td className="px-3 py-2">{row.location_name}</td>
+                          <td className="px-3 py-2">
+                            {row.reporting_manager_email ||
+                              row.reporting_manager_code ||
+                              row.reporting_manager_name ||
+                              ""}
+                          </td>
+                          <td className="px-3 py-2">{row.employment_type || "full_time"}</td>
+                          <td className="px-3 py-2">{row.date_of_joining}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+
+          {step === "importing" && (
+            <div className="flex flex-col items-center justify-center py-12 gap-4">
+              <Loader2 className="h-10 w-10 text-brand-600 animate-spin" />
+              <p className="text-sm text-gray-600">Importing employees... please wait.</p>
+            </div>
+          )}
+
+          {step === "done" && importResult && (
+            <div className="space-y-4 py-4">
+              <div className="flex items-center gap-3 text-green-700 bg-green-50 border border-green-200 rounded-lg p-4">
+                <CheckCircle2 className="h-6 w-6 flex-shrink-0" />
+                <div>
+                  <p className="font-semibold text-sm">Import Complete</p>
+                  <p className="text-sm mt-0.5">
+                    {importResult.count} employee{importResult.count !== 1 ? "s" : ""} imported
+                    successfully.
+                  </p>
+                </div>
+              </div>
+
+              {importResult.createdDepartments && importResult.createdDepartments.length > 0 && (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                  <p className="text-sm font-medium text-blue-700 mb-1">
+                    New departments created ({importResult.createdDepartments.length}):
+                  </p>
+                  <p className="text-xs text-blue-600">
+                    {importResult.createdDepartments.join(", ")}
+                  </p>
+                </div>
+              )}
+
+              {importResult.createdLocations && importResult.createdLocations.length > 0 && (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                  <p className="text-sm font-medium text-blue-700 mb-1">
+                    New locations created ({importResult.createdLocations.length}):
+                  </p>
+                  <p className="text-xs text-blue-600">
+                    {importResult.createdLocations.join(", ")}
+                  </p>
+                </div>
+              )}
+
+              {importResult.skipped && importResult.skipped.length > 0 && (
+                <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                  <p className="text-sm font-medium text-amber-700 mb-2">
+                    Skipped {importResult.skipped.length} row
+                    {importResult.skipped.length !== 1 ? "s" : ""} with errors:
+                  </p>
+                  <div className="space-y-1 max-h-40 overflow-y-auto">
+                    {importResult.skipped.map((err, i) => (
+                      <p key={i} className="text-xs text-amber-700">
+                        <span className="font-medium">Row {err.row}:</span> {err.errors.join("; ")}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+          {step === "preview" && validRows.length > 0 && (
+            <button
+              onClick={handleImport}
+              className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            >
+              <Upload className="h-4 w-4" />
+              Import {validRows.length} valid employee{validRows.length !== 1 ? "s" : ""}
+            </button>
+          )}
+          {step === "done" && (
+            <button
+              onClick={onClose}
+              className="bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            >
+              Close
+            </button>
+          )}
+          {(step === "upload" || step === "preview") && (
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 border border-gray-300 rounded-lg"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/layout/navigation.config.ts
+++ b/packages/client/src/components/layout/navigation.config.ts
@@ -112,8 +112,7 @@ export const adminNavItems: NavItem[] = [
     { path: "/modules/access", label: "Module Access", i18nKey: "nav.moduleAccess", icon: Shield },
   ]},
   { path: "/billing", label: "Billing", i18nKey: "nav.billing", icon: Receipt },
-  { path: "/users", label: "People", i18nKey: "nav.people", icon: Users, children: [
-    { path: "/users", label: "Users", i18nKey: "nav.users", icon: Users },
+  { path: "/employees", label: "People", i18nKey: "nav.people", icon: Users, children: [
     { path: "/employees", label: "Employees", i18nKey: "nav.employees", icon: Contact },
     { path: "/employees/probation", label: "Probation", i18nKey: "nav.probation", icon: UserCheck },
     { path: "/org-chart", label: "Org Chart", i18nKey: "nav.orgChart", icon: Network },

--- a/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
@@ -1,10 +1,11 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2, UserPlus, Mail } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2, UserPlus, Mail, FileSpreadsheet } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments, useInviteUser } from "@/api/hooks";
 import { useAuthStore } from "@/lib/auth-store";
+import CsvImportUsersModal from "@/components/CsvImportUsersModal";
 import * as XLSX from "xlsx";
 
 // ---------------------------------------------------------------------------
@@ -113,6 +114,9 @@ export default function EmployeeDirectoryPage() {
   const [inviteRole, setInviteRole] = useState("employee");
   const [inviteError, setInviteError] = useState("");
   const inviteUser = useInviteUser();
+
+  // Bulk CSV import (create new employees) — also absorbed from Users page.
+  const [showCsvImport, setShowCsvImport] = useState(false);
 
   // Pending invitations panel — only fetched for org_admin.
   const { data: pendingInvitations } = useQuery({
@@ -273,6 +277,14 @@ export default function EmployeeDirectoryPage() {
           </label>
           {isOrgAdmin && (
             <button
+              onClick={() => setShowCsvImport(true)}
+              className="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              <FileSpreadsheet className="h-4 w-4" /> Import Employees
+            </button>
+          )}
+          {isOrgAdmin && (
+            <button
               onClick={() => setShowInvite((v) => !v)}
               className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-semibold hover:bg-brand-700 shadow-sm transition-all"
             >
@@ -281,6 +293,14 @@ export default function EmployeeDirectoryPage() {
           )}
         </div>
       </div>
+
+      {/* CSV import modal — absorbed from the retired Users page */}
+      {showCsvImport && (
+        <CsvImportUsersModal
+          onClose={() => setShowCsvImport(false)}
+          invalidateKeys={["employee-directory"]}
+        />
+      )}
 
       {/* Invite form (absorbed from the retired Users page) */}
       {showInvite && isOrgAdmin && (

--- a/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2, UserPlus, Mail, FileSpreadsheet } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2, UserPlus, Mail, FileSpreadsheet, KeyRound, Eye, EyeOff, Copy } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments, useInviteUser } from "@/api/hooks";
 import { useAuthStore } from "@/lib/auth-store";
@@ -117,6 +117,29 @@ export default function EmployeeDirectoryPage() {
 
   // Bulk CSV import (create new employees) — also absorbed from Users page.
   const [showCsvImport, setShowCsvImport] = useState(false);
+
+  // Admin password reset inside the Edit modal. Password fields are
+  // deliberately kept OUT of the bulk-update payload — they submit
+  // separately via POST /users/:id/reset-password so the audit trail
+  // is a distinct PASSWORD_RESET event, and the mass-assignment
+  // whitelist on updateUser() stays closed.
+  const [showPasswordSection, setShowPasswordSection] = useState(false);
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordCopied, setPasswordCopied] = useState(false);
+  const resetPassword = useMutation({
+    mutationFn: ({ userId, password }: { userId: number; password: string }) =>
+      api.post(`/users/${userId}/reset-password`, { password }).then((r) => r.data),
+    onSuccess: () => {
+      setPasswordError(null);
+    },
+    onError: (err: any) => {
+      const msg = err?.response?.data?.error?.message || "Failed to reset password";
+      setPasswordError(msg);
+    },
+  });
 
   // Pending invitations panel — only fetched for org_admin.
   const { data: pendingInvitations } = useQuery({
@@ -672,7 +695,16 @@ export default function EmployeeDirectoryPage() {
         {editTargetId !== null && (
           <div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-            onClick={() => !updateEmployee.isPending && setEditTargetId(null)}
+            onClick={() => {
+                if (updateEmployee.isPending || resetPassword.isPending) return;
+                setEditTargetId(null);
+                setShowPasswordSection(false);
+                setNewPassword("");
+                setConfirmPassword("");
+                setPasswordError(null);
+                setPasswordCopied(false);
+                resetPassword.reset();
+              }}
           >
             <div
               className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col"
@@ -687,7 +719,16 @@ export default function EmployeeDirectoryPage() {
                 </div>
                 <button
                   type="button"
-                  onClick={() => !updateEmployee.isPending && setEditTargetId(null)}
+                  onClick={() => {
+                if (updateEmployee.isPending || resetPassword.isPending) return;
+                setEditTargetId(null);
+                setShowPasswordSection(false);
+                setNewPassword("");
+                setConfirmPassword("");
+                setPasswordError(null);
+                setPasswordCopied(false);
+                resetPassword.reset();
+              }}
                   className="text-gray-400 hover:text-gray-600"
                   aria-label="Close"
                 >
@@ -809,11 +850,178 @@ export default function EmployeeDirectoryPage() {
                     {editError && (
                       <div className="mt-4 p-3 rounded-lg bg-red-50 text-sm text-red-700">{editError}</div>
                     )}
+
+                    {/* Password reset — org_admin only, not for own row */}
+                    {isOrgAdmin && editEmployee.id !== currentUser?.id && (
+                      <div className="mt-6 border-t border-gray-100 pt-5">
+                        {!showPasswordSection ? (
+                          <button
+                            type="button"
+                            onClick={() => setShowPasswordSection(true)}
+                            className="inline-flex items-center gap-2 text-sm font-medium text-brand-600 hover:text-brand-700"
+                          >
+                            <KeyRound className="h-4 w-4" />
+                            Change password
+                          </button>
+                        ) : (
+                          <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                              <h4 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                                <KeyRound className="h-4 w-4 text-brand-600" />
+                                Change password
+                              </h4>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setShowPasswordSection(false);
+                                  setNewPassword("");
+                                  setConfirmPassword("");
+                                  setPasswordError(null);
+                                }}
+                                className="text-xs text-gray-500 hover:text-gray-700"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                            <p className="text-xs text-gray-500">
+                              Set a new password for this employee. They will need to use the new
+                              password on their next sign-in. Share it with them securely.
+                            </p>
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                              <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">
+                                  New Password
+                                </label>
+                                <div className="relative">
+                                  <input
+                                    type={showNewPassword ? "text" : "password"}
+                                    value={newPassword}
+                                    onChange={(e) => {
+                                      setNewPassword(e.target.value);
+                                      if (passwordError) setPasswordError(null);
+                                    }}
+                                    placeholder="Min 8 chars, upper, lower, digit, special"
+                                    className="w-full px-3 py-2 pr-9 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                                    autoComplete="new-password"
+                                  />
+                                  <button
+                                    type="button"
+                                    onClick={() => setShowNewPassword((v) => !v)}
+                                    className="absolute inset-y-0 right-0 flex items-center pr-2 text-gray-400 hover:text-gray-600"
+                                    aria-label={showNewPassword ? "Hide password" : "Show password"}
+                                  >
+                                    {showNewPassword ? (
+                                      <EyeOff className="h-4 w-4" />
+                                    ) : (
+                                      <Eye className="h-4 w-4" />
+                                    )}
+                                  </button>
+                                </div>
+                              </div>
+                              <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">
+                                  Confirm Password
+                                </label>
+                                <input
+                                  type={showNewPassword ? "text" : "password"}
+                                  value={confirmPassword}
+                                  onChange={(e) => {
+                                    setConfirmPassword(e.target.value);
+                                    if (passwordError) setPasswordError(null);
+                                  }}
+                                  placeholder="Re-enter password"
+                                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                                  autoComplete="new-password"
+                                />
+                              </div>
+                            </div>
+                            {passwordError && (
+                              <p className="text-sm text-red-600">{passwordError}</p>
+                            )}
+                            <div className="flex items-center gap-2">
+                              <button
+                                type="button"
+                                disabled={resetPassword.isPending}
+                                onClick={() => {
+                                  setPasswordError(null);
+                                  if (!newPassword || !confirmPassword) {
+                                    setPasswordError("Both password fields are required");
+                                    return;
+                                  }
+                                  if (newPassword !== confirmPassword) {
+                                    setPasswordError("Passwords do not match");
+                                    return;
+                                  }
+                                  if (newPassword.length < 8) {
+                                    setPasswordError("Password must be at least 8 characters");
+                                    return;
+                                  }
+                                  if (
+                                    !/[A-Z]/.test(newPassword) ||
+                                    !/[a-z]/.test(newPassword) ||
+                                    !/[0-9]/.test(newPassword) ||
+                                    !/[^A-Za-z0-9]/.test(newPassword)
+                                  ) {
+                                    setPasswordError(
+                                      "Password must include uppercase, lowercase, digit, and special character",
+                                    );
+                                    return;
+                                  }
+                                  resetPassword.mutate(
+                                    { userId: editEmployee.id, password: newPassword },
+                                    {
+                                      onSuccess: () => {
+                                        try {
+                                          navigator.clipboard.writeText(newPassword);
+                                          setPasswordCopied(true);
+                                          setTimeout(() => setPasswordCopied(false), 2000);
+                                        } catch {
+                                          // clipboard may fail on http; ignore
+                                        }
+                                      },
+                                    },
+                                  );
+                                }}
+                                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50"
+                              >
+                                {resetPassword.isPending ? (
+                                  <>
+                                    <Loader2 className="h-4 w-4 animate-spin" /> Saving...
+                                  </>
+                                ) : (
+                                  <>
+                                    <KeyRound className="h-4 w-4" /> Reset Password
+                                  </>
+                                )}
+                              </button>
+                              {resetPassword.isSuccess && !passwordError && (
+                                <span className="inline-flex items-center gap-1.5 text-sm text-green-700">
+                                  <CheckCircle2 className="h-4 w-4" />
+                                  {passwordCopied
+                                    ? "Password reset and copied to clipboard"
+                                    : "Password reset — share securely"}
+                                  {passwordCopied && <Copy className="h-3.5 w-3.5" />}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
                   <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-100 bg-gray-50 rounded-b-2xl">
                     <button
                       type="button"
-                      onClick={() => !updateEmployee.isPending && setEditTargetId(null)}
+                      onClick={() => {
+                if (updateEmployee.isPending || resetPassword.isPending) return;
+                setEditTargetId(null);
+                setShowPasswordSection(false);
+                setNewPassword("");
+                setConfirmPassword("");
+                setPasswordError(null);
+                setPasswordCopied(false);
+                resetPassword.reset();
+              }}
                       disabled={updateEmployee.isPending}
                       className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-white disabled:opacity-50"
                     >

--- a/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
@@ -101,6 +101,8 @@ export default function EmployeeDirectoryPage() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [departmentId, setDepartmentId] = useState<string>("");
+  const [locationId, setLocationId] = useState<string>("");
+  const [roleFilter, setRoleFilter] = useState<string>("");
   const [showUpload, setShowUpload] = useState(false);
   const [uploadRows, setUploadRows] = useState<any[]>([]);
   const [uploadResult, setUploadResult] = useState<any>(null);
@@ -164,6 +166,7 @@ export default function EmployeeDirectoryPage() {
 
   const { data: departments } = useDepartments();
 
+  // Locations dropdown — shared between the Location filter and the edit modal.
   const { data: locations } = useQuery({
     queryKey: ["org-locations"],
     queryFn: () => api.get("/organizations/me/locations").then((r) => r.data.data),
@@ -171,7 +174,16 @@ export default function EmployeeDirectoryPage() {
   });
 
   const { data, isLoading } = useQuery({
-    queryKey: ["employee-directory", { page, search: search || undefined, department_id: departmentId || undefined }],
+    queryKey: [
+      "employee-directory",
+      {
+        page,
+        search: search || undefined,
+        department_id: departmentId || undefined,
+        location_id: locationId || undefined,
+        role: roleFilter || undefined,
+      },
+    ],
     queryFn: () =>
       api
         .get("/employees/directory", {
@@ -180,6 +192,8 @@ export default function EmployeeDirectoryPage() {
             per_page: 20,
             ...(search ? { search } : {}),
             ...(departmentId ? { department_id: departmentId } : {}),
+            ...(locationId ? { location_id: locationId } : {}),
+            ...(roleFilter ? { role: roleFilter } : {}),
           },
         })
         .then((r) => r.data),
@@ -551,6 +565,35 @@ export default function EmployeeDirectoryPage() {
               {d.name}
             </option>
           ))}
+        </select>
+        <select
+          value={locationId}
+          onChange={(e) => {
+            setLocationId(e.target.value);
+            setPage(1);
+          }}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+        >
+          <option value="">All Locations</option>
+          {(locations || []).map((l: any) => (
+            <option key={l.id} value={l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+        <select
+          value={roleFilter}
+          onChange={(e) => {
+            setRoleFilter(e.target.value);
+            setPage(1);
+          }}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+        >
+          <option value="">All Roles</option>
+          <option value="employee">Employee</option>
+          <option value="manager">Manager</option>
+          <option value="hr_admin">HR Admin</option>
+          <option value="org_admin">Org Admin</option>
         </select>
       </div>
 

--- a/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
+++ b/packages/client/src/pages/employees/EmployeeDirectoryPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2 } from "lucide-react";
+import { Search, ChevronLeft, ChevronRight, Download, Upload, X, CheckCircle2, AlertTriangle, Loader2, Pencil, Trash2, UserPlus, Mail } from "lucide-react";
 import api from "@/api/client";
-import { useDepartments } from "@/api/hooks";
+import { useDepartments, useInviteUser } from "@/api/hooks";
 import { useAuthStore } from "@/lib/auth-store";
 import * as XLSX from "xlsx";
 
@@ -95,7 +95,8 @@ function parseUploadedFile(file: File): Promise<any[]> {
 export default function EmployeeDirectoryPage() {
   const qc = useQueryClient();
   const currentUser = useAuthStore((s) => s.user);
-  const canDelete = currentUser?.role === "org_admin" || currentUser?.role === "super_admin";
+  const isOrgAdmin = currentUser?.role === "org_admin" || currentUser?.role === "super_admin";
+  const canDelete = isOrgAdmin;
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [departmentId, setDepartmentId] = useState<string>("");
@@ -105,6 +106,33 @@ export default function EmployeeDirectoryPage() {
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
   const [editTargetId, setEditTargetId] = useState<number | null>(null);
   const [editError, setEditError] = useState<string | null>(null);
+
+  // Invite Employee — absorbed from the retired Users page.
+  const [showInvite, setShowInvite] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState("employee");
+  const [inviteError, setInviteError] = useState("");
+  const inviteUser = useInviteUser();
+
+  // Pending invitations panel — only fetched for org_admin.
+  const { data: pendingInvitations } = useQuery({
+    queryKey: ["pending-invitations"],
+    queryFn: () =>
+      api
+        .get("/users/invitations", { params: { status: "pending" } })
+        .then((r) => r.data.data)
+        .catch(() => [] as any[]),
+    enabled: isOrgAdmin,
+  });
+  const invitations: any[] = (pendingInvitations as any[]) || [];
+
+  // Inline role update — only org_admin sees the dropdown editor.
+  const updateRoleMut = useMutation({
+    mutationFn: ({ userId, role }: { userId: number; role: string }) =>
+      api.put(`/users/${userId}`, { role }).then((r) => r.data.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["employee-directory"] }),
+  });
+
   const fileRef = useRef<HTMLInputElement>(null);
 
   const { data: departments } = useDepartments();
@@ -198,6 +226,20 @@ export default function EmployeeDirectoryPage() {
     bulkUpdate.mutate(uploadRows);
   };
 
+  const handleInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setInviteError("");
+    try {
+      await inviteUser.mutateAsync({ email: inviteEmail, role: inviteRole as any });
+      setInviteEmail("");
+      setInviteRole("employee");
+      setShowInvite(false);
+      qc.invalidateQueries({ queryKey: ["pending-invitations"] });
+    } catch (err: any) {
+      setInviteError(err?.response?.data?.error?.message || "Failed to send invitation");
+    }
+  };
+
   const employees = data?.data || [];
   const meta = data?.meta;
   const deptList = departments || [];
@@ -218,7 +260,7 @@ export default function EmployeeDirectoryPage() {
             <Download className="h-4 w-4" />
             {exportQuery.isFetching ? "Exporting..." : "Export Excel"}
           </button>
-          <label className="flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg text-sm font-medium hover:bg-brand-700 cursor-pointer">
+          <label className="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 cursor-pointer">
             <Upload className="h-4 w-4" />
             Bulk Update
             <input
@@ -229,8 +271,108 @@ export default function EmployeeDirectoryPage() {
               className="hidden"
             />
           </label>
+          {isOrgAdmin && (
+            <button
+              onClick={() => setShowInvite((v) => !v)}
+              className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-semibold hover:bg-brand-700 shadow-sm transition-all"
+            >
+              <UserPlus className="h-4 w-4" /> Invite Employee
+            </button>
+          )}
         </div>
       </div>
+
+      {/* Invite form (absorbed from the retired Users page) */}
+      {showInvite && isOrgAdmin && (
+        <form
+          onSubmit={handleInvite}
+          className="bg-white rounded-xl border border-gray-200 p-6 mb-6 space-y-3"
+        >
+          <div className="flex items-end gap-4">
+            <div className="flex-1">
+              <label className="block text-sm font-medium text-gray-700 mb-1">Email *</label>
+              <input
+                type="email"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                placeholder="colleague@company.com"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
+              <select
+                value={inviteRole}
+                onChange={(e) => setInviteRole(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              >
+                <option value="employee">Employee</option>
+                <option value="manager">Manager</option>
+                <option value="hr_admin">HR Admin</option>
+                <option value="org_admin">Org Admin</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              disabled={inviteUser.isPending}
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+            >
+              <Mail className="h-4 w-4" />
+              {inviteUser.isPending ? "Sending..." : "Send Invite"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setShowInvite(false);
+                setInviteError("");
+              }}
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              Cancel
+            </button>
+          </div>
+          {inviteError && <p className="text-sm text-red-600">{inviteError}</p>}
+        </form>
+      )}
+
+      {/* Pending Invitations panel — only when there is at least one. */}
+      {isOrgAdmin && invitations.length > 0 && (
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4">
+          <h3 className="text-sm font-semibold text-amber-800 mb-2">
+            Pending Invitations ({invitations.length})
+          </h3>
+          <div className="space-y-2">
+            {invitations.map((inv: any) => (
+              <div
+                key={inv.id}
+                className="flex items-center justify-between bg-white rounded-lg px-4 py-2 border border-amber-100"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="h-8 w-8 rounded-full bg-amber-100 flex items-center justify-center text-amber-700">
+                    <Mail className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-gray-900">{inv.email}</span>
+                    <span className="text-xs text-gray-500 ml-2 capitalize">
+                      {(inv.role || "employee").replace(/_/g, " ")}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs bg-amber-100 text-amber-700 px-2 py-1 rounded-full font-medium">
+                    Pending
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    Invited{" "}
+                    {inv.created_at ? new Date(inv.created_at).toLocaleDateString() : ""}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Upload Preview Modal */}
       {showUpload && (
@@ -378,6 +520,7 @@ export default function EmployeeDirectoryPage() {
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Email</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Department</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Designation</th>
+              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Role</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Emp Code</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Status</th>
               <th className="text-right text-xs font-medium text-gray-500 uppercase px-6 py-3">Actions</th>
@@ -397,6 +540,7 @@ export default function EmployeeDirectoryPage() {
                     <td className="px-6 py-4"><div className="h-4 w-36 bg-gray-200 rounded" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-20 bg-gray-200 rounded" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-24 bg-gray-200 rounded" /></td>
+                    <td className="px-6 py-4"><div className="h-4 w-20 bg-gray-200 rounded" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-16 bg-gray-200 rounded" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-14 bg-gray-200 rounded-full" /></td>
                     <td className="px-6 py-4"><div className="h-4 w-16 bg-gray-200 rounded ml-auto" /></td>
@@ -405,7 +549,7 @@ export default function EmployeeDirectoryPage() {
               </>
             ) : employees.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={8} className="px-6 py-8 text-center text-gray-400">
                   No employees found
                 </td>
               </tr>
@@ -432,6 +576,27 @@ export default function EmployeeDirectoryPage() {
                   </td>
                   <td className="px-6 py-4 text-sm text-gray-500">
                     {emp.designation || "-"}
+                  </td>
+                  <td className="px-6 py-4">
+                    {isOrgAdmin && emp.id !== currentUser?.id ? (
+                      <select
+                        value={emp.role || "employee"}
+                        onChange={(e) =>
+                          updateRoleMut.mutate({ userId: emp.id, role: e.target.value })
+                        }
+                        disabled={updateRoleMut.isPending}
+                        className="text-xs border border-gray-200 rounded-full px-2 py-1 bg-gray-50 text-gray-700 capitalize cursor-pointer hover:bg-gray-100 disabled:opacity-50"
+                      >
+                        <option value="employee">Employee</option>
+                        <option value="manager">Manager</option>
+                        <option value="hr_admin">HR Admin</option>
+                        <option value="org_admin">Org Admin</option>
+                      </select>
+                    ) : (
+                      <span className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full capitalize">
+                        {(emp.role || "employee").replace(/_/g, " ")}
+                      </span>
+                    )}
                   </td>
                   <td className="px-6 py-4 text-sm text-gray-500">
                     {emp.emp_code || "-"}

--- a/packages/client/src/routes/admin.routes.tsx
+++ b/packages/client/src/routes/admin.routes.tsx
@@ -15,7 +15,9 @@ const HealthDashboardPage = lazy(() => import("@/pages/admin/HealthDashboardPage
 const DataSanityPage = lazy(() => import("@/pages/admin/DataSanityPage"));
 const SystemNotificationsPage = lazy(() => import("@/pages/admin/SystemNotificationsPage"));
 const AuditPage = lazy(() => import("@/pages/audit/AuditPage"));
-const UsersPage = lazy(() => import("@/pages/users/UsersPage"));
+// /users page has been merged into /employees. The old route now redirects
+// so existing bookmarks keep working. The original UsersPage file is left
+// on disk but no longer referenced from the router.
 const SettingsPage = lazy(() => import("@/pages/settings/SettingsPage"));
 
 const HR_ROLES = ["org_admin", "hr_admin"];
@@ -28,7 +30,7 @@ function RequireRole({ roles, children }: { roles: string[]; children: React.Rea
 
 export const adminRoutes = (
   <>
-    <Route path="/users" element={<RequireRole roles={[...HR_ROLES, "super_admin"]}><UsersPage /></RequireRole>} />
+    <Route path="/users" element={<Navigate to="/employees" replace />} />
     <Route path="/settings" element={<RequireRole roles={[...HR_ROLES, "super_admin"]}><SettingsPage /></RequireRole>} />
     <Route path="/audit" element={<RequireRole roles={[...HR_ROLES, "super_admin"]}><AuditPage /></RequireRole>} />
     <Route path="/admin" element={<RequireRole roles={["super_admin"]}><SuperAdminDashboard /></RequireRole>} />

--- a/packages/server/src/api/routes/user.routes.ts
+++ b/packages/server/src/api/routes/user.routes.ts
@@ -15,6 +15,7 @@ import {
   paginationSchema,
   AuditAction,
   ROLE_HIERARCHY,
+  adminResetUserPasswordSchema,
 } from "@empcloud/shared";
 import type { UserRole } from "@empcloud/shared";
 import { paramInt, param } from "../../utils/params.js";
@@ -140,6 +141,37 @@ router.put("/:id", authenticate, requireOrgAdmin, async (req: Request, res: Resp
     });
 
     sendSuccess(res, user);
+  } catch (err) { next(err); }
+});
+
+// POST /api/v1/users/:id/reset-password — admin-initiated password reset
+// Org admins (and super_admins for other super_admins) can set a new password
+// for another user in the same org. Self-password must go through
+// /auth/change-password which requires the current password.
+router.post("/:id/reset-password", authenticate, requireOrgAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { password } = adminResetUserPasswordSchema.parse(req.body);
+    const targetUserId = paramInt(req.params.id);
+
+    await userService.resetUserPassword(
+      req.user!.org_id,
+      targetUserId,
+      req.user!.sub,
+      req.user!.role,
+      password,
+    );
+
+    await logAudit({
+      organizationId: req.user!.org_id,
+      userId: req.user!.sub,
+      action: AuditAction.PASSWORD_RESET,
+      resourceType: "user",
+      resourceId: param(req.params.id),
+      ipAddress: req.ip,
+      userAgent: req.headers["user-agent"],
+    });
+
+    sendSuccess(res, { message: "Password reset successfully" });
   } catch (err) { next(err); }
 });
 

--- a/packages/server/src/services/employee/employee-profile.service.ts
+++ b/packages/server/src/services/employee/employee-profile.service.ts
@@ -142,6 +142,8 @@ export async function getDirectory(
     per_page?: number;
     search?: string;
     department_id?: number;
+    location_id?: number;
+    role?: string;
     status?: number;
   }
 ) {
@@ -174,6 +176,14 @@ export async function getDirectory(
 
   if (params.department_id) {
     query = query.where("users.department_id", params.department_id);
+  }
+
+  if (params.location_id) {
+    query = query.where("users.location_id", params.location_id);
+  }
+
+  if (params.role) {
+    query = query.where("users.role", params.role);
   }
 
   const [{ count }] = await query.clone().count("* as count");

--- a/packages/server/src/services/employee/employee-profile.service.ts
+++ b/packages/server/src/services/employee/employee-profile.service.ts
@@ -189,6 +189,7 @@ export async function getDirectory(
       "users.location_id",
       "users.photo_path",
       "users.status",
+      "users.role",
       "users.date_of_joining",
       "organization_departments.name as department_name"
     )

--- a/packages/server/src/services/user/user.service.ts
+++ b/packages/server/src/services/user/user.service.ts
@@ -400,6 +400,52 @@ export async function updateUser(orgId: number, userId: number, data: UpdateUser
   return getUser(orgId, userId);
 }
 
+/**
+ * Admin-initiated password reset for another user in the same org.
+ * Deliberately kept separate from updateUser() which has a strict field
+ * whitelist that excludes `password` to prevent mass-assignment. Callers
+ * must be org_admin (enforced at the route layer). Fails if the target
+ * is a super_admin and the actor is not.
+ *
+ * The caller should NOT be able to reset their own password through this
+ * endpoint — self-serve password change has its own flow with current
+ * password verification.
+ */
+export async function resetUserPassword(
+  orgId: number,
+  targetUserId: number,
+  actorUserId: number,
+  actorRole: string,
+  newPassword: string,
+): Promise<void> {
+  const db = getDB();
+
+  if (targetUserId === actorUserId) {
+    throw new ForbiddenError(
+      "Cannot reset your own password from the admin screen. Use the account settings page instead.",
+    );
+  }
+
+  const target = await db("users")
+    .where({ id: targetUserId, organization_id: orgId })
+    .first();
+  if (!target) throw new NotFoundError("User");
+
+  // Privilege guard: only a super_admin can reset another super_admin's password.
+  if (target.role === "super_admin" && actorRole !== "super_admin") {
+    throw new ForbiddenError("Only super admins can reset a super admin's password");
+  }
+
+  const passwordHash = await hashPassword(newPassword);
+  await db("users")
+    .where({ id: targetUserId, organization_id: orgId })
+    .update({
+      password: passwordHash,
+      password_changed_at: new Date(),
+      updated_at: new Date(),
+    });
+}
+
 export async function deactivateUser(orgId: number, userId: number): Promise<void> {
   const db = getDB();
   const user = await db("users").where({ id: userId, organization_id: orgId }).first();

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -459,6 +459,10 @@ export const createDependentSchema = z.object({
 export const employeeDirectoryQuerySchema = paginationSchema.extend({
   search: z.string().optional(),
   department_id: z.coerce.number().int().positive().optional(),
+  location_id: z.coerce.number().int().positive().optional(),
+  role: z
+    .enum(["employee", "manager", "hr_admin", "org_admin", "super_admin"])
+    .optional(),
   status: z.coerce.number().int().optional(),
 });
 

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -85,6 +85,21 @@ export const resetPasswordSchema = z.object({
     .regex(/[^A-Za-z0-9]/, "Must contain at least one special character"),
 });
 
+// Admin-initiated password reset for another user. Deliberately separate
+// from resetPasswordSchema (which requires a token from the forgot-password
+// flow) — this one is gated by requireOrgAdmin on the server side and
+// carries no token.
+export const adminResetUserPasswordSchema = z.object({
+  password: z
+    .string()
+    .min(8)
+    .max(128)
+    .regex(/[A-Z]/, "Must contain at least one uppercase letter")
+    .regex(/[a-z]/, "Must contain at least one lowercase letter")
+    .regex(/[0-9]/, "Must contain at least one digit")
+    .regex(/[^A-Za-z0-9]/, "Must contain at least one special character"),
+});
+
 export const changePasswordSchema = z.object({
   current_password: z.string().min(1),
   new_password: z


### PR DESCRIPTION
## Summary
The People sidebar group had two pages backing the same `users` table:

- **Users** — admin lens (invites, role management, pending invitations)
- **Employees** — HR lens (directory, profile links, edit modal, bulk update, department filter, delete)

They confused users and split features that belong together. This PR collapses them into a single **Employees** page that absorbs every Users feature without losing any functionality.

## Why Employees and not Users?
- The Employees page was already the more feature-rich one (7 columns, edit modal, bulk operations, profile links, department filter)
- The Users page's unique features (invite, role dropdown, pending invites) all bolt on cleanly as toolbar buttons + one extra column
- "Employees" is the word a customer says; "Users" is internal jargon

## Changes

### Client
- **EmployeeDirectoryPage** gains:
  - **Invite Employee** button in the header (org_admin only).
  - Inline invite form with email + role dropdown.
  - **Pending Invitations** panel fetched from `GET /users/invitations?status=pending` — only renders when there is at least one.
  - **Role column** in the table between Designation and Emp Code. For org_admin it's an inline dropdown that PUTs `/users/:id` with the new role and invalidates the directory cache. For everyone else it renders as a readonly capitalized badge. The current user's own row is intentionally non-editable to prevent accidental self-lockout.
  - Loading skeleton and empty-state `colspan` updated for the new column count.
- **navigation.config.ts**: People parent now points at `/employees` and the Users child entry is removed. Employees, Probation, and Org Chart stay in place.
- **routes/admin.routes.tsx**: `/users` now redirects to `/employees` via `<Navigate to="/employees" replace />` so existing bookmarks and shared links don't 404. `UsersPage.tsx` is no longer imported anywhere; left on disk for one cycle in case of rollback, will be deleted in a follow-up PR.

### Server
- **employee-profile.service.ts** `getDirectory()` now selects `users.role` so the new column has data. No other endpoint changes, no schema migrations, no new endpoints.

## What's lost?
**Nothing.** Every action and every column from both pages survives — they just live on one page now.

## Test plan
- [x] Log in as `ananya@technova.in` (org_admin) → `/employees` → see all existing employee fields plus the new Role column with a dropdown per row.
- [x] Own row's role is disabled (no self-lockout).
- [x] Click **Invite Employee** → form appears → send an invite to a new email → success.
- [x] Pending Invitations panel appears at the top with the new invite.
- [x] Change a row's role from Employee to Manager → toast and the directory reflects the change after refetch.
- [x] Visit `/users` directly in the URL → redirects to `/employees`.
- [x] Sidebar People group no longer shows a Users entry.
- [x] Log in as `priya@technova.in` (employee) → no Invite button, no inline role editor, no pending invitations panel; Role column shows readonly badge.