### PR TITLE
fix(surveys): show per-page row count in pagination footer

### DIFF
--- a/packages/client/src/pages/surveys/SurveyListPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyListPage.tsx
@@ -246,8 +246,10 @@ export default function SurveyListPage() {
       {/* Pagination */}
       {meta && meta.total_pages > 1 && (
         <div className="flex items-center justify-between mt-6">
+          {/* #1533 — Show the per-page count alongside the total so admins can
+              tell at a glance how many surveys are in view, not just the total. */}
           <p className="text-sm text-gray-500">
-            Page {meta.page} of {meta.total_pages} ({meta.total} total)
+            Showing {surveys.length} of {meta.total} surveys &middot; Page {meta.page} of {meta.total_pages}
           </p>
           <div className="flex gap-2">
             <button


### PR DESCRIPTION
Closes #1533

## Summary

Mirrors the fix in #1562 (assets). The Surveys list pagination footer previously only showed `Page N of M (T total)`. Updated to `Showing X of T surveys · Page N of M`.

## Test plan

- [ ] Workplace → All Surveys → pagination footer shows "Showing 20 of 45 surveys · Page 1 of 3".
- [ ] Page to last (partial) page — "Showing X" updates to the partial count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)