### PR TITLE
fix(forum): add delete action for categories on dashboard

### DIFF
--- a/packages/client/src/pages/forum/ForumDashboardPage.tsx
+++ b/packages/client/src/pages/forum/ForumDashboardPage.tsx
@@ -10,6 +10,8 @@ import {
   Heart,
   Plus,
   Pencil,
+  Trash2,
+  Loader2,
   BarChart3,
   MessagesSquare,
 } from "lucide-react";
@@ -32,6 +34,8 @@ export default function ForumDashboardPage() {
   const [catDescription, setCatDescription] = useState("");
   const [catIcon, setCatIcon] = useState("");
   const [catSortOrder, setCatSortOrder] = useState(0);
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string; post_count: number } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const createCategory = useMutation({
     mutationFn: (data: object) => api.post("/forum/categories", data).then((r) => r.data.data),
@@ -50,6 +54,19 @@ export default function ForumDashboardPage() {
       qc.invalidateQueries({ queryKey: ["forum-categories"] });
       resetCatForm();
     },
+  });
+
+  const deleteCategory = useMutation({
+    mutationFn: (id: number) =>
+      api.delete(`/forum/categories/${id}`).then((r) => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["forum-dashboard"] });
+      qc.invalidateQueries({ queryKey: ["forum-categories"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
+    },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete category"),
   });
 
   const resetCatForm = () => {
@@ -330,14 +347,94 @@ export default function ForumDashboardPage() {
                 <button
                   onClick={() => startEditCategory(cat)}
                   className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+                  title="Edit category"
                 >
                   <Pencil className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => {
+                    setDeleteTarget({ id: cat.id, name: cat.name, post_count: Number(cat.post_count || 0) });
+                    setDeleteError(null);
+                  }}
+                  className="p-1.5 rounded-lg hover:bg-red-50 text-gray-400 hover:text-red-600"
+                  title="Delete category"
+                >
+                  <Trash2 className="h-4 w-4" />
                 </button>
               </div>
             ))}
           </div>
         )}
       </div>
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteCategory.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Delete category?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Delete{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.name}</span>?
+                    {deleteTarget.post_count > 0 ? (
+                      <>
+                        {" "}The {deleteTarget.post_count} existing post
+                        {deleteTarget.post_count === 1 ? "" : "s"} keep their tag, but no
+                        new posts can be added here until it's restored.
+                      </>
+                    ) : (
+                      <>
+                        {" "}The category will be hidden from the forum and from new-post
+                        selection.
+                      </>
+                    )}
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteCategory.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteCategory.mutate(deleteTarget.id)}
+                disabled={deleteCategory.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteCategory.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/server/src/api/routes/forum.routes.ts
+++ b/packages/server/src/api/routes/forum.routes.ts
@@ -55,6 +55,14 @@ router.put("/categories/:id", authenticate, requireHR, async (req: Request, res:
   } catch (err) { next(err); }
 });
 
+// DELETE /api/v1/forum/categories/:id — soft-delete a forum category (HR)
+router.delete("/categories/:id", authenticate, requireHR, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await forumService.deleteCategory(req.user!.org_id, paramInt(req.params.id));
+    sendSuccess(res, { message: "Category deactivated" });
+  } catch (err) { next(err); }
+});
+
 // ---- Posts ----
 
 // POST /api/v1/forum/posts

--- a/packages/server/src/services/forum/forum.service.ts
+++ b/packages/server/src/services/forum/forum.service.ts
@@ -108,6 +108,21 @@ export async function updateCategory(
   return db("forum_categories").where({ id: categoryId }).first();
 }
 
+export async function deleteCategory(orgId: number, categoryId: number) {
+  const db = getDB();
+  const existing = await db("forum_categories")
+    .where({ id: categoryId, organization_id: orgId })
+    .first();
+  if (!existing) throw new NotFoundError("Forum category");
+
+  // Soft-delete — mark inactive. Existing posts keep their category_id but
+  // the category is hidden from the listing and createPost blocks new posts
+  // since it filters on is_active=true.
+  await db("forum_categories")
+    .where({ id: categoryId })
+    .update({ is_active: false, updated_at: new Date() });
+}
+
 // ---------------------------------------------------------------------------
 // Posts
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1473.

## Summary
The Forum dashboard had **Add** and **Edit** actions for categories but no way to delete one — HR could create a typo'd category and have to live with it. This adds the missing delete flow on the dashboard and the matching backend endpoint.

## Changes

### Backend
- **`forum.service.ts`** — `deleteCategory(orgId, categoryId)`. Soft-delete only (`is_active = false`), matching the existing pattern for asset categories. Chose soft over hard because `forum_posts.category_id` has existing rows that shouldn't silently break, and `listCategories` / `createPost` already filter on `is_active = true`, so after the flip:
  - the category disappears from the dashboard list and from category-picker dropdowns,
  - existing posts still reference it via `category_id` and keep working,
  - `createPost` rejects any new post targeting that category.
- **`forum.routes.ts`** — `DELETE /api/v1/forum/categories/:id`, gated by `requireHR`.

### Frontend (`ForumDashboardPage.tsx`)
- Red **trash** icon button next to the existing pencil on each category row.
- Clicking it opens a styled confirm modal (same pattern used in the asset-category / KB-article destructive actions): red trash icon, category name in bold, and a body copy that adapts to whether the category currently has posts — if yes, it tells HR that the N existing post(s) keep their tag but new posts are blocked; if zero, the simpler "hidden from forum" message.
- Inline server-error banner inside the modal, click-outside-to-close blocked while the mutation is pending.
- On success invalidates `forum-dashboard` and `forum-categories` queries so every consumer of the category list refetches.

## Test plan
- [x] Dashboard → category row trash icon → confirm modal opens showing category name and post count copy.
- [x] Cancel closes the modal; Delete calls `DELETE /forum/categories/:id` and the row disappears.
- [x] Deactivated category no longer appears in the Forum category picker when creating a post.
- [x] Existing posts under the deleted category still render (they kept their `category_id`).
- [x] Non-HR users still see only the dashboard view — no trash button (button is only rendered in the HR-only Manage Categories block).
- [x] Network failure keeps the modal open and shows the server error inline.