### PR TITLE
fix(leave): align delete-policy confirm label with actual action

### DIFF
--- a/packages/client/src/pages/leave/LeaveTypesPage.tsx
+++ b/packages/client/src/pages/leave/LeaveTypesPage.tsx
@@ -573,7 +573,7 @@ export default function LeaveTypesPage() {
                           <Pencil className="h-3.5 w-3.5 text-gray-500" />
                         </button>
                         <button
-                          onClick={() => { if (confirm("Deactivate this policy?")) deletePolicy.mutate(p.id); }}
+                          onClick={() => { if (confirm("Delete this leave policy? This action cannot be undone.")) deletePolicy.mutate(p.id); }}
                           className="p-1 hover:bg-gray-100 rounded"
                         >
                           <Trash2 className="h-3.5 w-3.5 text-red-500" />


### PR DESCRIPTION
Closes #1536

## Summary

The trash-icon button on the Leave Policies table showed a `"Deactivate this policy?"` confirmation, but the handler calls `DELETE /leave/policies/:id` — an actual destructive delete. Reporter correctly flagged this as misleading.

Updated to `"Delete this leave policy? This action cannot be undone."`

## Test plan

- [ ] Leave → Leave Settings → Leave Policies → click trash icon on any row.
- [ ] Native confirm dialog should now say "Delete this leave policy? This action cannot be undone."
- [ ] Cancel — no API call made.
- [ ] OK — policy is deleted (row removed from list).

## Follow-up note

Worth revisiting: the server may only do a soft-delete/deactivate rather than a hard delete. If so, the confirm wording should swing the other way — "Deactivate this policy?" — and the handler should stay. I've matched the label to what the current handler actually does (`api.delete(...)`), which is the safer framing for now. If the API returns 200 but the row comes back after reload, that's the signal to flip both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)