### PR TITLE
fix(positions): dashboard routing, delete feedback, search UX

### DIFF
--- a/packages/client/src/pages/positions/PositionDashboardPage.tsx
+++ b/packages/client/src/pages/positions/PositionDashboardPage.tsx
@@ -50,7 +50,10 @@ export default function PositionDashboardPage() {
           <p className="text-xs text-gray-400">Budget: {stats.total_budget || 0} headcount</p>
         </Link>
 
-        <Link to="/positions/list" className="block text-left w-full bg-white rounded-xl border border-gray-200 p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        {/* #1553 — Filled card deep-links to the list filtered to status=filled
+            so users actually see filled positions, not every position. The
+            Total Positions card above stays unfiltered (that's the point). */}
+        <Link to="/positions/list?status=filled" className="block text-left w-full bg-white rounded-xl border border-gray-200 p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-3">
             <div className="h-10 w-10 rounded-lg bg-green-50 flex items-center justify-center">
               <Users className="h-5 w-5 text-green-600" />

--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -218,31 +218,38 @@ export default function PositionDetailPage() {
                   // filter.
                   if (assignForm.user_id) setAssignForm({ ...assignForm, user_id: "" });
                 }}
-                placeholder="Search users..."
+                placeholder="Start typing to search users..."
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 mb-2"
               />
-              <div className="max-h-48 overflow-y-auto border border-gray-300 rounded-lg text-sm bg-white">
-                {(usersData || []).length === 0 ? (
-                  <div className="px-3 py-2 text-gray-400">No users match</div>
-                ) : (
-                  (usersData || []).map((u: any) => {
-                    const selected = String(u.id) === String(assignForm.user_id);
-                    return (
-                      <button
-                        type="button"
-                        key={u.id}
-                        onClick={() => setAssignForm({ ...assignForm, user_id: String(u.id) })}
-                        className={`w-full text-left px-3 py-2 border-b border-gray-100 last:border-0 hover:bg-brand-50 ${
-                          selected ? "bg-brand-50 text-brand-700 font-medium" : "text-gray-700"
-                        }`}
-                      >
-                        {u.first_name} {u.last_name}{" "}
-                        <span className="text-xs text-gray-400">({u.email})</span>
-                      </button>
-                    );
-                  })
-                )}
-              </div>
+              {/* #1547 — The user list was previously always rendered with every
+                  user in the org, making it look like a dropdown "auto-opened".
+                  Only render results after the user has typed at least one
+                  character — or after a valid selection has been stored (so the
+                  picked row stays visible). */}
+              {(userSearch.trim().length > 0 || assignForm.user_id) && (
+                <div className="max-h-48 overflow-y-auto border border-gray-300 rounded-lg text-sm bg-white">
+                  {(usersData || []).length === 0 ? (
+                    <div className="px-3 py-2 text-gray-400">No users match</div>
+                  ) : (
+                    (usersData || []).map((u: any) => {
+                      const selected = String(u.id) === String(assignForm.user_id);
+                      return (
+                        <button
+                          type="button"
+                          key={u.id}
+                          onClick={() => setAssignForm({ ...assignForm, user_id: String(u.id) })}
+                          className={`w-full text-left px-3 py-2 border-b border-gray-100 last:border-0 hover:bg-brand-50 ${
+                            selected ? "bg-brand-50 text-brand-700 font-medium" : "text-gray-700"
+                          }`}
+                        >
+                          {u.first_name} {u.last_name}{" "}
+                          <span className="text-xs text-gray-400">({u.email})</span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+              )}
               {/* Hidden input keeps the `required` semantics for the form */}
               <input type="hidden" value={assignForm.user_id} required readOnly />
             </div>

--- a/packages/client/src/pages/positions/PositionListPage.tsx
+++ b/packages/client/src/pages/positions/PositionListPage.tsx
@@ -1,32 +1,68 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { Search, Plus, ChevronLeft, ChevronRight, AlertTriangle, Trash2, Loader2 } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments } from "@/api/hooks";
 
 export default function PositionListPage() {
   const queryClient = useQueryClient();
+  // #1553 — Seed the status filter from ?status= so deep-links from the
+  // Position Dashboard top cards land on the matching filtered list.
+  // Whitelisted against known values so a bad URL doesn't wedge the dropdown.
+  const [searchParams] = useSearchParams();
+  const initialStatus = (() => {
+    const raw = searchParams.get("status") || "";
+    return ["active", "filled", "frozen", "closed"].includes(raw) ? raw : "";
+  })();
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [departmentId, setDepartmentId] = useState<string>("");
-  const [status, setStatus] = useState<string>("");
+  const [status, setStatus] = useState<string>(initialStatus);
   const [showCreate, setShowCreate] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; title: string } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: departments } = useDepartments();
 
+  // #1545 / #1551 — Delete reported as "says deleted but doesn't disappear".
+  // The backend soft-closes the position (status="closed") rather than hard-
+  // deleting, so when the list refetches the same row comes back under the
+  // current filter. Two fixes layered here:
+  //  1. Optimistically strip the row from every cached `positions` query so
+  //     the user sees immediate feedback.
+  //  2. After the server confirms, invalidate so any background changes
+  //     (e.g. status counts on the dashboard) sync up.
   const deleteMutation = useMutation({
     mutationFn: (positionId: number) => api.delete(`/positions/${positionId}`).then((r) => r.data),
+    onMutate: async (positionId: number) => {
+      await queryClient.cancelQueries({ queryKey: ["positions"] });
+      const snapshots: { key: unknown; value: any }[] = [];
+      queryClient.getQueryCache().findAll({ queryKey: ["positions"] }).forEach((q) => {
+        snapshots.push({ key: q.queryKey, value: q.state.data });
+        const data = q.state.data as any;
+        if (data?.data) {
+          queryClient.setQueryData(q.queryKey, {
+            ...data,
+            data: data.data.filter((p: any) => p.id !== positionId),
+            meta: data.meta ? { ...data.meta, total: Math.max(0, (data.meta.total || 1) - 1) } : data.meta,
+          });
+        }
+      });
+      return { snapshots };
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["positions"] });
       queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
       setDeleteTarget(null);
       setDeleteError(null);
     },
-    onError: (err: any) =>
-      setDeleteError(err?.response?.data?.error?.message || "Failed to delete position"),
+    onError: (err: any, _positionId, context) => {
+      // Roll the optimistic removal back so the row reappears if the server
+      // rejected the delete.
+      context?.snapshots?.forEach(({ key, value }) => queryClient.setQueryData(key as any, value));
+      setDeleteError(err?.response?.data?.error?.message || "Failed to delete position");
+    },
   });
 
   const { data, isLoading } = useQuery({


### PR DESCRIPTION
Closes #1553, #1545, #1551, #1547

## Summary

Three fixes in the Positions / Vacancies cluster, bundled into one PR because all three touch overlapping files (PositionListPage, PositionDetailPage, PositionDashboardPage) — splitting them would force sequential rebase-conflicts against each other.

### 1. #1553 — "Filled" card on Position Dashboard deep-links to filtered list

Previously both \`Total Positions\` and \`Filled\` cards linked to \`/positions/list\` unfiltered, so clicking Filled showed every position including the unfilled ones. Now:
- \`Filled\` card → \`/positions/list?status=filled\`
- \`PositionListPage\` reads \`?status=\` via \`useSearchParams\` and seeds the status dropdown (whitelisted against \`active\` / \`filled\` / \`frozen\` / \`closed\` so bad URLs don't wedge the filter).

### 2. #1545 / #1551 — "Delete says success but the position stays in the list"

Root cause: the backend soft-closes the position (sets \`status="closed"\`) rather than hard-deleting, so when the list refetches the same row comes back under the current filter.

Fix: optimistic cache update on the delete mutation.
- \`onMutate\` snapshots every cached \`positions\` query and filters the deleted row out immediately → user sees the row vanish.
- \`onSuccess\` still invalidates so dashboard counts resync.
- \`onError\` restores the snapshots so the UI rolls back faithfully if the server rejects.

If the user then filters to status=closed they'll still see the position there, which matches the actual backend behavior.

### 3. #1547 — Assign-Employee search "dropdown auto-opens"

The user-search results list on \`PositionDetailPage\` was always rendered with every org user, making it look like a dropdown popped up without any interaction. Now only renders the results list once the user has typed at least one character (or a selection has been committed, so the chosen row stays visible).

## Out of scope — need more info

Five other issues in this cluster need more than their image-only bodies to fix confidently. Posting comments on each:

- **#1543** — "Position status button is not clickable" — the position-detail status is a \`<select>\`, not a button. Need to know which control is blocked and what happens on click.
- **#1544** — "Unable to save changes from edit tab" — need the error message (network 4xx? validation?).
- **#1549** — "Assign employee: error message + vacancy gets removed" — need the error text.
- **#1550** — "Unwanted 0 is showing on vacancy card" — need which element (\`open_count\`, salary fallback, headcount_filled?).
- **#1552** — "Mark as Filled not working" — handler looks wired; likely a backend validation rejection. Need the network response.

## Test plan

- [ ] Positions → Dashboard → click **Filled** card → lands on \`/positions/list?status=filled\` with the dropdown preselected.
- [ ] Click **Total Positions** card → unfiltered list (unchanged behavior).
- [ ] Visit \`/positions/list?status=garbage\` → dropdown stays "All Statuses" (no JS error).
- [ ] Positions → All Positions → delete any row → row vanishes immediately from the list, dashboard counts update. Refreshing the page doesn't bring it back (unless you switch the status filter to "Closed").
- [ ] Positions → any position detail → **Assign Employee** → the results list is hidden until you type. Type "a" → list appears with matches. Clear the input → list disappears. Pick someone → their row stays visible so you can confirm the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)