### PR TITLE
fix(assets): dashboard top cards deep-link to filtered list

### DIFF
--- a/packages/client/src/pages/assets/AssetDashboardPage.tsx
+++ b/packages/client/src/pages/assets/AssetDashboardPage.tsx
@@ -45,12 +45,17 @@ export default function AssetDashboardPage() {
 
   if (!stats) return null;
 
+  // #1531 — Each card deep-links into /assets with the matching status filter
+  // preselected. AssetListPage reads `?status=<v>` from the URL on mount.
+  // "Lost / Damaged" is a combined card but the list currently only filters on
+  // a single status — link to lost as the default; user can swap to damaged
+  // from the dropdown. A "multi-status" filter is a follow-up.
   const statCards = [
     { label: "Total Assets", value: stats.total, icon: Package, color: "text-gray-900 bg-gray-50", to: "/assets" },
-    { label: "Available", value: stats.available, icon: Box, color: "text-green-700 bg-green-50", to: "/assets" },
-    { label: "Assigned", value: stats.assigned, icon: UserCheck, color: "text-blue-700 bg-blue-50", to: "/assets" },
-    { label: "In Repair", value: stats.in_repair, icon: Wrench, color: "text-yellow-700 bg-yellow-50", to: "/assets" },
-    { label: "Lost / Damaged", value: (stats.lost || 0) + (stats.damaged || 0), icon: AlertTriangle, color: "text-red-700 bg-red-50", to: "/assets" },
+    { label: "Available", value: stats.available, icon: Box, color: "text-green-700 bg-green-50", to: "/assets?status=available" },
+    { label: "Assigned", value: stats.assigned, icon: UserCheck, color: "text-blue-700 bg-blue-50", to: "/assets?status=assigned" },
+    { label: "In Repair", value: stats.in_repair, icon: Wrench, color: "text-yellow-700 bg-yellow-50", to: "/assets?status=in_repair" },
+    { label: "Lost / Damaged", value: (stats.lost || 0) + (stats.damaged || 0), icon: AlertTriangle, color: "text-red-700 bg-red-50", to: "/assets?status=lost" },
   ];
 
   return (

--- a/packages/client/src/pages/assets/AssetListPage.tsx
+++ b/packages/client/src/pages/assets/AssetListPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
 import AssetBulkUploadModal from "@/components/AssetBulkUploadModal";
@@ -37,8 +37,17 @@ const STATUSES = ["available", "assigned", "in_repair", "retired", "lost", "dama
 const CONDITIONS = ["new", "good", "fair", "poor"];
 
 export default function AssetListPage() {
+  // #1531 — Seed `statusFilter` from ?status= so deep-links from the Asset
+  // Dashboard top cards land on a pre-filtered list instead of showing every
+  // asset. Whitelisted against known values so a bad URL doesn't wedge the
+  // filter UI into an unlisted state.
+  const [searchParams] = useSearchParams();
+  const initialStatus = (() => {
+    const raw = searchParams.get("status") || "";
+    return ["available", "assigned", "in_repair", "retired", "lost", "damaged"].includes(raw) ? raw : "";
+  })();
   const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState(initialStatus);
   const [categoryFilter, setCategoryFilter] = useState("");
   const [search, setSearch] = useState("");
   const [showForm, setShowForm] = useState(false);


### PR DESCRIPTION
Closes #1531

## Summary

Asset Dashboard top cards all linked to \`/assets\` unfiltered, so clicking "Assigned" showed every asset. Updated each card to deep-link with a matching \`?status=\` param, and made \`AssetListPage\` read that param on mount.

## Changes

- **AssetDashboardPage** — card targets now include \`?status=available\`, \`?status=assigned\`, \`?status=in_repair\`, \`?status=lost\`. Total Assets stays unfiltered.
- **AssetListPage** — imports \`useSearchParams\`, seeds \`statusFilter\` from \`?status=\` with a whitelist check so bogus URLs don't break the dropdown.

## Known limitation

The "Lost / Damaged" card is a combined count but the list currently supports single-status filtering only. Linked to \`?status=lost\` as a reasonable default; users can flip to damaged via the existing dropdown. A proper multi-status filter would be a separate (backend + UI) change.

## Test plan

- [ ] Workplace → Asset Dashboard → click Available card → lands on \`/assets?status=available\` with the dropdown showing "Available".
- [ ] Same for Assigned, In Repair, Lost/Damaged.
- [ ] Total Assets card → unfiltered \`/assets\`.
- [ ] Manually visit \`/assets?status=junk\` — dropdown falls back to "All Statuses" (no JS error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)