### PR TITLE
fix(positions): replace silent confirm() with styled modal + add list-row delete

### DIFF
--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, UserPlus, X, Briefcase, AlertTriangle, MapPin, Pencil, Trash2, Save } from "lucide-react";
+import { ArrowLeft, UserPlus, X, Briefcase, AlertTriangle, MapPin, Pencil, Trash2, Save, Loader2 } from "lucide-react";
 import { useDepartments } from "@/api/hooks";
 import api from "@/api/client";
 
@@ -81,12 +81,20 @@ export default function PositionDetailPage() {
     },
   });
 
+  const [showDelete, setShowDelete] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
   const deleteMutation = useMutation({
     mutationFn: () => api.delete(`/positions/${id}`).then((r) => r.data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["positions"] });
+      queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
+      setShowDelete(false);
+      setDeleteError(null);
       navigate("/positions/list");
     },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete position"),
   });
 
   if (isLoading) {
@@ -173,12 +181,10 @@ export default function PositionDetailPage() {
           </button>
           <button
             onClick={() => {
-              if (confirm("Are you sure you want to delete this position? This action cannot be undone.")) {
-                deleteMutation.mutate();
-              }
+              setShowDelete(true);
+              setDeleteError(null);
             }}
-            disabled={deleteMutation.isPending}
-            className="inline-flex items-center gap-2 px-4 py-2 border border-red-300 text-red-600 text-sm font-medium rounded-lg hover:bg-red-50 disabled:opacity-50"
+            className="inline-flex items-center gap-2 px-4 py-2 border border-red-300 text-red-600 text-sm font-medium rounded-lg hover:bg-red-50"
           >
             <Trash2 className="h-4 w-4" />
             Delete
@@ -506,6 +512,64 @@ export default function PositionDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Delete confirmation modal */}
+      {showDelete && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteMutation.isPending && setShowDelete(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Delete position?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Delete{" "}
+                    <span className="font-medium text-gray-700">{pos.title}</span>?
+                    Active assignments are ended and the position is closed. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setShowDelete(false)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate()}
+                disabled={deleteMutation.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/pages/positions/PositionListPage.tsx
+++ b/packages/client/src/pages/positions/PositionListPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
-import { Search, Plus, ChevronLeft, ChevronRight, AlertTriangle } from "lucide-react";
+import { Search, Plus, ChevronLeft, ChevronRight, AlertTriangle, Trash2, Loader2 } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments } from "@/api/hooks";
 
@@ -12,8 +12,22 @@ export default function PositionListPage() {
   const [departmentId, setDepartmentId] = useState<string>("");
   const [status, setStatus] = useState<string>("active");
   const [showCreate, setShowCreate] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<{ id: number; title: string } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: departments } = useDepartments();
+
+  const deleteMutation = useMutation({
+    mutationFn: (positionId: number) => api.delete(`/positions/${positionId}`).then((r) => r.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["positions"] });
+      queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
+      setDeleteTarget(null);
+      setDeleteError(null);
+    },
+    onError: (err: any) =>
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete position"),
+  });
 
   const { data, isLoading } = useQuery({
     queryKey: ["positions", { page, search, department_id: departmentId, status }],
@@ -272,16 +286,17 @@ export default function PositionListPage() {
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Headcount</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Status</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Critical</th>
+              <th className="text-right text-xs font-medium text-gray-500 uppercase px-6 py-3">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
             {isLoading ? (
               <tr>
-                <td colSpan={7} className="px-6 py-8 text-center text-gray-400">Loading...</td>
+                <td colSpan={8} className="px-6 py-8 text-center text-gray-400">Loading...</td>
               </tr>
             ) : positions.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-6 py-8 text-center text-gray-400">No positions found</td>
+                <td colSpan={8} className="px-6 py-8 text-center text-gray-400">No positions found</td>
               </tr>
             ) : (
               positions.map((pos: any) => (
@@ -325,6 +340,18 @@ export default function PositionListPage() {
                       <span className="text-gray-300">-</span>
                     )}
                   </td>
+                  <td className="px-6 py-4 text-right">
+                    <button
+                      onClick={() => {
+                        setDeleteTarget({ id: pos.id, title: pos.title });
+                        setDeleteError(null);
+                      }}
+                      className="p-1.5 rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-600"
+                      title="Delete position"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </td>
                 </tr>
               ))
             )}
@@ -355,6 +382,64 @@ export default function PositionListPage() {
           </div>
         )}
       </div>
+
+      {/* Delete confirmation modal */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !deleteMutation.isPending && setDeleteTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-5">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-red-50">
+                  <Trash2 className="h-5 w-5 text-red-600" />
+                </div>
+                <div className="flex-1">
+                  <h3 className="text-lg font-semibold text-gray-900">Delete position?</h3>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Delete{" "}
+                    <span className="font-medium text-gray-700">{deleteTarget.title}</span>?
+                    Active assignments are ended and the position is closed. This cannot be undone.
+                  </p>
+                </div>
+              </div>
+            </div>
+            {deleteError && (
+              <div className="mx-6 mb-4 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                {deleteError}
+              </div>
+            )}
+            <div className="flex justify-end gap-3 rounded-b-xl border-t border-gray-100 bg-gray-50 px-6 py-4">
+              <button
+                type="button"
+                onClick={() => setDeleteTarget(null)}
+                disabled={deleteMutation.isPending}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-white disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                disabled={deleteMutation.isPending}
+                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleteMutation.isPending ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" /> Deleting...
+                  </>
+                ) : (
+                  "Delete"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #1477.

## Root cause
Clicking **Delete** on a position opened a native `confirm()` popup — clicking OK appeared to do nothing. Two things hid the real behavior:

1. `deleteMutation` had no `onError` handler. If the server returned anything other than 2xx, the error was swallowed and the UI looked unchanged.
2. On success the user was `navigate`d to `/positions/list`, which defaults to `status=active`. The deleted (now `closed`) position disappears from the default view, so if the API *did* succeed, the only visible signal was "I'm back on the list page" — easily mistaken for "nothing happened".

So whether the delete worked or not, the user got the same silent result.

## Changes

### `PositionDetailPage.tsx`
- Replaced native `confirm()` with the same styled modal pattern used across the KB / forum / asset / event destructive flows: red trash icon, position title in bold, `Loader2` spinner on the Delete button while pending, click-outside-to-close blocked while pending.
- `deleteMutation` now has an `onError` that captures the server message and shows it inline in the modal. "Nothing happens" is no longer possible — if the API is failing, the message will surface.
- Added `queryKey: ["position-dashboard"]` to the invalidation list so the dashboard counts stay in sync.

### `PositionListPage.tsx`
Added an **Actions** column to the positions table with a trash-icon button on each row. Clicking it opens the same styled confirm modal. The user's screenshot showed them expecting delete to be available directly on the list — before this change they had to drill into the detail page first. The modal and mutation are local to this page so the list invalidates cleanly without any navigation dance.

### Not changed
Backend `deletePosition` already does the right thing (soft-delete to `status=closed`, ends active assignments). No server change needed — the bug was entirely in the client.

## Test plan
- [x] List row trash icon → modal with position title → Cancel closes; Delete closes on success and the row disappears (default filter hides closed).
- [x] Detail page Delete → modal → success navigates back to `/positions/list` with the position gone from the default view.
- [x] Forcing a failure (e.g. token expired mid-flow) keeps the modal open and shows the server error inline instead of silently doing nothing.
- [x] Status filter dropdown → Closed → shows the closed position (confirms soft-delete worked, position not lost).