### PR TITLE
feat(assets): add Send for Repair and Repair Complete actions

### DIFF
--- a/packages/client/src/pages/assets/AssetCategoriesPage.tsx
+++ b/packages/client/src/pages/assets/AssetCategoriesPage.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   X,
   Check,
+  Loader2,
 } from "lucide-react";
 
 export default function AssetCategoriesPage() {
@@ -16,6 +17,9 @@ export default function AssetCategoriesPage() {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [formName, setFormName] = useState("");
   const [formDescription, setFormDescription] = useState("");
+  // Confirm dialog for deactivating a category. Replaces window.confirm().
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: categories, isLoading } = useQuery({
     queryKey: ["asset-categories"],
@@ -43,7 +47,11 @@ export default function AssetCategoriesPage() {
     mutationFn: (id: number) => api.delete(`/assets/categories/${id}`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["asset-categories"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
     },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to deactivate category"),
   });
 
   function resetForm() {
@@ -121,9 +129,8 @@ export default function AssetCategoriesPage() {
                       </button>
                       <button
                         onClick={() => {
-                          if (confirm(`Deactivate category "${cat.name}"?`)) {
-                            deleteCategory.mutate(cat.id);
-                          }
+                          setDeleteTarget({ id: cat.id, name: cat.name });
+                          setDeleteError(null);
                         }}
                         className="p-1.5 rounded hover:bg-red-50 text-gray-500 hover:text-red-600"
                         title="Delete"
@@ -190,6 +197,65 @@ export default function AssetCategoriesPage() {
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Deactivate confirmation — replaces window.confirm() */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteCategory.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Deactivate category?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Deactivate{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.name}</span>? Existing
+                    assets tagged with this category keep the tag, but no new assets can be placed
+                    here until it's restored.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteCategory.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteCategory.mutate(deleteTarget.id)}
+                disabled={deleteCategory.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteCategory.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deactivating...
+                  </>
+                ) : (
+                  "Deactivate"
+                )}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/packages/client/src/pages/assets/AssetDashboardPage.tsx
+++ b/packages/client/src/pages/assets/AssetDashboardPage.tsx
@@ -19,6 +19,7 @@ const ACTION_COLORS: Record<string, string> = {
   repaired: "text-yellow-600",
   retired: "text-gray-600",
   lost: "text-red-600",
+  found: "text-green-600",
   damaged: "text-orange-600",
   updated: "text-indigo-600",
 };

--- a/packages/client/src/pages/assets/AssetDashboardPage.tsx
+++ b/packages/client/src/pages/assets/AssetDashboardPage.tsx
@@ -16,6 +16,7 @@ const ACTION_COLORS: Record<string, string> = {
   created: "text-green-600",
   assigned: "text-blue-600",
   returned: "text-purple-600",
+  sent_to_repair: "text-yellow-600",
   repaired: "text-yellow-600",
   retired: "text-gray-600",
   lost: "text-red-600",

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -16,6 +16,8 @@ import {
   AlertTriangle,
   RotateCcw,
   Trash2,
+  Wrench,
+  CheckCircle,
   X,
   Loader2,
 } from "lucide-react";
@@ -40,6 +42,7 @@ const ACTION_COLORS: Record<string, string> = {
   created: "bg-green-500",
   assigned: "bg-blue-500",
   returned: "bg-purple-500",
+  sent_to_repair: "bg-yellow-500",
   repaired: "bg-yellow-500",
   retired: "bg-gray-500",
   lost: "bg-red-500",
@@ -61,7 +64,9 @@ export default function AssetDetailPage() {
   // Which in-place confirm dialog is open. Replaces window.confirm() so the
   // Retire and Report Lost flows use a styled modal consistent with the
   // rest of the app.
-  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | "found" | null>(null);
+  const [confirmAction, setConfirmAction] = useState<
+    "retire" | "lost" | "found" | "repair_start" | "repair_complete" | null
+  >(null);
   const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const isHR = user && ["hr_admin", "org_admin", "super_admin"].includes(user.role);
@@ -129,6 +134,30 @@ export default function AssetDetailPage() {
       setConfirmError(err?.response?.data?.error?.message || "Failed to mark asset as found"),
   });
 
+  const sendToRepairMutation = useMutation({
+    mutationFn: () =>
+      api.post(`/assets/${id}/send-to-repair`, { notes: "Sent for repair via dashboard" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to send asset to repair"),
+  });
+
+  const completeRepairMutation = useMutation({
+    mutationFn: () =>
+      api.post(`/assets/${id}/complete-repair`, { notes: "Repair completed via dashboard" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to complete repair"),
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -177,6 +206,30 @@ export default function AssetDetailPage() {
               >
                 <RotateCcw className="h-4 w-4" />
                 Return
+              </button>
+            )}
+            {(asset.status === "available" || asset.status === "assigned") && (
+              <button
+                onClick={() => {
+                  setConfirmAction("repair_start");
+                  setConfirmError(null);
+                }}
+                className="inline-flex items-center gap-2 px-3 py-2 border border-yellow-200 text-yellow-700 rounded-lg hover:bg-yellow-50 text-sm font-medium"
+              >
+                <Wrench className="h-4 w-4" />
+                Send for Repair
+              </button>
+            )}
+            {asset.status === "in_repair" && (
+              <button
+                onClick={() => {
+                  setConfirmAction("repair_complete");
+                  setConfirmError(null);
+                }}
+                className="inline-flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 text-sm font-medium"
+              >
+                <CheckCircle className="h-4 w-4" />
+                Repair Complete
               </button>
             )}
             {asset.status !== "retired" && asset.status !== "lost" && (
@@ -501,46 +554,64 @@ export default function AssetDetailPage() {
         </div>
       )}
 
-      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost / Mark Found */}
+      {/* Confirmation dialog — styled replacement for Retire / Report Lost / Mark Found / Repair */}
       {confirmAction && (() => {
-        const mutation =
-          confirmAction === "lost"
-            ? reportLostMutation
-            : confirmAction === "found"
-              ? markFoundMutation
-              : retireMutation;
-        const pending = mutation.isPending;
-        const run = () => mutation.mutate();
-        const title =
-          confirmAction === "lost"
-            ? "Report asset as lost?"
-            : confirmAction === "found"
-              ? "Mark asset as found?"
-              : "Retire this asset?";
-        const body =
-          confirmAction === "lost"
-            ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
-            : confirmAction === "found"
-              ? "This will return the asset to active inventory as available, so it can be reassigned."
-              : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
-        const confirmLabel =
-          confirmAction === "lost"
-            ? "Report as Lost"
-            : confirmAction === "found"
-              ? "Mark as Found"
-              : "Retire Asset";
-        const iconColor =
-          confirmAction === "lost"
-            ? "text-red-600 bg-red-50"
-            : confirmAction === "found"
-              ? "text-green-600 bg-green-50"
-              : "text-gray-600 bg-gray-100";
-        const confirmBtn =
-          confirmAction === "lost"
-            ? "bg-red-600 hover:bg-red-700"
-            : confirmAction === "found"
-              ? "bg-green-600 hover:bg-green-700"
-              : "bg-gray-900 hover:bg-black";
+        const CONFIG = {
+          retire: {
+            mutation: retireMutation,
+            title: "Retire this asset?",
+            body: "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.",
+            confirmLabel: "Retire Asset",
+            iconColor: "text-gray-600 bg-gray-100",
+            confirmBtn: "bg-gray-900 hover:bg-black",
+            Icon: Trash2,
+          },
+          lost: {
+            mutation: reportLostMutation,
+            title: "Report asset as lost?",
+            body: "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page.",
+            confirmLabel: "Report as Lost",
+            iconColor: "text-red-600 bg-red-50",
+            confirmBtn: "bg-red-600 hover:bg-red-700",
+            Icon: AlertTriangle,
+          },
+          found: {
+            mutation: markFoundMutation,
+            title: "Mark asset as found?",
+            body: "This will return the asset to active inventory as available, so it can be reassigned.",
+            confirmLabel: "Mark as Found",
+            iconColor: "text-green-600 bg-green-50",
+            confirmBtn: "bg-green-600 hover:bg-green-700",
+            Icon: PackageCheck,
+          },
+          repair_start: {
+            mutation: sendToRepairMutation,
+            title: "Send asset for repair?",
+            body:
+              asset.status === "assigned"
+                ? "This will unassign the asset and move it to 'In Repair'. The current holder stays recorded in the history."
+                : "This will move the asset to 'In Repair'. It won't be assignable until repair is complete.",
+            confirmLabel: "Send for Repair",
+            iconColor: "text-yellow-700 bg-yellow-50",
+            confirmBtn: "bg-yellow-600 hover:bg-yellow-700",
+            Icon: Wrench,
+          },
+          repair_complete: {
+            mutation: completeRepairMutation,
+            title: "Mark repair as complete?",
+            body: "This will return the asset to active inventory as available, so it can be reassigned.",
+            confirmLabel: "Mark as Repaired",
+            iconColor: "text-green-600 bg-green-50",
+            confirmBtn: "bg-green-600 hover:bg-green-700",
+            Icon: CheckCircle,
+          },
+        } as const;
+
+        const cfg = CONFIG[confirmAction];
+        const pending = cfg.mutation.isPending;
+        const run = () => cfg.mutation.mutate();
+        const { title, body, confirmLabel, iconColor, confirmBtn, Icon } = cfg;
+
         return (
           <div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
@@ -555,13 +626,7 @@ export default function AssetDetailPage() {
                   <div
                     className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${iconColor}`}
                   >
-                    {confirmAction === "lost" ? (
-                      <AlertTriangle className="h-5 w-5" />
-                    ) : confirmAction === "found" ? (
-                      <PackageCheck className="h-5 w-5" />
-                    ) : (
-                      <Trash2 className="h-5 w-5" />
-                    )}
+                    <Icon className="h-5 w-5" />
                   </div>
                   <div className="flex-1">
                     <h3 className="text-lg font-semibold text-gray-900">{title}</h3>

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/lib/auth-store";
 import {
   ArrowLeft,
   Package,
+  PackageCheck,
   UserCheck,
   Calendar,
   MapPin,
@@ -42,6 +43,7 @@ const ACTION_COLORS: Record<string, string> = {
   repaired: "bg-yellow-500",
   retired: "bg-gray-500",
   lost: "bg-red-500",
+  found: "bg-green-500",
   damaged: "bg-orange-500",
   updated: "bg-indigo-500",
 };
@@ -59,7 +61,7 @@ export default function AssetDetailPage() {
   // Which in-place confirm dialog is open. Replaces window.confirm() so the
   // Retire and Report Lost flows use a styled modal consistent with the
   // rest of the app.
-  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | null>(null);
+  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | "found" | null>(null);
   const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const isHR = user && ["hr_admin", "org_admin", "super_admin"].includes(user.role);
@@ -114,6 +116,17 @@ export default function AssetDetailPage() {
     },
     onError: (err: any) =>
       setConfirmError(err?.response?.data?.error?.message || "Failed to report asset as lost"),
+  });
+
+  const markFoundMutation = useMutation({
+    mutationFn: () => api.post(`/assets/${id}/mark-found`, { notes: "Marked found via dashboard" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to mark asset as found"),
   });
 
   if (isLoading) {
@@ -189,6 +202,18 @@ export default function AssetDetailPage() {
                   Report Lost
                 </button>
               </>
+            )}
+            {asset.status === "lost" && (
+              <button
+                onClick={() => {
+                  setConfirmAction("found");
+                  setConfirmError(null);
+                }}
+                className="inline-flex items-center gap-2 px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 text-sm font-medium"
+              >
+                <PackageCheck className="h-4 w-4" />
+                Mark Found
+              </button>
             )}
           </div>
         )}
@@ -476,20 +501,46 @@ export default function AssetDetailPage() {
         </div>
       )}
 
-      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost */}
+      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost / Mark Found */}
       {confirmAction && (() => {
-        const isLost = confirmAction === "lost";
-        const pending = isLost ? reportLostMutation.isPending : retireMutation.isPending;
-        const run = () => (isLost ? reportLostMutation.mutate() : retireMutation.mutate());
-        const title = isLost ? "Report asset as lost?" : "Retire this asset?";
-        const body = isLost
-          ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
-          : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
-        const confirmLabel = isLost ? "Report as Lost" : "Retire Asset";
-        const iconColor = isLost ? "text-red-600 bg-red-50" : "text-gray-600 bg-gray-100";
-        const confirmBtn = isLost
-          ? "bg-red-600 hover:bg-red-700"
-          : "bg-gray-900 hover:bg-black";
+        const mutation =
+          confirmAction === "lost"
+            ? reportLostMutation
+            : confirmAction === "found"
+              ? markFoundMutation
+              : retireMutation;
+        const pending = mutation.isPending;
+        const run = () => mutation.mutate();
+        const title =
+          confirmAction === "lost"
+            ? "Report asset as lost?"
+            : confirmAction === "found"
+              ? "Mark asset as found?"
+              : "Retire this asset?";
+        const body =
+          confirmAction === "lost"
+            ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
+            : confirmAction === "found"
+              ? "This will return the asset to active inventory as available, so it can be reassigned."
+              : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
+        const confirmLabel =
+          confirmAction === "lost"
+            ? "Report as Lost"
+            : confirmAction === "found"
+              ? "Mark as Found"
+              : "Retire Asset";
+        const iconColor =
+          confirmAction === "lost"
+            ? "text-red-600 bg-red-50"
+            : confirmAction === "found"
+              ? "text-green-600 bg-green-50"
+              : "text-gray-600 bg-gray-100";
+        const confirmBtn =
+          confirmAction === "lost"
+            ? "bg-red-600 hover:bg-red-700"
+            : confirmAction === "found"
+              ? "bg-green-600 hover:bg-green-700"
+              : "bg-gray-900 hover:bg-black";
         return (
           <div
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
@@ -504,8 +555,10 @@ export default function AssetDetailPage() {
                   <div
                     className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${iconColor}`}
                   >
-                    {isLost ? (
+                    {confirmAction === "lost" ? (
                       <AlertTriangle className="h-5 w-5" />
+                    ) : confirmAction === "found" ? (
+                      <PackageCheck className="h-5 w-5" />
                     ) : (
                       <Trash2 className="h-5 w-5" />
                     )}

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   RotateCcw,
   Trash2,
   X,
+  Loader2,
 } from "lucide-react";
 
 const STATUS_COLORS: Record<string, string> = {
@@ -55,6 +56,11 @@ export default function AssetDetailPage() {
   const [assignNotes, setAssignNotes] = useState("");
   const [returnCondition, setReturnCondition] = useState("good");
   const [returnNotes, setReturnNotes] = useState("");
+  // Which in-place confirm dialog is open. Replaces window.confirm() so the
+  // Retire and Report Lost flows use a styled modal consistent with the
+  // rest of the app.
+  const [confirmAction, setConfirmAction] = useState<"retire" | "lost" | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
 
   const isHR = user && ["hr_admin", "org_admin", "super_admin"].includes(user.role);
 
@@ -90,12 +96,24 @@ export default function AssetDetailPage() {
 
   const retireMutation = useMutation({
     mutationFn: () => api.post(`/assets/${id}/retire`, { notes: "Retired via dashboard" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["asset", id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to retire asset"),
   });
 
   const reportLostMutation = useMutation({
     mutationFn: () => api.post(`/assets/${id}/report-lost`, { notes: "Reported lost via dashboard" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["asset", id] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["asset", id] });
+      setConfirmAction(null);
+      setConfirmError(null);
+    },
+    onError: (err: any) =>
+      setConfirmError(err?.response?.data?.error?.message || "Failed to report asset as lost"),
   });
 
   if (isLoading) {
@@ -151,14 +169,20 @@ export default function AssetDetailPage() {
             {asset.status !== "retired" && asset.status !== "lost" && (
               <>
                 <button
-                  onClick={() => { if (confirm("Retire this asset?")) retireMutation.mutate(); }}
+                  onClick={() => {
+                    setConfirmAction("retire");
+                    setConfirmError(null);
+                  }}
                   className="inline-flex items-center gap-2 px-3 py-2 border border-gray-200 text-gray-600 rounded-lg hover:bg-gray-50 text-sm font-medium"
                 >
                   <Trash2 className="h-4 w-4" />
                   Retire
                 </button>
                 <button
-                  onClick={() => { if (confirm("Report this asset as lost?")) reportLostMutation.mutate(); }}
+                  onClick={() => {
+                    setConfirmAction("lost");
+                    setConfirmError(null);
+                  }}
                   className="inline-flex items-center gap-2 px-3 py-2 border border-red-200 text-red-600 rounded-lg hover:bg-red-50 text-sm font-medium"
                 >
                   <AlertTriangle className="h-4 w-4" />
@@ -451,6 +475,85 @@ export default function AssetDetailPage() {
           </div>
         </div>
       )}
+
+      {/* Confirmation dialog — replaces window.confirm() for Retire / Report Lost */}
+      {confirmAction && (() => {
+        const isLost = confirmAction === "lost";
+        const pending = isLost ? reportLostMutation.isPending : retireMutation.isPending;
+        const run = () => (isLost ? reportLostMutation.mutate() : retireMutation.mutate());
+        const title = isLost ? "Report asset as lost?" : "Retire this asset?";
+        const body = isLost
+          ? "This will mark the asset as lost and record it in the audit history. You can mark it found later from the asset detail page."
+          : "Retiring an asset takes it out of active inventory. Past assignments stay on record but the asset can no longer be assigned.";
+        const confirmLabel = isLost ? "Report as Lost" : "Retire Asset";
+        const iconColor = isLost ? "text-red-600 bg-red-50" : "text-gray-600 bg-gray-100";
+        const confirmBtn = isLost
+          ? "bg-red-600 hover:bg-red-700"
+          : "bg-gray-900 hover:bg-black";
+        return (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            onClick={() => !pending && setConfirmAction(null)}
+          >
+            <div
+              className="w-full max-w-md rounded-xl bg-white shadow-xl"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="px-6 py-5">
+                <div className="flex items-start gap-3">
+                  <div
+                    className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full ${iconColor}`}
+                  >
+                    {isLost ? (
+                      <AlertTriangle className="h-5 w-5" />
+                    ) : (
+                      <Trash2 className="h-5 w-5" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                      <span className="font-medium text-gray-700">
+                        {asset.asset_tag} — {asset.name}
+                      </span>
+                    </p>
+                    <p className="mt-2 text-sm text-gray-500">{body}</p>
+                  </div>
+                </div>
+              </div>
+              {confirmError && (
+                <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                  {confirmError}
+                </div>
+              )}
+              <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+                <button
+                  type="button"
+                  onClick={() => setConfirmAction(null)}
+                  disabled={pending}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={run}
+                  disabled={pending}
+                  className={`flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${confirmBtn}`}
+                >
+                  {pending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" /> Working...
+                    </>
+                  ) : (
+                    confirmLabel
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/packages/server/src/api/routes/asset.routes.ts
+++ b/packages/server/src/api/routes/asset.routes.ts
@@ -411,4 +411,46 @@ router.post(
   }
 );
 
+// POST /api/v1/assets/:id/send-to-repair — Move asset into repair (HR)
+router.post(
+  "/:id/send-to-repair",
+  authenticate,
+  requireHR,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const data = assetActionSchema.parse(req.body);
+      const asset = await assetService.sendToRepair(
+        req.user!.org_id,
+        paramInt(req.params.id),
+        req.user!.sub,
+        data.notes
+      );
+      sendSuccess(res, asset);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+// POST /api/v1/assets/:id/complete-repair — Mark repair done, back to available (HR)
+router.post(
+  "/:id/complete-repair",
+  authenticate,
+  requireHR,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const data = assetActionSchema.parse(req.body);
+      const asset = await assetService.completeRepair(
+        req.user!.org_id,
+        paramInt(req.params.id),
+        req.user!.sub,
+        data.notes
+      );
+      sendSuccess(res, asset);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
 export default router;

--- a/packages/server/src/api/routes/asset.routes.ts
+++ b/packages/server/src/api/routes/asset.routes.ts
@@ -390,4 +390,25 @@ router.post(
   }
 );
 
+// POST /api/v1/assets/:id/mark-found — Recover a lost asset back to available (HR)
+router.post(
+  "/:id/mark-found",
+  authenticate,
+  requireHR,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const data = assetActionSchema.parse(req.body);
+      const asset = await assetService.markFound(
+        req.user!.org_id,
+        paramInt(req.params.id),
+        req.user!.sub,
+        data.notes
+      );
+      sendSuccess(res, asset);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
 export default router;

--- a/packages/server/src/db/migrations/043_asset_history_found_action.ts
+++ b/packages/server/src/db/migrations/043_asset_history_found_action.ts
@@ -1,0 +1,23 @@
+// =============================================================================
+// MIGRATION 043 — Add "found" to asset_history.action enum
+// =============================================================================
+
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE asset_history
+    MODIFY COLUMN action ENUM(
+      'created','assigned','returned','repaired','retired','lost','found','damaged','updated'
+    ) NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE asset_history
+    MODIFY COLUMN action ENUM(
+      'created','assigned','returned','repaired','retired','lost','damaged','updated'
+    ) NOT NULL
+  `);
+}

--- a/packages/server/src/db/migrations/044_asset_history_sent_to_repair_action.ts
+++ b/packages/server/src/db/migrations/044_asset_history_sent_to_repair_action.ts
@@ -1,0 +1,23 @@
+// =============================================================================
+// MIGRATION 044 — Add "sent_to_repair" to asset_history.action enum
+// =============================================================================
+
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE asset_history
+    MODIFY COLUMN action ENUM(
+      'created','assigned','returned','repaired','retired','lost','found','sent_to_repair','damaged','updated'
+    ) NOT NULL
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE asset_history
+    MODIFY COLUMN action ENUM(
+      'created','assigned','returned','repaired','retired','lost','found','damaged','updated'
+    ) NOT NULL
+  `);
+}

--- a/packages/server/src/services/asset/asset.service.ts
+++ b/packages/server/src/services/asset/asset.service.ts
@@ -515,6 +515,102 @@ export async function reportLost(
 }
 
 // ---------------------------------------------------------------------------
+// Send to Repair — move an available or assigned asset into repair
+// ---------------------------------------------------------------------------
+
+export async function sendToRepair(
+  orgId: number,
+  assetId: number,
+  userId: number,
+  notes?: string | null
+) {
+  const db = getDB();
+
+  const asset = await db("assets")
+    .where({ id: assetId, organization_id: orgId })
+    .first();
+  if (!asset) throw new NotFoundError("Asset");
+
+  if (asset.status !== "available" && asset.status !== "assigned") {
+    throw new ForbiddenError(
+      `Cannot send an asset with status '${asset.status}' to repair`
+    );
+  }
+
+  const previousAssignedTo = asset.assigned_to;
+  const now = new Date();
+
+  await db.transaction(async (trx) => {
+    await trx("assets").where({ id: assetId }).update({
+      status: "in_repair",
+      assigned_to: null,
+      assigned_at: null,
+      assigned_by: null,
+      updated_at: now,
+    });
+
+    await trx("asset_history").insert({
+      asset_id: assetId,
+      organization_id: orgId,
+      action: "sent_to_repair",
+      from_user_id: previousAssignedTo || null,
+      to_user_id: null,
+      performed_by: userId,
+      notes: notes || "Asset sent for repair",
+      created_at: now,
+    });
+  });
+
+  logger.info(`Asset #${assetId} sent to repair by user ${userId} in org ${orgId}`);
+  return db("assets").where({ id: assetId }).first();
+}
+
+// ---------------------------------------------------------------------------
+// Complete Repair — return an in-repair asset back to available
+// ---------------------------------------------------------------------------
+
+export async function completeRepair(
+  orgId: number,
+  assetId: number,
+  userId: number,
+  notes?: string | null
+) {
+  const db = getDB();
+
+  const asset = await db("assets")
+    .where({ id: assetId, organization_id: orgId })
+    .first();
+  if (!asset) throw new NotFoundError("Asset");
+
+  if (asset.status !== "in_repair") {
+    throw new ForbiddenError("Only in-repair assets can be marked as repaired");
+  }
+
+  const now = new Date();
+
+  await db.transaction(async (trx) => {
+    await trx("assets").where({ id: assetId }).update({
+      status: "available",
+      updated_at: now,
+    });
+
+    await trx("asset_history").insert({
+      asset_id: assetId,
+      organization_id: orgId,
+      action: "repaired",
+      from_user_id: null,
+      to_user_id: null,
+      performed_by: userId,
+      notes: notes || "Repair complete, asset back to available",
+      created_at: now,
+    });
+  });
+
+  logger.info(`Asset #${assetId} repair completed by user ${userId} in org ${orgId}`);
+  return db("assets").where({ id: assetId }).first();
+}
+
+// ---------------------------------------------------------------------------
 // Mark Found — recover a previously-lost asset back to available
 // ---------------------------------------------------------------------------
 

--- a/packages/server/src/services/asset/asset.service.ts
+++ b/packages/server/src/services/asset/asset.service.ts
@@ -515,6 +515,51 @@ export async function reportLost(
 }
 
 // ---------------------------------------------------------------------------
+// Mark Found — recover a previously-lost asset back to available
+// ---------------------------------------------------------------------------
+
+export async function markFound(
+  orgId: number,
+  assetId: number,
+  userId: number,
+  notes?: string | null
+) {
+  const db = getDB();
+
+  const asset = await db("assets")
+    .where({ id: assetId, organization_id: orgId })
+    .first();
+  if (!asset) throw new NotFoundError("Asset");
+
+  if (asset.status !== "lost") {
+    throw new ForbiddenError("Only lost assets can be marked as found");
+  }
+
+  const now = new Date();
+
+  await db.transaction(async (trx) => {
+    await trx("assets").where({ id: assetId }).update({
+      status: "available",
+      updated_at: now,
+    });
+
+    await trx("asset_history").insert({
+      asset_id: assetId,
+      organization_id: orgId,
+      action: "found",
+      from_user_id: null,
+      to_user_id: null,
+      performed_by: userId,
+      notes: notes || "Asset marked as found",
+      created_at: now,
+    });
+  });
+
+  logger.info(`Asset #${assetId} marked found by user ${userId} in org ${orgId}`);
+  return db("assets").where({ id: assetId }).first();
+}
+
+// ---------------------------------------------------------------------------
 // Delete Asset (soft — retire; blocks if currently assigned)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1442.

## Summary
The asset dashboard has an **In Repair** stat card, but there was no way to actually put an asset into that status — no button in the UI and no endpoint on the backend. This PR adds the full round-trip: send an asset out for repair, and mark the repair complete.

> Stacks on #1499 (styled confirm modal) and #1500 (Mark Found). Until those merge, the diff against main shows all three PRs; once they land, this PR narrows to just the repair work.

## Changes

### Backend
- **`asset.service.ts`** — two new functions, both transactional (status update and history insert commit together, matching the fix we put in place for `markFound`):
  - `sendToRepair(orgId, assetId, userId, notes)` — accepts `status = available` or `assigned`. Clears `assigned_to` / `assigned_at` / `assigned_by` (the prior holder is preserved as `from_user_id` on the history row), then flips status to `in_repair`. History action: `sent_to_repair`.
  - `completeRepair(orgId, assetId, userId, notes)` — requires `status = in_repair`. Flips back to `available`. History action: `repaired` (existing enum value).
- **`asset.routes.ts`** — `POST /api/v1/assets/:id/send-to-repair` and `POST /api/v1/assets/:id/complete-repair`, both HR-only, both reusing `assetActionSchema`.
- **Migration 044** — adds `'sent_to_repair'` to `asset_history.action`. Without this the history insert would fail with `Data truncated for column 'action'`, same gotcha we hit with `'found'` in migration 043.

### Frontend
- **`AssetDetailPage.tsx`**
  - Yellow **Send for Repair** button (Wrench icon) shown when status is `available` or `assigned`. Body copy in the confirm modal adapts: on `assigned` it warns that the asset will be unassigned first.
  - Green **Repair Complete** button (CheckCircle icon) shown when status is `in_repair`.
  - Refactored the unified confirm-modal IIFE into a `CONFIG` map keyed by action. One data structure now drives all five actions (retire, lost, found, repair_start, repair_complete) — the stacked ternaries had reached the point where adding a case was too easy to get wrong.
- **`AssetDashboardPage.tsx`** — yellow `sent_to_repair` color added so the action appears correctly in Recent Activity.

### Why allow assigned → in_repair
The other option was to require the holder to `Return` first, then send to repair — two clicks, no magic. I went with the one-click flow because in practice HR / IT want to record "this laptop is in the shop" quickly, and the prior holder is preserved as `from_user_id` on the history row so we don't lose the audit trail. If this turns out to be too loose, it's a one-line tightening (`if (asset.status !== 'available') throw …`).

## Test plan
- [x] Available asset → Send for Repair → yellow modal → status flips to `in_repair`, history shows yellow `sent_to_repair` row.
- [x] Assigned asset → Send for Repair → modal copy mentions unassigning → on confirm, `assigned_to` is cleared and the history row captures the prior holder as `from_user`.
- [x] In-repair asset → Repair Complete → green modal → status flips back to `available`, history shows a `repaired` row.
- [x] Retire, Report Lost, and Mark Found flows still work unchanged (regression check on the CONFIG-map refactor).
- [x] Non-HR users get 403 on both new endpoints.
- [x] Calling `/send-to-repair` on a `retired` / `lost` / `in_repair` asset returns a clear 403 with the disallowed status named in the message.
- [x] Transaction verified: if the history insert throws, the status update rolls back.