### PR TITLE
fix(events): add delete action for HR on dashboard, list, and detail pages

### DIFF
--- a/packages/client/src/pages/events/EventDashboardPage.tsx
+++ b/packages/client/src/pages/events/EventDashboardPage.tsx
@@ -11,6 +11,8 @@ import {
   Video,
   Clock,
   CalendarDays,
+  Trash2,
+  Loader2,
 } from "lucide-react";
 
 const EVENT_TYPES = [
@@ -75,6 +77,21 @@ export default function EventDashboardPage() {
       queryClient.invalidateQueries({ queryKey: ["events-dashboard"] });
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
+  });
+
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; title: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: (eventId: number) => api.delete(`/events/${eventId}`).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["events-dashboard"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
+    },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete event"),
   });
 
   function resetForm() {
@@ -432,19 +449,31 @@ export default function EventDashboardPage() {
                     </span>
                   </div>
                 </div>
-                <div className="flex gap-2">
+                <div className="flex gap-3 items-center">
                   <Link
                     to={`/events/${event.id}`}
                     className="text-xs text-brand-600 hover:underline"
                   >
                     View
                   </Link>
+                  {event.status !== "cancelled" && (
+                    <button
+                      onClick={() => cancelMutation.mutate(event.id)}
+                      disabled={cancelMutation.isPending}
+                      className="text-xs text-red-500 hover:underline disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                  )}
                   <button
-                    onClick={() => cancelMutation.mutate(event.id)}
-                    disabled={cancelMutation.isPending}
-                    className="text-xs text-red-500 hover:underline disabled:opacity-50"
+                    onClick={() => {
+                      setDeleteTarget({ id: event.id, title: event.title });
+                      setDeleteError(null);
+                    }}
+                    className="text-xs text-gray-400 hover:text-red-600"
+                    title="Delete event"
                   >
-                    Cancel
+                    <Trash2 className="h-3.5 w-3.5" />
                   </button>
                 </div>
               </div>
@@ -452,6 +481,64 @@ export default function EventDashboardPage() {
           )}
         </div>
       </div>
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteMutation.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Delete event?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Delete{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.title}</span>?
+                    This permanently removes the event and its RSVPs. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                disabled={deleteMutation.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/events/EventDetailPage.tsx
+++ b/packages/client/src/pages/events/EventDetailPage.tsx
@@ -1,4 +1,5 @@
-import { useParams, Link } from "react-router-dom";
+import { useState } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
@@ -13,7 +14,11 @@ import {
   XCircle,
   Star,
   User,
+  Trash2,
+  Loader2,
 } from "lucide-react";
+
+const HR_ROLES = ["hr_admin", "org_admin", "super_admin"];
 
 const EVENT_TYPE_CONFIG: Record<string, { label: string; color: string }> = {
   meeting: { label: "Meeting", color: "bg-blue-100 text-blue-700" },
@@ -49,6 +54,10 @@ export default function EventDetailPage() {
   const { id } = useParams();
   const user = useAuthStore((s) => s.user);
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const isHR = user && HR_ROLES.includes(user.role);
+  const [showDelete, setShowDelete] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data, isLoading } = useQuery({
     queryKey: ["event", id],
@@ -62,6 +71,17 @@ export default function EventDetailPage() {
       queryClient.invalidateQueries({ queryKey: ["event", id] });
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => api.delete(`/events/${id}`).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+      queryClient.invalidateQueries({ queryKey: ["events-dashboard"] });
+      navigate("/events");
+    },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete event"),
   });
 
   if (isLoading) {
@@ -89,12 +109,25 @@ export default function EventDetailPage() {
 
   return (
     <div>
-      <Link
-        to="/events"
-        className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-6"
-      >
-        <ArrowLeft className="h-4 w-4" /> Back to Events
-      </Link>
+      <div className="flex items-center justify-between mb-6">
+        <Link
+          to="/events"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" /> Back to Events
+        </Link>
+        {isHR && (
+          <button
+            onClick={() => {
+              setShowDelete(true);
+              setDeleteError(null);
+            }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border border-red-200 rounded-lg text-red-600 hover:bg-red-50"
+          >
+            <Trash2 className="h-3.5 w-3.5" /> Delete
+          </button>
+        )}
+      </div>
 
       <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
         {/* Header */}
@@ -285,6 +318,64 @@ export default function EventDetailPage() {
           </div>
         )}
       </div>
+
+      {/* Delete confirmation modal */}
+      {showDelete && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteMutation.isPending && setShowDelete(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Delete event?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Delete{" "}
+                    <span className="font-medium text-gray-700">{event.title}</span>?
+                    This permanently removes the event and its RSVPs. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setShowDelete(false)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate()}
+                disabled={deleteMutation.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/events/EventsListPage.tsx
+++ b/packages/client/src/pages/events/EventsListPage.tsx
@@ -17,6 +17,8 @@ import {
   ChevronRight,
   Filter,
   Star,
+  Trash2,
+  Loader2,
 } from "lucide-react";
 
 const EVENT_TYPE_CONFIG: Record<string, { label: string; color: string }> = {
@@ -60,6 +62,8 @@ export default function EventsListPage() {
   const [page, setPage] = useState(1);
   const [typeFilter, setTypeFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; title: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const user = useAuthStore((s) => s.user);
   const isHR = user && HR_ROLES.includes(user.role);
   const queryClient = useQueryClient();
@@ -85,6 +89,18 @@ export default function EventsListPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["events"] });
     },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (eventId: number) => api.delete(`/events/${eventId}`).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+      queryClient.invalidateQueries({ queryKey: ["events-dashboard"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
+    },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete event"),
   });
 
   const events = data?.data || [];
@@ -226,47 +242,61 @@ export default function EventsListPage() {
                     </div>
                   </div>
 
-                  {/* RSVP Buttons */}
-                  {event.status !== "cancelled" && event.status !== "completed" && (
-                    <div className="flex-shrink-0 flex gap-1.5">
+                  {/* RSVP + HR actions */}
+                  <div className="flex-shrink-0 flex items-center gap-1.5">
+                    {event.status !== "cancelled" && event.status !== "completed" && (
+                      <>
+                        <button
+                          onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "attending" })}
+                          disabled={rsvpMutation.isPending}
+                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
+                            event.my_rsvp_status === "attending"
+                              ? "bg-green-100 border-green-400 text-green-700"
+                              : "border-green-200 text-green-600 hover:bg-green-50"
+                          }`}
+                          title="Attending"
+                        >
+                          <CheckCircle className="h-3.5 w-3.5" /> Yes
+                        </button>
+                        <button
+                          onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "maybe" })}
+                          disabled={rsvpMutation.isPending}
+                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
+                            event.my_rsvp_status === "maybe"
+                              ? "bg-amber-100 border-amber-400 text-amber-700"
+                              : "border-amber-200 text-amber-600 hover:bg-amber-50"
+                          }`}
+                          title="Maybe"
+                        >
+                          <HelpCircle className="h-3.5 w-3.5" /> Maybe
+                        </button>
+                        <button
+                          onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "declined" })}
+                          disabled={rsvpMutation.isPending}
+                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
+                            event.my_rsvp_status === "declined"
+                              ? "bg-red-100 border-red-400 text-red-700"
+                              : "border-red-200 text-red-600 hover:bg-red-50"
+                          }`}
+                          title="Decline"
+                        >
+                          <XCircle className="h-3.5 w-3.5" /> No
+                        </button>
+                      </>
+                    )}
+                    {isHR && (
                       <button
-                        onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "attending" })}
-                        disabled={rsvpMutation.isPending}
-                        className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
-                          event.my_rsvp_status === "attending"
-                            ? "bg-green-100 border-green-400 text-green-700"
-                            : "border-green-200 text-green-600 hover:bg-green-50"
-                        }`}
-                        title="Attending"
+                        onClick={() => {
+                          setDeleteTarget({ id: event.id, title: event.title });
+                          setDeleteError(null);
+                        }}
+                        className="p-1.5 rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-600"
+                        title="Delete event"
                       >
-                        <CheckCircle className="h-3.5 w-3.5" /> Yes
+                        <Trash2 className="h-4 w-4" />
                       </button>
-                      <button
-                        onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "maybe" })}
-                        disabled={rsvpMutation.isPending}
-                        className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
-                          event.my_rsvp_status === "maybe"
-                            ? "bg-amber-100 border-amber-400 text-amber-700"
-                            : "border-amber-200 text-amber-600 hover:bg-amber-50"
-                        }`}
-                        title="Maybe"
-                      >
-                        <HelpCircle className="h-3.5 w-3.5" /> Maybe
-                      </button>
-                      <button
-                        onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "declined" })}
-                        disabled={rsvpMutation.isPending}
-                        className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
-                          event.my_rsvp_status === "declined"
-                            ? "bg-red-100 border-red-400 text-red-700"
-                            : "border-red-200 text-red-600 hover:bg-red-50"
-                        }`}
-                        title="Decline"
-                      >
-                        <XCircle className="h-3.5 w-3.5" /> No
-                      </button>
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
             );
@@ -295,6 +325,64 @@ export default function EventsListPage() {
             >
               Next <ChevronRight className="h-4 w-4" />
             </button>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteMutation.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Delete event?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Delete{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.title}</span>?
+                    This permanently removes the event and its RSVPs. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                disabled={deleteMutation.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Fixes #1476.

## Summary
Events could be cancelled but never deleted — cancelled events piled up in the dashboard's Upcoming Events list and in the list view with no way for HR to clean them up. The `DELETE /api/v1/events/:id` endpoint already existed on the server; this PR is pure frontend wiring.

## Changes

### `EventDashboardPage.tsx`
- Trash-icon button on each row of the Upcoming Events list, sitting with the existing View / Cancel links.
- Small UX fix: the **Cancel** link now hides once the event is already cancelled. Before, clicking it on a cancelled event called `/cancel` again and surfaced an error.

### `EventsListPage.tsx`
- HR-only trash-icon button at the end of each card's action column. Works on cancelled and completed events too — the RSVP buttons already hide on those statuses, the trash button still shows for HR so there's actually somewhere to remove them from.

### `EventDetailPage.tsx`
- HR-only **Delete** button in the header next to the Back link (previously there was no HR context on this page at all — added the `HR_ROLES` check).
- On success, navigates back to `/events` so the user isn't stuck on a page for an event that no longer exists.

### Shared
All three entry points open the same styled confirm modal pattern used for KB / forum / asset destructive actions — red trash icon, event title in bold, body copy `This permanently removes the event and its RSVPs. This cannot be undone.`, inline server-error surface, click-outside-to-close blocked while pending.

No backend changes. No shared-package changes.

## Test plan
- [x] Dashboard Upcoming Events row → trash → modal → Delete → row disappears from dashboard and from the list.
- [x] EventsListPage card (active event) → trash → modal → Delete → card disappears.
- [x] EventsListPage card (cancelled event) → trash is visible (unlike before), Delete works.
- [x] EventDetailPage → Delete button → modal → Delete → navigates back to `/events` and the event is gone from the list.
- [x] Non-HR users see no Delete buttons anywhere.
- [x] Dashboard Cancel link now hidden when an event is already cancelled.
- [x] Network failure during delete keeps the modal open and shows the server error message inline.