### PR TITLE
feat(assets): add Mark Found action for recovering lost assets

### DIFF
--- a/packages/client/src/pages/assets/AssetCategoriesPage.tsx
+++ b/packages/client/src/pages/assets/AssetCategoriesPage.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   X,
   Check,
+  Loader2,
 } from "lucide-react";
 
 export default function AssetCategoriesPage() {
@@ -16,6 +17,9 @@ export default function AssetCategoriesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [formName, setFormName] = useState("");
   const [formDescription, setFormDescription] = useState("");
+  // Confirm dialog for deactivating a category. Replaces window.confirm().
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: categories, isLoading } = useQuery({
     queryKey: ["asset-categories"],
@@ -43,7 +47,11 @@ export default function AssetCategoriesPage() {
     mutationFn: (id: number) => api.delete(`/assets/categories/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["asset-categories"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
     },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to deactivate category"),
   });
 
   function resetForm() {
@@ -121,9 +129,8 @@ export default function AssetCategoriesPage() {
                       </button>
                       <button
                         onClick={() => {
-                          if (confirm(`Deactivate category "${cat.name}"?`)) {
-                            deleteCategory.mutate(cat.id);
-                          }
+                          setDeleteTarget({ id: cat.id, name: cat.name });
+                          setDeleteError(null);
                         }}
                         className="p-1.5 rounded hover:bg-red-50 text-gray-500 hover:text-red-600"
                         title="Delete"
@@ -190,6 +197,65 @@ export default function AssetCategoriesPage() {
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Deactivate confirmation — replaces window.confirm() */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteCategory.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Deactivate category?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Deactivate{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.name}</span>? Existing
+                    assets tagged with this category keep the tag, but no new assets can be placed
+                    here until it's restored.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteCategory.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteCategory.mutate(deleteTarget.id)}
+                disabled={deleteCategory.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteCategory.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deactivating...
+                  </>
+                ) : (
+                  "Deactivate"
+                )}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/packages/client/src/pages/assets/AssetDashboardPage.tsx
+++ b/packages/client/src/pages/assets/AssetDashboardPage.tsx
@@ -19,6 +19,7 @@ const ACTION_COLORS: Record<string, string> = {
   repaired: "text-yellow-600",
   retired: "text-gray-600",
   lost: "text-red-600",
+  found: "text-green-600",
   damaged: "text-orange-600",
   updated: "text-indigo-600",
 };

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/lib/auth-store";
 import {
   ArrowLeft,
   Package,
+  PackageCheck,
   UserCheck,
   Calendar,
   MapPin,
@@ -42,6 +43,7 @@ const ACTION_COLORS: Record<string, string> = {
   repaired: "bg-yellow-500",
   retired: "bg-gray-500",
   lost: "bg-red-500",
+  found: "bg-green-500",
   damaged: "bg-orange-500",
   updated: "bg-indigo-500",
 };
@@ -59,7 +61,7 @@ export default function AssetDetailPage() {
   // Which in-place confirm dialog is open. Replaces window.confirm() so the
   // Retire and Report Lost flows use a styled modal consistent with the
   // rest of the app.
-  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | null>(null);
+  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | "found" | null>(null);
   const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const isHR = user && ["hr_admin", "org_admin", "super_admin"].includes(user.role);
@@ -114,6 +116,17 @@ export default function AssetDetailPage() {
     },
     onError: (err: any) =>
       setConfirmError(err?.response?.data?.error?.message || "Failed to report asset as lost"),
+  });
+
+  const markFoundMutation = useMutation({
+    mutationFn: () => api.post(`/assets/${id}/mark-found`, { notes: "Marked found via dashboard" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to mark asset as found"),
   });
 
   if (isLoading) {
@@ -189,6 +202,18 @@ export default function AssetDetailPage() {
                   Report Lost
                 </button>
               </>
+            )}
+            {asset.status === "lost" && (
+              <button
+                onClick={() => {
+                  setConfirmAction("found");
+                  setConfirmError(null);
+                }}
+                className="inline-flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 text-sm font-medium"
+              >
+                <PackageCheck className="h-4 w-4" />
+                Mark Found
+              </button>
             )}
           </div>
         )}
@@ -476,20 +501,46 @@ export default function AssetDetailPage() {
         </div>
       )}
 
-      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost */}
+      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost / Mark Found */}
       {confirmAction && (() => {
-        const isLost = confirmAction === "lost";
-        const pending = isLost ? reportLostMutation.isPending : retireMutation.isPending;
-        const run = () => (isLost ? reportLostMutation.mutate() : retireMutation.mutate());
-        const title = isLost ? "Report asset as lost?" : "Retire this asset?";
-        const body = isLost
-          ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
-          : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
-        const confirmLabel = isLost ? "Report as Lost" : "Retire Asset";
-        const iconColor = isLost ? "text-red-600 bg-red-50" : "text-gray-600 bg-gray-100";
-        const confirmBtn = isLost
-          ? "bg-red-600 hover:bg-red-700"
-          : "bg-gray-900 hover:bg-black";
+        const mutation =
+          confirmAction === "lost"
+            ? reportLostMutation
+            : confirmAction === "found"
+              ? markFoundMutation
+              : retireMutation;
+        const pending = mutation.isPending;
+        const run = () => mutation.mutate();
+        const title =
+          confirmAction === "lost"
+            ? "Report asset as lost?"
+            : confirmAction === "found"
+              ? "Mark asset as found?"
+              : "Retire this asset?";
+        const body =
+          confirmAction === "lost"
+            ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
+            : confirmAction === "found"
+              ? "This will return the asset to active inventory as available, so it can be reassigned."
+              : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
+        const confirmLabel =
+          confirmAction === "lost"
+            ? "Report as Lost"
+            : confirmAction === "found"
+              ? "Mark as Found"
+              : "Retire Asset";
+        const iconColor =
+          confirmAction === "lost"
+            ? "text-red-600 bg-red-50"
+            : confirmAction === "found"
+              ? "text-green-600 bg-green-50"
+              : "text-gray-600 bg-gray-100";
+        const confirmBtn =
+          confirmAction === "lost"
+            ? "bg-red-600 hover:bg-red-700"
+            : confirmAction === "found"
+              ? "bg-green-600 hover:bg-green-700"
+              : "bg-gray-900 hover:bg-black";
         return (
           <div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
@@ -504,8 +555,10 @@ export default function AssetDetailPage() {
                   <div
                     className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${iconColor}`}
                   >
-                    {isLost ? (
+                    {confirmAction === "lost" ? (
                       <AlertTriangle className="h-5 w-5" />
+                    ) : confirmAction === "found" ? (
+                      <PackageCheck className="h-5 w-5" />
                     ) : (
                       <Trash2 className="h-5 w-5" />
                     )}

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   RotateCcw,
   Trash2,
   X,
+  Loader2,
 } from "lucide-react";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -55,6 +56,11 @@ export default function AssetDetailPage() {
   const [assignNotes, setAssignNotes] = useState("");
   const [returnCondition, setReturnCondition] = useState("good");
   const [returnNotes, setReturnNotes] = useState("");
+  // Which in-place confirm dialog is open. Replaces window.confirm() so the
+  // Retire and Report Lost flows use a styled modal consistent with the
+  // rest of the app.
+  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const isHR = user && ["hr_admin", "org_admin", "super_admin"].includes(user.role);
 
@@ -90,12 +96,24 @@ export default function AssetDetailPage() {
 
   const retireMutation = useMutation({
     mutationFn: () => api.post(`/assets/${id}/retire`, { notes: "Retired via dashboard" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["asset", id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to retire asset"),
   });
 
   const reportLostMutation = useMutation({
     mutationFn: () => api.post(`/assets/${id}/report-lost`, { notes: "Reported lost via dashboard" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["asset", id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to report asset as lost"),
   });
 
   if (isLoading) {
@@ -151,14 +169,20 @@ export default function AssetDetailPage() {
             {asset.status !== "retired" && asset.status !== "lost" && (
               <>
                 <button
-                  onClick={() => { if (confirm("Retire this asset?")) retireMutation.mutate(); }}
+                  onClick={() => {
+                    setConfirmAction("retire");
+                    setConfirmError(null);
+                  }}
                   className="inline-flex items-center gap-2 px-3 py-2 border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 text-sm font-medium"
                 >
                   <Trash2 className="h-4 w-4" />
                   Retire
                 </button>
                 <button
-                  onClick={() => { if (confirm("Report this asset as lost?")) reportLostMutation.mutate(); }}
+                  onClick={() => {
+                    setConfirmAction("lost");
+                    setConfirmError(null);
+                  }}
                   className="inline-flex items-center gap-2 px-3 py-2 border border-red-200 text-red-600 rounded-lg hover:bg-red-50 text-sm font-medium"
                 >
                   <AlertTriangle className="h-4 w-4" />
@@ -451,6 +475,85 @@ export default function AssetDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost */}
+      {confirmAction && (() => {
+        const isLost = confirmAction === "lost";
+        const pending = isLost ? reportLostMutation.isPending : retireMutation.isPending;
+        const run = () => (isLost ? reportLostMutation.mutate() : retireMutation.mutate());
+        const title = isLost ? "Report asset as lost?" : "Retire this asset?";
+        const body = isLost
+          ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
+          : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
+        const confirmLabel = isLost ? "Report as Lost" : "Retire Asset";
+        const iconColor = isLost ? "text-red-600 bg-red-50" : "text-gray-600 bg-gray-100";
+        const confirmBtn = isLost
+          ? "bg-red-600 hover:bg-red-700"
+          : "bg-gray-900 hover:bg-black";
+        return (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={() => !pending && setConfirmAction(null)}
+          >
+            <div
+              className="w-full max-w-md rounded-xl bg-white shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="px-6 py-5">
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${iconColor}`}
+                  >
+                    {isLost ? (
+                      <AlertTriangle className="h-5 w-5" />
+                    ) : (
+                      <Trash2 className="h-5 w-5" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                      <span className="font-medium text-gray-700">
+                        {asset.asset_tag} — {asset.name}
+                      </span>
+                    </p>
+                    <p className="mt-2 text-sm text-gray-500">{body}</p>
+                  </div>
+                </div>
+              </div>
+              {confirmError && (
+                <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                  {confirmError}
+                </div>
+              )}
+              <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+                <button
+                  type="button"
+                  onClick={() => setConfirmAction(null)}
+                  disabled={pending}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={run}
+                  disabled={pending}
+                  className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${confirmBtn}`}
+                >
+                  {pending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" /> Working...
+                    </>
+                  ) : (
+                    confirmLabel
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/server/src/api/routes/asset.routes.ts
+++ b/packages/server/src/api/routes/asset.routes.ts
@@ -390,4 +390,25 @@ router.post(
   }
 );
 
+// POST /api/v1/assets/:id/mark-found — Recover a lost asset back to available (HR)
+router.post(
+  "/:id/mark-found",
+  authenticate,
+  requireHR,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const data = assetActionSchema.parse(req.body);
+      const asset = await assetService.markFound(
+        req.user!.org_id,
+        paramInt(req.params.id),
+        req.user!.sub,
+        data.notes
+      );
+      sendSuccess(res, asset);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
 export default router;

--- a/packages/server/src/db/migrations/043_asset_history_found_action.ts
+++ b/packages/server/src/db/migrations/043_asset_history_found_action.ts
@@ -1,0 +1,23 @@
+// =============================================================================
+// MIGRATION 043 — Add "found" to asset_history.action enum
+// =============================================================================
+
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE asset_history
+    MODIFY COLUMN action ENUM(
+      'created','assigned','returned','repaired','retired','lost','found','damaged','updated'
+    ) NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE asset_history
+    MODIFY COLUMN action ENUM(
+      'created','assigned','returned','repaired','retired','lost','damaged','updated'
+    ) NOT NULL
+  `);
+}

--- a/packages/server/src/services/asset/asset.service.ts
+++ b/packages/server/src/services/asset/asset.service.ts
@@ -515,6 +515,51 @@ export async function reportLost(
 }
 
 // ---------------------------------------------------------------------------
+// Mark Found — recover a previously-lost asset back to available
+// ---------------------------------------------------------------------------
+
+export async function markFound(
+  orgId: number,
+  assetId: number,
+  userId: number,
+  notes?: string | null
+) {
+  const db = getDB();
+
+  const asset = await db("assets")
+    .where({ id: assetId, organization_id: orgId })
+    .first();
+  if (!asset) throw new NotFoundError("Asset");
+
+  if (asset.status !== "lost") {
+    throw new ForbiddenError("Only lost assets can be marked as found");
+  }
+
+  const now = new Date();
+
+  await db.transaction(async (trx) => {
+    await trx("assets").where({ id: assetId }).update({
+      status: "available",
+      updated_at: now,
+    });
+
+    await trx("asset_history").insert({
+      asset_id: assetId,
+      organization_id: orgId,
+      action: "found",
+      from_user_id: null,
+      to_user_id: null,
+      performed_by: userId,
+      notes: notes || "Asset marked as found",
+      created_at: now,
+    });
+  });
+
+  logger.info(`Asset #${assetId} marked found by user ${userId} in org ${orgId}`);
+  return db("assets").where({ id: assetId }).first();
+}
+
+// ---------------------------------------------------------------------------
 // Delete Asset (soft — retire; blocks if currently assigned)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1443.

## Summary
When an asset was reported lost there was no way back to active inventory — on `status=lost` the detail page hid every action, so the only options were leaving it lost or editing the row directly in the DB. Added a **Mark Found** flow that flips the asset back to `available` and records a `found` entry in the audit history.

> Built on top of #1499 (the `window.confirm` → styled modal work). The confirm modal file shows up here too; once #1499 merges, the diff against main will narrow to just the Mark Found changes.

## Changes

### Backend
- **`asset.service.ts`** — new `markFound(orgId, assetId, userId, notes)`. Validates the asset is currently `lost`, then in a single transaction updates `status` to `available` **and** writes an `asset_history` row with `action='found'`. The transaction is the important part: before wrapping this, a missing enum value could leave the asset row updated while the history insert threw, so the record drifted.
- **`asset.routes.ts`** — `POST /api/v1/assets/:id/mark-found`, HR-only (matches the `/retire` route shape, reuses `assetActionSchema`).
- **Migration 043** — adds `'found'` to the `asset_history.action` enum. Without this the history insert fails with `Data truncated for column 'action'`.

### Frontend
- **`AssetDetailPage.tsx`**
  - Extended `confirmAction` state to `"retire" | "lost" | "found" | null` and added `markFoundMutation` (same invalidate-on-success / keep-open-on-error pattern as the other two).
  - Green **Mark Found** button (with `PackageCheck` icon) shown when `asset.status === "lost"`, in the HR action group.
  - The shared confirm modal IIFE now branches on all three cases — green icon + green confirm button for `found`, body text explains the asset returns to available.
  - Timeline dot: added `found: "bg-green-500"` to `ACTION_COLORS`.
- **`AssetDashboardPage.tsx`** — `found: "text-green-600"` added to its `ACTION_COLORS` so the Recent Activity label renders green too.

### Not included
- No reusable modal component — still only a few sites, inline branching is fine.
- No audit-log row (matching existing `/report-lost`, which also skips `logAudit`). Can add later if audit coverage for asset lifecycle becomes uniform.

## Test plan
- [x] Report an asset lost → `/assets/:id` shows only the **Mark Found** button (retire + report-lost hidden).
- [x] Click Mark Found → styled green modal with asset tag + name → Cancel closes, Mark as Found flips status to `available` and adds a green **Found** entry in the history timeline.
- [x] Dashboard Recent Activity renders the `found` action in green.
- [x] Calling the endpoint on a non-lost asset returns `Only lost assets can be marked as found`.
- [x] Non-HR users get 403 on `POST /mark-found`.
- [x] Transaction verified — if the history insert fails (e.g. enum missing), the status update rolls back.