### PR TITLE
fix(assets): always-visible delete button on history entries

### DIFF
--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -553,13 +553,19 @@ export default function AssetDetailPage() {
                         </p>
                       </div>
                       {isHR && (
+                        // #1535 — Button was previously opacity-0 group-hover:opacity-100,
+                        // making it invisible until hover and completely unreachable on
+                        // touch devices. Reporter assumed there was no way to delete
+                        // history entries. Now always visible for HR admins, with a
+                        // subtle default color that emphasizes on hover.
                         <button
                           onClick={() => {
                             setHistoryDeleteId(entry.id);
                             setHistoryDeleteError(null);
                           }}
                           title="Delete history entry"
-                          className="p-1 rounded hover:bg-red-50 text-gray-300 hover:text-red-600 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+                          aria-label="Delete history entry"
+                          className="p-1 rounded text-gray-400 hover:bg-red-50 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors"
                         >
                           <Trash2 className="h-3.5 w-3.5" />
                         </button>


### PR DESCRIPTION
Closes #1535

## Summary

The reporter said "No button to delete history of assets". There IS a per-entry delete button on the asset detail history timeline, but it was rendered with `opacity-0 group-hover:opacity-100` — invisible until the user hovered the entry, and completely unreachable on touch devices.

Made the button always visible for HR admins (`hr_admin` / `org_admin` / `super_admin`), with a subtle grey default that emphasizes to red on hover. Also added `aria-label` for screen-reader discoverability.

The mutation (`DELETE /assets/:id/history/:entryId`) and the existing confirmation modal are unchanged — only the button's visibility.

## Test plan

- [ ] Assets → any asset detail page → History timeline.
- [ ] As HR admin: trash icon is visible on every history entry without needing hover.
- [ ] Click trash → confirmation modal opens → confirm → entry removed.
- [ ] As non-HR employee: no trash icon (unchanged).
- [ ] Tab through the timeline — focus ring shows on the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)