### PR TITLE
fix(positions): Mark as Filled now works + upgrade confirm/error UX

### DIFF
--- a/packages/client/src/components/ui/ConfirmDialog.tsx
+++ b/packages/client/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,114 @@
+// =============================================================================
+// EMP CLOUD — Confirmation Dialog (replaces window.confirm)
+// =============================================================================
+//
+// Usage:
+//   <ConfirmDialog
+//     open={open}
+//     title="Mark as filled?"
+//     description="This position will be removed from the open vacancies list."
+//     confirmText="Mark as Filled"
+//     variant="success"
+//     loading={mutation.isPending}
+//     onConfirm={() => mutation.mutate(id)}
+//     onCancel={() => setOpen(false)}
+//   />
+// =============================================================================
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+
+type Variant = "danger" | "success" | "info";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: Variant;
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const VARIANT_STYLES: Record<Variant, { icon: typeof AlertTriangle; iconBg: string; iconColor: string; button: string }> = {
+  danger: {
+    icon: AlertTriangle,
+    iconBg: "bg-red-50",
+    iconColor: "text-red-600",
+    button: "bg-red-600 hover:bg-red-700",
+  },
+  success: {
+    icon: CheckCircle2,
+    iconBg: "bg-green-50",
+    iconColor: "text-green-600",
+    button: "bg-green-600 hover:bg-green-700",
+  },
+  info: {
+    icon: AlertTriangle,
+    iconBg: "bg-blue-50",
+    iconColor: "text-blue-600",
+    button: "bg-brand-600 hover:bg-brand-700",
+  },
+};
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "info",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const style = VARIANT_STYLES[variant];
+  const Icon = style.icon;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(v) => !v && onCancel()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-xl bg-white shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95">
+          <div className="p-6">
+            <div className="flex items-start gap-4">
+              <div className={`shrink-0 rounded-full p-2 ${style.iconBg}`}>
+                <Icon className={`h-5 w-5 ${style.iconColor}`} />
+              </div>
+              <div className="flex-1">
+                <Dialog.Title className="text-base font-semibold text-gray-900">
+                  {title}
+                </Dialog.Title>
+                {description && (
+                  <Dialog.Description className="mt-2 text-sm text-gray-600">
+                    {description}
+                  </Dialog.Description>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="flex justify-end gap-3 border-t border-gray-100 bg-gray-50 px-6 py-4 rounded-b-xl">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={loading}
+              className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            >
+              {cancelText}
+            </button>
+            <button
+              type="button"
+              onClick={onConfirm}
+              disabled={loading}
+              className={`rounded-lg px-4 py-2 text-sm font-medium text-white disabled:opacity-50 ${style.button}`}
+            >
+              {loading ? "Working..." : confirmText}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/client/src/pages/positions/VacanciesPage.tsx
+++ b/packages/client/src/pages/positions/VacanciesPage.tsx
@@ -1,10 +1,19 @@
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Briefcase, AlertTriangle, MapPin, CheckCircle2 } from "lucide-react";
 import api from "@/api/client";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import { showToast } from "@/components/ui/Toast";
+
+interface PendingConfirm {
+  id: number;
+  title: string;
+}
 
 export default function VacanciesPage() {
   const queryClient = useQueryClient();
+  const [pending, setPending] = useState<PendingConfirm | null>(null);
   const { data, isLoading } = useQuery({
     queryKey: ["position-vacancies"],
     queryFn: () => api.get("/positions/vacancies").then((r) => r.data.data),
@@ -21,9 +30,12 @@ export default function VacanciesPage() {
       queryClient.invalidateQueries({ queryKey: ["position-vacancies"] });
       queryClient.invalidateQueries({ queryKey: ["positions"] });
       queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
+      showToast("success", pending ? `"${pending.title}" marked as filled.` : "Position marked as filled.");
+      setPending(null);
     },
     onError: (err: any) => {
-      alert(err?.response?.data?.error?.message || "Failed to mark position as filled");
+      showToast("error", err?.response?.data?.error?.message || "Failed to mark position as filled");
+      setPending(null);
     },
   });
 
@@ -130,13 +142,7 @@ export default function VacanciesPage() {
                       onClick={(e) => {
                         e.preventDefault();
                         e.stopPropagation();
-                        if (
-                          confirm(
-                            `Mark "${pos.title}" as filled? It will be removed from the open vacancies list.`
-                          )
-                        ) {
-                          markFilledMutation.mutate(pos.id);
-                        }
+                        setPending({ id: pos.id, title: pos.title });
                       }}
                       disabled={markFilledMutation.isPending}
                       className="mt-4 inline-flex items-center gap-1 text-xs font-medium text-green-600 hover:text-green-700 disabled:opacity-50"
@@ -153,6 +159,17 @@ export default function VacanciesPage() {
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        open={pending !== null}
+        title={pending ? `Mark "${pending.title}" as filled?` : ""}
+        description="This position will be removed from the open vacancies list."
+        confirmText="Mark as Filled"
+        variant="success"
+        loading={markFilledMutation.isPending}
+        onConfirm={() => pending && markFilledMutation.mutate(pending.id)}
+        onCancel={() => !markFilledMutation.isPending && setPending(null)}
+      />
     </div>
   );
 }

--- a/packages/server/src/db/migrations/046_positions_status_add_filled.ts
+++ b/packages/server/src/db/migrations/046_positions_status_add_filled.ts
@@ -1,0 +1,28 @@
+// =============================================================================
+// MIGRATION 046 — Add "filled" to positions.status enum
+// =============================================================================
+// The zod `positionStatusEnum` + service layer (auto-fill on headcount reach,
+// HR "Mark as Filled" button) all expect a `filled` status, but the DB column
+// was never extended beyond the original 3 values, causing PUT /positions/:id
+// { status: "filled" } to fail with MySQL error 1265 (Data truncated).
+// =============================================================================
+
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    ALTER TABLE positions
+    MODIFY COLUMN status ENUM('active','filled','frozen','closed')
+      NOT NULL DEFAULT 'active'
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // Map any 'filled' rows to 'active' so they don't break enum narrowing
+  await knex("positions").where({ status: "filled" }).update({ status: "active" });
+  await knex.raw(`
+    ALTER TABLE positions
+    MODIFY COLUMN status ENUM('active','frozen','closed')
+      NOT NULL DEFAULT 'active'
+  `);
+}


### PR DESCRIPTION
## Summary
Fixes **#1552** â€” "Mark as Filled" on `/positions/vacancies` was triggering a 500, and the UX around the click was a native `window.confirm` + `alert`.

## Root cause
The zod validator (`positionStatusEnum`) and the positions service (auto-fill when `headcount_filled == headcount_budget`, auto-revert on new vacancy) both expect `status = "filled"`, but the DB column was never extended beyond the original `ENUM('active','frozen','closed')`. Every `PUT /positions/:id { status: "filled" }` was getting rejected with MySQL error 1265 (Data truncated) and surfacing as `INTERNAL_ERROR`.

## Fixes
- **Migration 046** â€” `ALTER TABLE positions MODIFY COLUMN status ENUM('active','filled','frozen','closed') NOT NULL DEFAULT 'active'`. Idempotent, with a safe `down()` that maps existing `filled` rows to `active` before narrowing the enum back.
- **VacanciesPage** â€” replaced `window.confirm(...)` with a styled `<ConfirmDialog>` driven by pending-state, replaced `window.alert(...)` on error with the existing `showToast()` pipeline, and added a success toast (`"<Title>" marked as filled.`) on completion.
- **New `components/ui/ConfirmDialog.tsx`** â€” Radix-based, reusable, variant-aware (`danger` / `success` / `info`), loading state with disabled buttons, ESC/backdrop-to-cancel. Drop-in replacement anywhere else `confirm()` is still being used.

## Side benefit
`assignUserToPosition` silently swallows the same error path when a position auto-promotes to `filled` after reaching `headcount_budget`. Migration 046 unblocks that code path too.

## Files
- `packages/server/src/db/migrations/046_positions_status_add_filled.ts` (new)
- `packages/client/src/components/ui/ConfirmDialog.tsx` (new)
- `packages/client/src/pages/positions/VacanciesPage.tsx`

## Test plan
- [ ] `/positions/vacancies` â†’ click **Mark as Filled** on a card â†’ styled modal appears with green check icon
- [ ] Confirm â†’ toast `"<Title>" marked as filled.` appears and the card disappears from the list
- [ ] Cancel â†’ modal closes, no change
- [ ] Backend error (e.g., force 500 on API) â†’ red error toast with the server message
- [ ] Position record: `status = 'filled'` in DB after confirm
- [ ] Assign last open headcount â†’ position auto-promotes to `filled` without a 500

Closes #1552
