### PR TITLE
fix(assets): show per-page row count in pagination footer

### DIFF
--- a/packages/client/src/pages/assets/AssetListPage.tsx
+++ b/packages/client/src/pages/assets/AssetListPage.tsx
@@ -392,8 +392,11 @@ export default function AssetListPage() {
           {/* Pagination */}
           {meta && meta.total_pages > 1 && (
             <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200">
+              {/* #1534 — Show the per-page count alongside the total. Previously
+                  only "Page N of M (T total)" was rendered, so admins couldn't
+                  tell how many rows were in view. */}
               <p className="text-sm text-gray-500">
-                Page {meta.page} of {meta.total_pages} ({meta.total} total)
+                Showing {assets.length} of {meta.total} assets &middot; Page {meta.page} of {meta.total_pages}
               </p>
               <div className="flex gap-2">
                 <button


### PR DESCRIPTION
Closes #1534

## Summary

Previously the Assets list pagination footer only rendered `Page N of M (T total)` — so admins couldn't tell how many rows the current page was displaying. Updated to `Showing X of T assets · Page N of M` where X is the actual row count in view.

## Test plan

- [ ] Workplace → Assets → verify pagination footer shows "Showing 20 of 45 assets · Page 1 of 3" (or whatever your data is).
- [ ] Page through — "Showing X" updates to reflect partial last page (e.g. "Showing 5 of 45 assets · Page 3 of 3").
- [ ] Empty filter result — footer hidden (existing `total_pages > 1` check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)