### PR TITLE
fix(module-access): make seat tiles clickable to filter employees

### DIFF
--- a/packages/client/src/pages/modules/ModuleAccessPage.tsx
+++ b/packages/client/src/pages/modules/ModuleAccessPage.tsx
@@ -195,16 +195,37 @@ export default function ModuleAccessPage() {
             const used = sub?.used_seats || 0;
             const total = sub?.total_seats || 0;
             const pct = total > 0 ? Math.min(100, (used / total) * 100) : 0;
+            const isFilteredOnThis = filterModule === `enabled:${m.id}`;
             return (
-              <div key={m.id} className="bg-white rounded-xl border border-gray-200 p-3">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className={`w-2 h-2 rounded-full ${used > 0 ? "bg-green-500" : "bg-gray-300"}`} />
-                  <span className="text-xs font-medium text-gray-700 truncate">{m.name.replace(/^EMP\s+/i, "")}</span>
-                </div>
-                <div className="text-lg font-bold text-gray-900">{used}<span className="text-sm font-normal text-gray-400">/{total}</span></div>
-                <div className="w-full bg-gray-100 rounded-full h-1.5 mt-1">
-                  <div className="bg-brand-500 h-1.5 rounded-full transition-all" style={{ width: `${pct}%` }} />
-                </div>
+              <div
+                key={m.id}
+                className={`bg-white rounded-xl border p-3 ${
+                  isFilteredOnThis ? "border-brand-400 ring-1 ring-brand-200" : "border-gray-200"
+                }`}
+              >
+                {/* #1537 — Card header is a button that filters the employee
+                    table below to only show people enabled for this module.
+                    Clicking again clears the filter (toggle). The Enable/
+                    Disable All buttons below are separate so they don't
+                    trigger the filter. */}
+                <button
+                  type="button"
+                  onClick={() => setFilterModule(isFilteredOnThis ? "all" : `enabled:${m.id}`)}
+                  aria-label={isFilteredOnThis
+                    ? `Clear filter for ${m.name}`
+                    : `Show employees enabled for ${m.name}`}
+                  aria-pressed={isFilteredOnThis}
+                  className="w-full text-left rounded-md -m-1 p-1 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 transition-colors"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className={`w-2 h-2 rounded-full ${used > 0 ? "bg-green-500" : "bg-gray-300"}`} />
+                    <span className="text-xs font-medium text-gray-700 truncate">{m.name.replace(/^EMP\s+/i, "")}</span>
+                  </div>
+                  <div className="text-lg font-bold text-gray-900">{used}<span className="text-sm font-normal text-gray-400">/{total}</span></div>
+                  <div className="w-full bg-gray-100 rounded-full h-1.5 mt-1">
+                    <div className="bg-brand-500 h-1.5 rounded-full transition-all" style={{ width: `${pct}%` }} />
+                  </div>
+                </button>
                 <div className="flex gap-1 mt-3">
                   <button
                     onClick={() => setConfirmAllAction({ moduleId: m.id, moduleName: m.name, action: "enable" })}


### PR DESCRIPTION
Closes #1537

## Summary

The module seat tiles at the top of \`/modules/access\` were plain \`<div>\`s — reporter couldn't click them to drill into the list of employees enrolled in a given module. The employee table below already supports the \`enabled:<moduleId>\` filter via the dropdown, so wiring the tile click to toggle that filter is the minimal change.

## Behavior

- Click a tile's header area → employee table filters to people enabled for that module.
- Active tile gets a brand ring + border so you can tell which one is the scope.
- Click the same tile again → filter clears back to All Employees.
- The Enable All / Disable All buttons inside the tile are unchanged — they don't trigger the filter (they're siblings, not descendants, of the header button).
- Keyboard accessible: \`aria-pressed\`, \`aria-label\`, focus ring.

## Test plan

- [ ] Modules → Module Access → click any tile's header area → employee table shrinks to only employees with that module enabled; dropdown shows the same filter value.
- [ ] Click the tile again → filter clears.
- [ ] Click a different tile → filter switches.
- [ ] Click "Enable All" / "Disable All" inside a tile — opens the confirm modal, doesn't flip the filter.
- [ ] Tab through tiles — focus ring visible, Enter toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)