### PR TITLE
fix(surveys): Active Surveys card deep-links to filtered list

### DIFF
--- a/packages/client/src/pages/surveys/SurveyDashboardPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyDashboardPage.tsx
@@ -98,8 +98,12 @@ export default function SurveyDashboardPage() {
       </div>
 
       {/* Stats Grid */}
+      {/* #1532 — Active Surveys deep-links to the list filtered to status=active.
+          Total Responses / Avg Response Rate / Total Surveys don't map to any
+          single list filter (responses & response-rate aren't filterable fields;
+          Total = unfiltered = correct already), so they stay on /surveys/list. */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <StatCard label="Active Surveys" value={d.active_count ?? 0} icon={Clock} color="bg-green-100 text-green-600" to="/surveys/list" />
+        <StatCard label="Active Surveys" value={d.active_count ?? 0} icon={Clock} color="bg-green-100 text-green-600" to="/surveys/list?status=active" />
         <StatCard label="Total Responses" value={d.total_responses ?? 0} icon={Users} color="bg-blue-100 text-blue-600" to="/surveys/list" />
         <StatCard label="Avg Response Rate" value={`${d.avg_response_rate ?? 0}%`} icon={TrendingUp} color="bg-purple-100 text-purple-600" to="/surveys/list" />
         <StatCard label="Total Surveys" value={d.total_count ?? 0} icon={BarChart3} color="bg-gray-100 text-gray-600" to="/surveys/list" />

--- a/packages/client/src/pages/surveys/SurveyListPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyListPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "@/api/client";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { Plus, Trash2, Play, Square, Eye, Edit } from "lucide-react";
 
 const STATUS_BADGE: Record<string, string> = {
@@ -21,8 +21,16 @@ const TYPE_BADGE: Record<string, string> = {
 };
 
 export default function SurveyListPage() {
+  // #1532 — Seed statusFilter from ?status= so deep-links from the Survey
+  // Dashboard top cards land on the matching filter instead of the full list.
+  // Whitelisted against known values.
+  const [searchParams] = useSearchParams();
+  const initialStatus = (() => {
+    const raw = searchParams.get("status") || "";
+    return ["draft", "active", "closed", "archived"].includes(raw) ? raw : "";
+  })();
   const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState(initialStatus);
   const [typeFilter, setTypeFilter] = useState("");
   const qc = useQueryClient();
 


### PR DESCRIPTION
Closes #1532

## Summary

The Survey Dashboard "Active Surveys" card linked to \`/surveys/list\` without any filter — clicking it showed every survey. Updated to deep-link with \`?status=active\` and made \`SurveyListPage\` read the param on mount.

## Scope caveat

Only "Active Surveys" has a logical single-status filter. The other three cards intentionally stay on unfiltered \`/surveys/list\`:
- **Total Responses** — responses aren't a filterable field on the list.
- **Avg Response Rate** — not a filter.
- **Total Surveys** — already "all surveys"; filtering would be wrong.

## Test plan

- [ ] Workplace → Survey Dashboard → click "Active Surveys" card → lands on \`/surveys/list?status=active\` with the dropdown preselected.
- [ ] Total Responses / Avg Response Rate / Total Surveys cards → unfiltered \`/surveys/list\`.
- [ ] Visit \`/surveys/list?status=junk\` → dropdown stays on "All Statuses" (no JS error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)