### PR TITLE
fix(assets): replace window.confirm with styled modal dialogs

### DIFF
--- a/packages/client/src/pages/assets/AssetCategoriesPage.tsx
+++ b/packages/client/src/pages/assets/AssetCategoriesPage.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   X,
   Check,
+  Loader2,
 } from "lucide-react";
 
 export default function AssetCategoriesPage() {
@@ -16,6 +17,9 @@ export default function AssetCategoriesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [formName, setFormName] = useState("");
   const [formDescription, setFormDescription] = useState("");
+  // Confirm dialog for deactivating a category. Replaces window.confirm().
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: categories, isLoading } = useQuery({
     queryKey: ["asset-categories"],
@@ -43,7 +47,11 @@ export default function AssetCategoriesPage() {
     mutationFn: (id: number) => api.delete(`/assets/categories/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["asset-categories"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
     },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to deactivate category"),
   });
 
   function resetForm() {
@@ -121,9 +129,8 @@ export default function AssetCategoriesPage() {
                       </button>
                       <button
                         onClick={() => {
-                          if (confirm(`Deactivate category "${cat.name}"?`)) {
-                            deleteCategory.mutate(cat.id);
-                          }
+                          setDeleteTarget({ id: cat.id, name: cat.name });
+                          setDeleteError(null);
                         }}
                         className="p-1.5 rounded hover:bg-red-50 text-gray-500 hover:text-red-600"
                         title="Delete"
@@ -190,6 +197,65 @@ export default function AssetCategoriesPage() {
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Deactivate confirmation — replaces window.confirm() */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteCategory.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Deactivate category?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Deactivate{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.name}</span>? Existing
+                    assets tagged with this category keep the tag, but no new assets can be placed
+                    here until it's restored.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteCategory.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteCategory.mutate(deleteTarget.id)}
+                disabled={deleteCategory.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteCategory.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deactivating...
+                  </>
+                ) : (
+                  "Deactivate"
+                )}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   RotateCcw,
   Trash2,
   X,
+  Loader2,
 } from "lucide-react";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -55,6 +56,11 @@ export default function AssetDetailPage() {
   const [assignNotes, setAssignNotes] = useState("");
   const [returnCondition, setReturnCondition] = useState("good");
   const [returnNotes, setReturnNotes] = useState("");
+  // Which in-place confirm dialog is open. Replaces window.confirm() so the
+  // Retire and Report Lost flows use a styled modal consistent with the
+  // rest of the app.
+  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const isHR = user && ["hr_admin", "org_admin", "super_admin"].includes(user.role);
 
@@ -90,12 +96,24 @@ export default function AssetDetailPage() {
 
   const retireMutation = useMutation({
     mutationFn: () => api.post(`/assets/${id}/retire`, { notes: "Retired via dashboard" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["asset", id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to retire asset"),
   });
 
   const reportLostMutation = useMutation({
     mutationFn: () => api.post(`/assets/${id}/report-lost`, { notes: "Reported lost via dashboard" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["asset", id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to report asset as lost"),
   });
 
   if (isLoading) {
@@ -151,14 +169,20 @@ export default function AssetDetailPage() {
             {asset.status !== "retired" && asset.status !== "lost" && (
               <>
                 <button
-                  onClick={() => { if (confirm("Retire this asset?")) retireMutation.mutate(); }}
+                  onClick={() => {
+                    setConfirmAction("retire");
+                    setConfirmError(null);
+                  }}
                   className="inline-flex items-center gap-2 px-3 py-2 border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 text-sm font-medium"
                 >
                   <Trash2 className="h-4 w-4" />
                   Retire
                 </button>
                 <button
-                  onClick={() => { if (confirm("Report this asset as lost?")) reportLostMutation.mutate(); }}
+                  onClick={() => {
+                    setConfirmAction("lost");
+                    setConfirmError(null);
+                  }}
                   className="inline-flex items-center gap-2 px-3 py-2 border border-red-200 text-red-600 rounded-lg hover:bg-red-50 text-sm font-medium"
                 >
                   <AlertTriangle className="h-4 w-4" />
@@ -451,6 +475,85 @@ export default function AssetDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost */}
+      {confirmAction && (() => {
+        const isLost = confirmAction === "lost";
+        const pending = isLost ? reportLostMutation.isPending : retireMutation.isPending;
+        const run = () => (isLost ? reportLostMutation.mutate() : retireMutation.mutate());
+        const title = isLost ? "Report asset as lost?" : "Retire this asset?";
+        const body = isLost
+          ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
+          : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
+        const confirmLabel = isLost ? "Report as Lost" : "Retire Asset";
+        const iconColor = isLost ? "text-red-600 bg-red-50" : "text-gray-600 bg-gray-100";
+        const confirmBtn = isLost
+          ? "bg-red-600 hover:bg-red-700"
+          : "bg-gray-900 hover:bg-black";
+        return (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={() => !pending && setConfirmAction(null)}
+          >
+            <div
+              className="w-full max-w-md rounded-xl bg-white shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="px-6 py-5">
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${iconColor}`}
+                  >
+                    {isLost ? (
+                      <AlertTriangle className="h-5 w-5" />
+                    ) : (
+                      <Trash2 className="h-5 w-5" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                      <span className="font-medium text-gray-700">
+                        {asset.asset_tag} — {asset.name}
+                      </span>
+                    </p>
+                    <p className="mt-2 text-sm text-gray-500">{body}</p>
+                  </div>
+                </div>
+              </div>
+              {confirmError && (
+                <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                  {confirmError}
+                </div>
+              )}
+              <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+                <button
+                  type="button"
+                  onClick={() => setConfirmAction(null)}
+                  disabled={pending}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={run}
+                  disabled={pending}
+                  className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${confirmBtn}`}
+                >
+                  {pending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" /> Working...
+                    </>
+                  ) : (
+                    confirmLabel
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
The **Retire**, **Report Lost**, and **Deactivate Category** actions on the assets pages used native `window.confirm()` prompts. Those look out of place next to the rest of the app's chrome and can't carry context like the asset tag or category name.

Replaced with inline styled modals matching the Delete Employee / course delete pattern already used elsewhere in the codebase.

### AssetDetailPage.tsx
- New `confirmAction` state (`"retire" | "lost" | null`) plus `confirmError` for surfacing server errors inline.
- **Retire** button opens a neutral-styled dialog with a `Trash2` icon and a dark confirm button.
- **Report Lost** button opens a red-tinted dialog with an `AlertTriangle` icon and a red confirm button.
- Both dialogs include the asset's `asset_tag — name` in the body so the user confirms against the right asset.
- Click-outside-to-close is blocked while the mutation is pending.
- `retireMutation` and `reportLostMutation` gained `onSuccess` (close dialog, clear error) and `onError` (keep dialog open, show server message) handlers.

### AssetCategoriesPage.tsx
- Same pattern for the deactivate-category action. The dialog shows the category name and explains the consequence (existing assets keep their tag; no new assets can be placed there until restored).

### Not included
- No reusable `<ConfirmDialog>` component — 3 call sites, inline is fine and ships faster. Can be extracted once more appear.
- No server changes.

## Test plan
- [x] `/assets/:id` → Retire → modal with asset tag + name → Cancel closes, Retire Asset calls the API and closes on success.
- [x] `/assets/:id` → Report Lost → red modal → Report as Lost works end-to-end.
- [x] If the server returns an error, the modal stays open with the error message visible.
- [x] `/assets/categories` → trash icon → modal with category name → Deactivate succeeds and the row disappears.
- [x] Clicking outside the overlay closes the modal (unless the mutation is pending).