### PR TITLE
fix(nav): dashboard link stays active when a sibling is more specific

### DIFF
--- a/packages/client/src/components/layout/NavSection.tsx
+++ b/packages/client/src/components/layout/NavSection.tsx
@@ -46,7 +46,7 @@ export function NavSection({ label, items, location, t, activeClass = "bg-brand-
             location={location}
             t={t}
             activeClass={activeClass}
-
+            allItems={items}
           />
         )
       )}


### PR DESCRIPTION
Fixes #1474.

## Summary
On the Positions sidebar, the **Dashboard** item (path `/positions`) kept its active highlight whenever a sub-page like `/positions/vacancies` or `/positions/headcount-plans` was open — so two items "glowed" at once. The same bug affected any flat nav section that has a root path plus child paths (Forum, Events, etc.); it just shows up most obviously on Positions because the sub-pages are used a lot.

## Root cause
`isItemActive` in [NavSection.tsx](packages/client/src/components/layout/NavSection.tsx) already knew how to handle this:

```ts
const hasMoreSpecificMatch = isPrefix && allItems.some(
  (other) => other.path !== item.path && other.path.startsWith(item.path + "/") && ...
);
return isExact || (isPrefix && !hasMoreSpecificMatch);
```

But the **flat** `NavLink` render in `NavSection` didn't pass `allItems`, so it defaulted to `[]`. `allItems.some(...)` on an empty array is always `false`, `hasMoreSpecificMatch` stayed `false`, and `/positions` matched as active for every `/positions/*` URL.

The **nested** `NavLink` render already passed `allItems={item.children!}`. The flat render just got overlooked — one-line fix to match.

## Change
```diff
           <NavLink
             key={item.path}
             item={item}
             location={location}
             t={t}
             activeClass={activeClass}
+            allItems={items}
           />
```

## Test plan
- [x] `/positions` → only Dashboard highlighted.
- [x] `/positions/list` → only All Positions highlighted, Dashboard no longer glowing.
- [x] `/positions/vacancies` → only Vacancies highlighted.
- [x] `/positions/headcount-plans` → only Headcount Plans highlighted.
- [x] Forum / Events sections that follow the same root-plus-subpages shape behave correctly.
- [x] Nested-dropdown nav groups still work (they already passed `allItems`, regression only).