### PR TITLE
fix(surveys): clarify that Start/End fields capture both date and time

### DIFF
--- a/packages/client/src/pages/surveys/SurveyBuilderPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyBuilderPage.tsx
@@ -292,18 +292,25 @@ export default function SurveyBuilderPage() {
               </select>
             </div>
 
+            {/* #1541 — These inputs are type="datetime-local", so the browser's
+                native picker opens a date calendar AND a time selector side by
+                side. Previously the labels said "Start Date" / "End Date" only,
+                which made users think the time-picker popover was a bug. The
+                labels now say "Start Date & Time" and there's a helper line
+                under each input making the expectation explicit. */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Start Date &amp; Time</label>
               <input
                 type="datetime-local"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
               />
+              <p className="text-xs text-gray-400 mt-1">Pick a date and a time of day.</p>
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">End Date &amp; Time</label>
               <input
                 type="datetime-local"
                 value={endDate}
@@ -311,6 +318,7 @@ export default function SurveyBuilderPage() {
                 min={startDate || undefined}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
               />
+              <p className="text-xs text-gray-400 mt-1">Pick a date and a time of day.</p>
             </div>
 
             <div className="flex items-center gap-3 pt-6">


### PR DESCRIPTION
Closes #1541

## Summary

The Start Date / End Date inputs on the New Survey form are \`type=\"datetime-local\"\`, so the browser's native picker opens a date calendar alongside a time-of-day selector. Reporter flagged this as confusing — a "time module" popped up next to the date without saying so.

We can't alter the browser-native picker. The fix is to make the **field labels** convey the full intent so users aren't surprised:

- "Start Date" → **"Start Date & Time"**
- "End Date" → **"End Date & Time"**
- Added helper text under each: *"Pick a date and a time of day."*

## Test plan

- [ ] Workplace → Surveys → New Survey → scroll to Start / End fields.
- [ ] Labels read "Start Date & Time" and "End Date & Time".
- [ ] Helper line visible under each input.
- [ ] Clicking the field still opens the browser-native date-and-time picker.
- [ ] End date < start date still produces the existing inline error (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)