### PR TITLE
fix(self-service): clear query cache on login/logout + compact dashboard

### DIFF
--- a/packages/client/src/features/feed/widgets/CompanyFeedWidget.tsx
+++ b/packages/client/src/features/feed/widgets/CompanyFeedWidget.tsx
@@ -1,34 +1,24 @@
-import { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
-import { MessageSquare, ArrowRight, Loader2 } from "lucide-react";
+import { MessageSquare, ArrowRight } from "lucide-react";
 import { useFeed } from "../api";
 import { PostComposer } from "../components/PostComposer";
 import { PostCard } from "../components/PostCard";
 
-// Dashboard feed card. Composer on top, every post that has been fetched, a
-// "View all" link out to /feed. Mirrors the FeedPage behaviour so the
-// dashboard is a self-contained feed reader: posts paginate in via infinite
-// scroll as the user reads down.
-export function CompanyFeedWidget() {
-  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useFeed();
-  const posts = data?.pages.flatMap((p) => p.items) ?? [];
+// Dashboard feed card — shows a short PREVIEW of the most recent posts
+// (first page, capped at PREVIEW_LIMIT) with a "Open full feed" link to
+// the dedicated /feed page. The widget deliberately does NOT paginate —
+// infinite scroll belongs on the full feed page so the dashboard stays a
+// glanceable summary instead of growing into an endless scroll.
+const PREVIEW_LIMIT = 3;
 
-  // IntersectionObserver-driven "load more" so paging is invisible.
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el) return;
-    const io = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      { rootMargin: "200px" }
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+export function CompanyFeedWidget() {
+  const { data, isLoading } = useFeed();
+  // Only use the first fetched page and cap the visible posts so that
+  // cached pages from /feed don't bloat the dashboard widget.
+  const firstPagePosts = data?.pages[0]?.items ?? [];
+  const posts = firstPagePosts.slice(0, PREVIEW_LIMIT);
+  const totalInFirstPage = firstPagePosts.length;
+  const hasMore = totalInFirstPage > PREVIEW_LIMIT || (data?.pages[0]?.next_cursor ?? null) !== null;
 
   return (
     <div className="space-y-4">
@@ -63,12 +53,13 @@ export function CompanyFeedWidget() {
         </div>
       )}
 
-      <div ref={sentinelRef} />
-
-      {isFetchingNextPage && (
-        <div className="flex items-center justify-center gap-2 py-2 text-xs text-gray-400">
-          <Loader2 className="h-3 w-3 animate-spin" /> Loading more...
-        </div>
+      {hasMore && posts.length > 0 && (
+        <Link
+          to="/feed"
+          className="flex items-center justify-center gap-1 rounded-xl border border-gray-200 bg-white py-2.5 text-xs font-medium text-brand-600 hover:bg-brand-50"
+        >
+          View more posts in the full feed <ArrowRight className="h-3 w-3" />
+        </Link>
       )}
     </div>
   );

--- a/packages/client/src/lib/auth-store.ts
+++ b/packages/client/src/lib/auth-store.ts
@@ -4,6 +4,7 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { queryClient } from "@/main";
 
 interface AuthUser {
   id: number;
@@ -41,21 +42,28 @@ export const useAuthStore = create<AuthState>()(
       setUser: (user) =>
         set({ user, isAuthenticated: true }),
 
-      login: (user, tokens) =>
+      login: (user, tokens) => {
+        // Purge any cached queries from a previous session on the same
+        // browser — otherwise the new user briefly sees the old user's
+        // attendance status, leave balances, notifications, etc.
+        queryClient.clear();
         set({
           user,
           accessToken: tokens.access_token,
           refreshToken: tokens.refresh_token,
           isAuthenticated: true,
-        }),
+        });
+      },
 
-      logout: () =>
+      logout: () => {
+        queryClient.clear();
         set({
           accessToken: null,
           refreshToken: null,
           user: null,
           isAuthenticated: false,
-        }),
+        });
+      },
     }),
     { name: "empcloud-auth" }
   )

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -54,7 +54,11 @@ window.addEventListener("unhandledrejection", (event) => {
 // Export for use in api/client.ts
 export { reportClientError };
 
-const queryClient = new QueryClient({
+// Exported so auth-store can clear cached queries on login/logout —
+// otherwise when user A logs out and user B logs in on the same browser,
+// user B sees user A's cached data (e.g. "my-attendance-today" survives
+// across sessions and leaks the previous user's check-in state).
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 1,

--- a/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
+++ b/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
@@ -9,13 +9,11 @@ import {
   ArrowRight,
   CheckCircle2,
   XCircle,
-  Sparkles,
   Pencil,
   LogIn,
   LogOut,
   Loader2,
 } from "lucide-react";
-import { AiBadge } from "@/components/AiBadge";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
 import { CompanyFeedWidget } from "@/features/feed/widgets/CompanyFeedWidget";
@@ -165,7 +163,7 @@ export default function SelfServiceDashboardPage() {
         <QuickLink to="/my-profile" icon={FileText} label="My Profile" />
         <QuickLink to={`/employees/${user?.id}`} icon={Pencil} label="Edit My Details" />
         <QuickLink to="/leave" icon={CalendarDays} label="Apply Leave" />
-        <QuickLink to="/attendance/my" icon={Clock} label="Mark Attendance" />
+        <QuickLink to="/attendance/my" icon={Clock} label="Attendance" />
         <QuickLink to="/helpdesk/my-tickets" icon={FileText} label="Request Update" />
       </div>
 
@@ -176,47 +174,99 @@ export default function SelfServiceDashboardPage() {
         media and replies; on smaller screens it collapses to a single column
         with the feed first.
       */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 items-start">
         {/* Left column — Company Feed */}
         <div className="lg:col-span-3">
           <CompanyFeedWidget />
         </div>
 
-        {/* Right column — stacked dashboard cards */}
-        <div className="lg:col-span-2 space-y-6">
+        {/* Right column — stacked dashboard cards. Sticky so short content
+            doesn't leave a big empty gap beside the feed when the user scrolls. */}
+        <div className="lg:col-span-2 space-y-6 lg:sticky lg:top-4 lg:self-start">
         {/* Attendance Today */}
         <div className="bg-white border border-gray-200 rounded-xl p-6">
           <div className="flex items-center gap-2 mb-4">
             <Clock className="h-5 w-5 text-brand-600" />
             <h2 className="text-lg font-semibold text-gray-900">My Attendance Today</h2>
           </div>
-          {todayAttendance ? (
-            <div className="flex items-center gap-3">
-              <CheckCircle2 className="h-5 w-5 text-green-500" />
-              <div>
-                <p className="text-sm font-medium text-gray-900">Checked in</p>
-                <p className="text-xs text-gray-500">
-                  {/* #1383 — The API returns check_in / check_out as ISO
-                      timestamps, not check_in_time / check_out_time strings */}
-                  {(() => {
-                    const ci = todayAttendance.check_in || todayAttendance.check_in_time;
-                    const co = todayAttendance.check_out || todayAttendance.check_out_time;
-                    const fmt = (v: string | null | undefined) =>
-                      v
-                        ? new Date(v).toLocaleTimeString("en-IN", {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                            hour12: true,
-                          })
-                        : null;
-                    const ciText = fmt(ci) || "N/A";
-                    const coText = fmt(co);
-                    return coText ? `${ciText} - ${coText}` : ciText;
-                  })()}
-                </p>
+          {todayAttendance ? (() => {
+            // #1383 — API returns check_in / check_out as ISO timestamps,
+            // not check_in_time / check_out_time strings
+            const ci = todayAttendance.check_in || todayAttendance.check_in_time;
+            const co = todayAttendance.check_out || todayAttendance.check_out_time;
+            const fmt = (v: string | null | undefined) =>
+              v
+                ? new Date(v).toLocaleTimeString("en-IN", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    hour12: true,
+                  })
+                : null;
+            const ciText = fmt(ci);
+            const coText = fmt(co);
+
+            // Total worked duration when both times exist
+            let workedText: string | null = null;
+            if (ci && co) {
+              const mins = Math.max(
+                0,
+                Math.round((new Date(co).getTime() - new Date(ci).getTime()) / 60000),
+              );
+              const h = Math.floor(mins / 60);
+              const m = mins % 60;
+              workedText = h > 0 ? `${h}h ${m}m` : `${m}m`;
+            }
+
+            return (
+              <div className="space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  {/* Check In */}
+                  <div className="rounded-lg border border-green-100 bg-green-50 p-3">
+                    <div className="flex items-center gap-1.5 text-xs font-medium text-green-700">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      Check In
+                    </div>
+                    <p className="mt-1 text-base font-semibold text-gray-900">
+                      {ciText || "—"}
+                    </p>
+                  </div>
+
+                  {/* Check Out */}
+                  <div
+                    className={`rounded-lg border p-3 ${
+                      co
+                        ? "border-indigo-100 bg-indigo-50"
+                        : "border-gray-200 bg-gray-50"
+                    }`}
+                  >
+                    <div
+                      className={`flex items-center gap-1.5 text-xs font-medium ${
+                        co ? "text-indigo-700" : "text-gray-500"
+                      }`}
+                    >
+                      <LogOut className="h-3.5 w-3.5" />
+                      Check Out
+                    </div>
+                    <p
+                      className={`mt-1 text-base font-semibold ${
+                        co ? "text-gray-900" : "text-gray-400"
+                      }`}
+                    >
+                      {coText || "Not yet"}
+                    </p>
+                  </div>
+                </div>
+
+                {/* Total worked */}
+                {workedText && (
+                  <div className="flex items-center justify-between rounded-lg bg-gray-50 px-3 py-2 text-xs">
+                    <span className="text-gray-500">Total worked today</span>
+                    <span className="font-semibold text-gray-900">{workedText}</span>
+                  </div>
+                )}
               </div>
-            </div>
-          ) : (
+            );
+          })() : (
             <div className="flex items-center gap-3">
               <XCircle className="h-5 w-5 text-gray-300" />
               <p className="text-sm text-gray-500">Not checked in yet today</p>
@@ -270,18 +320,18 @@ export default function SelfServiceDashboardPage() {
           )}
         </div>
 
-        {/* Recent Announcements */}
-        <div className="bg-white border border-gray-200 rounded-xl p-6">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center gap-2">
-              <Megaphone className="h-5 w-5 text-brand-600" />
-              <h2 className="text-lg font-semibold text-gray-900">Announcements</h2>
+        {/* Recent Announcements — only render when there are items */}
+        {announcementList.length > 0 && (
+          <div className="bg-white border border-gray-200 rounded-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <Megaphone className="h-5 w-5 text-brand-600" />
+                <h2 className="text-lg font-semibold text-gray-900">Announcements</h2>
+              </div>
+              <Link to="/announcements" className="text-xs text-brand-600 hover:underline">
+                View all
+              </Link>
             </div>
-            <Link to="/announcements" className="text-xs text-brand-600 hover:underline">
-              View all
-            </Link>
-          </div>
-          {announcementList.length > 0 ? (
             <ul className="space-y-3">
               {announcementList.slice(0, 3).map((a: any) => (
                 <li key={a.id}>
@@ -292,23 +342,21 @@ export default function SelfServiceDashboardPage() {
                 </li>
               ))}
             </ul>
-          ) : (
-            <p className="text-sm text-gray-400">No recent announcements</p>
-          )}
-        </div>
-
-        {/* Policies to Acknowledge */}
-        <div className="bg-white border border-gray-200 rounded-xl p-6">
-          <div className="flex items-center justify-between mb-4">
-            <div className="flex items-center gap-2">
-              <BookOpen className="h-5 w-5 text-brand-600" />
-              <h2 className="text-lg font-semibold text-gray-900">Policies</h2>
-            </div>
-            <Link to="/policies" className="text-xs text-brand-600 hover:underline">
-              View all
-            </Link>
           </div>
-          {policyList.length > 0 ? (
+        )}
+
+        {/* Policies to Acknowledge — only render when there are items */}
+        {policyList.length > 0 && (
+          <div className="bg-white border border-gray-200 rounded-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <BookOpen className="h-5 w-5 text-brand-600" />
+                <h2 className="text-lg font-semibold text-gray-900">Policies</h2>
+              </div>
+              <Link to="/policies" className="text-xs text-brand-600 hover:underline">
+                View all
+              </Link>
+            </div>
             <ul className="space-y-2">
               {policyList.slice(0, 5).map((p: any) => (
                 <li
@@ -331,33 +379,8 @@ export default function SelfServiceDashboardPage() {
                 </li>
               ))}
             </ul>
-          ) : (
-            <p className="text-sm text-gray-400">No policies to review</p>
-          )}
-        </div>
-
-        {/* AI Insights */}
-        <div className="bg-gradient-to-br from-purple-50 to-indigo-50 border border-purple-200 rounded-xl p-6">
-          <div className="flex items-center gap-2 mb-4">
-            <Sparkles className="h-5 w-5 text-purple-600" />
-            <h2 className="text-lg font-semibold text-gray-900">AI Insights</h2>
-            <AiBadge label="Beta" />
           </div>
-          <ul className="space-y-3 text-sm text-gray-700">
-            <li className="flex items-start gap-2">
-              <span className="text-purple-500 mt-0.5">&#128161;</span>
-              <span>You have <strong>15 days</strong> of earned leave remaining. Consider planning time off before Q2 ends.</span>
-            </li>
-            <li className="flex items-start gap-2">
-              <span className="text-purple-500 mt-0.5">&#128202;</span>
-              <span>Your attendance this month: <strong>95%</strong> &mdash; above team average of 91%.</span>
-            </li>
-            <li className="flex items-start gap-2">
-              <span className="text-purple-500 mt-0.5">&#128203;</span>
-              <span>2 company policies updated recently. <Link to="/policies" className="text-purple-600 underline">Review them</Link>.</span>
-            </li>
-          </ul>
-        </div>
+        )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes a cross-user data leak in the self-service dashboard plus several UI polish items that were making the page feel cluttered and noisy.

### Critical bug fix: cached attendance data leaking across users

When user A checked in and then logged out, their `/attendance/me/today` response stayed in the React Query cache (which is in-memory, not tied to auth). When user B logged in on the same browser, the key `["my-attendance-today"]` still held user A's data, so user B's dashboard incorrectly showed **"Attendance complete for today"** with user A's timestamps.

Same pattern affected `leave-balances`, `my-documents-pending`, `recent-announcements`, `pending-policies`, etc.

**Fix:** `queryClient.clear()` is now called from both `login` and `logout` in `auth-store.ts`, so cached queries from a previous session never leak across users on the same browser. Verified by logging in as Priya after Ananya — Priya now correctly sees the Check In button instead of the cached "complete" state.

### UI polish on `/self-service`

**My Attendance Today card**
- Previously showed an ambiguous time range like `04:15 pm - 04:15 pm`
- Now shows two labeled cards side-by-side (green Check In, indigo Check Out) and a footer with **Total worked today** (computed h/m)
- Check Out card grays out and reads "Not yet" when not checked out

**Right column cleanup**
- Announcements, Policies cards now only render when there's actual data — no more empty "No recent announcements" cards padding the column
- Removed the hardcoded AI Insights card (fake static content)
- Right column is `sticky top-4` on lg+ so it stays visible as the user scrolls the feed, eliminating the big empty gap that appeared when the feed was taller than the sidebar cards

**Feed widget**
- Dashboard `CompanyFeedWidget` now shows a **3-post preview** instead of running full infinite scroll. The widget shared the `["feed"]` cache with the `/feed` page, so scrolling through the full feed was bloating the dashboard too. Preview + "View more posts in the full feed" link keeps the dashboard glanceable.

**Quick links**
- Renamed `Mark Attendance` to just `Attendance` — the check-in button already lives in the page header so this link just opens the attendance history page.

## Files changed
- `packages/client/src/main.tsx` — export `queryClient`
- `packages/client/src/lib/auth-store.ts` — `queryClient.clear()` on login/logout
- `packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx` — attendance card redesign, conditional sidebar cards, sticky right column, label rename
- `packages/client/src/features/feed/widgets/CompanyFeedWidget.tsx` — preview-only mode (3 posts), no inline infinite scroll

## Test plan
- [x] Log in as user A, check in, log out. Log in as user B on same browser — user B sees Check In button, not stale check-in state
- [x] Attendance Today card clearly labels Check In vs Check Out
- [x] Self-service page no longer has a long empty scroll area after content ends
- [x] Feed widget on dashboard shows 3 posts with "View more" link; scrolling through /feed doesn't change the dashboard widget's length
- [x] Announcements/Policies cards hidden when empty