### PR TITLE
fix(events): make dashboard stat cards clickable

### DIFF
--- a/packages/client/src/pages/events/EventDashboardPage.tsx
+++ b/packages/client/src/pages/events/EventDashboardPage.tsx
@@ -138,61 +138,52 @@ export default function EventDashboardPage() {
       {/* Stats Cards */}
       {!isLoading && dashboard && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-          <div className="bg-white rounded-xl border border-gray-200 p-5">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="h-10 w-10 rounded-lg bg-blue-50 flex items-center justify-center">
-                <Calendar className="h-5 w-5 text-blue-600" />
+          {([
+            { label: "Upcoming Events", value: dashboard.upcoming_count, icon: Calendar, iconBg: "bg-blue-50", iconColor: "text-blue-600", href: "/events" },
+            { label: "This Month", value: dashboard.month_count, icon: CalendarDays, iconBg: "bg-green-50", iconColor: "text-green-600", href: "/events" },
+            { label: "Total RSVPs", value: dashboard.total_attendees, icon: Users, iconBg: "bg-purple-50", iconColor: "text-purple-600", href: "/events/my" },
+            { label: "Event Types", value: dashboard.type_breakdown?.length || 0, icon: TrendingUp, iconBg: "bg-amber-50", iconColor: "text-amber-600", anchorId: "type-breakdown" },
+          ] as const).map((card) => {
+            const Icon = card.icon;
+            const content = (
+              <div className="flex items-center gap-3 mb-2">
+                <div className={`h-10 w-10 rounded-lg ${card.iconBg} flex items-center justify-center`}>
+                  <Icon className={`h-5 w-5 ${card.iconColor}`} />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400">{card.label}</p>
+                  <p className="text-xl font-bold text-gray-900">{card.value}</p>
+                </div>
               </div>
-              <div>
-                <p className="text-xs text-gray-400">Upcoming Events</p>
-                <p className="text-xl font-bold text-gray-900">{dashboard.upcoming_count}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl border border-gray-200 p-5">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="h-10 w-10 rounded-lg bg-green-50 flex items-center justify-center">
-                <CalendarDays className="h-5 w-5 text-green-600" />
-              </div>
-              <div>
-                <p className="text-xs text-gray-400">This Month</p>
-                <p className="text-xl font-bold text-gray-900">{dashboard.month_count}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl border border-gray-200 p-5">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="h-10 w-10 rounded-lg bg-purple-50 flex items-center justify-center">
-                <Users className="h-5 w-5 text-purple-600" />
-              </div>
-              <div>
-                <p className="text-xs text-gray-400">Total RSVPs</p>
-                <p className="text-xl font-bold text-gray-900">{dashboard.total_attendees}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl border border-gray-200 p-5">
-            <div className="flex items-center gap-3 mb-2">
-              <div className="h-10 w-10 rounded-lg bg-amber-50 flex items-center justify-center">
-                <TrendingUp className="h-5 w-5 text-amber-600" />
-              </div>
-              <div>
-                <p className="text-xs text-gray-400">Event Types</p>
-                <p className="text-xl font-bold text-gray-900">
-                  {dashboard.type_breakdown?.length || 0}
-                </p>
-              </div>
-            </div>
-          </div>
+            );
+            const sharedClass =
+              "block text-left w-full bg-white rounded-xl border border-gray-200 p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500";
+            if ("href" in card) {
+              return (
+                <Link key={card.label} to={card.href} className={sharedClass}>
+                  {content}
+                </Link>
+              );
+            }
+            return (
+              <button
+                key={card.label}
+                type="button"
+                onClick={() => {
+                  document.getElementById(card.anchorId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }}
+                className={sharedClass}
+              >
+                {content}
+              </button>
+            );
+          })}
         </div>
       )}
 
       {/* Type Breakdown */}
       {dashboard?.type_breakdown?.length > 0 && (
-        <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6">
+        <div id="type-breakdown" className="bg-white rounded-xl border border-gray-200 p-6 mb-6 scroll-mt-4">
           <h2 className="text-sm font-semibold text-gray-700 mb-3">Event Type Breakdown</h2>
           <div className="flex flex-wrap gap-3">
             {dashboard.type_breakdown.map((t: any) => (


### PR DESCRIPTION
Fixes #1475.

## Summary
All four top cards on the Event Dashboard were static `<div>`s — employees could see `Upcoming Events: 5` but had no way to drill in from the count. Same class of bug as the asset-dashboard fix (#1439) and survey-results fix (#1438); mirroring those patterns here.

## Changes

### `EventDashboardPage.tsx`
Refactored the four copy-pasted card blocks into a `statCards` array, then render each card as either a `<Link>` (when it has an `href`) or a `<button>` that smooth-scrolls to a section on the same page (when it has an `anchorId`).

| Card | Destination |
|---|---|
| Upcoming Events | `/events` |
| This Month | `/events` |
| Total RSVPs | `/events/my` |
| Event Types | `#type-breakdown` (smooth scroll) |

- Linking Total RSVPs to `/events/my` is the best fit we have today — the dashboard's `total_attendees` is org-wide while `/events/my` is the per-user RSVP list, but there's no "all RSVPs" list view to point at, and `/events/my` is the closest concept. If that lands badly in review, the fix is changing one string (`href: "/events"`).
- Added `id="type-breakdown"` + `scroll-mt-4` on the existing Type Breakdown container so the scroll target lands with a bit of gap under the sticky topbar.
- Hover border + shadow and a focus-ring on every card so they visually read as clickable; matches the affordance used on the asset dashboard cards.

No backend changes, no new routes.

## Test plan
- [x] Click **Upcoming Events** → navigates to `/events`.
- [x] Click **This Month** → navigates to `/events`.
- [x] Click **Total RSVPs** → navigates to `/events/my`.
- [x] Click **Event Types** → smooth-scrolls to the Type Breakdown section; the section lands with a small top gap (no header overlap).
- [x] Tab through the dashboard — each card is focusable and shows the focus ring.
- [x] If the dashboard data is still loading, nothing renders (the `!isLoading && dashboard` guard is unchanged).