### PR TITLE
fix(feed, self-service): remove blank canvas from grid-row-stretch layout bug

### DIFF
--- a/packages/client/src/pages/feed/FeedPage.tsx
+++ b/packages/client/src/pages/feed/FeedPage.tsx
@@ -117,10 +117,16 @@ export default function FeedPage() {
         </div>
       </header>
 
-      {/* ───────────────────── Body grid ───────────────────── */}
-      <div className={isHR ? "grid grid-cols-1 lg:grid-cols-3 gap-6" : ""}>
-        {/* Main column */}
-        <div className={isHR ? "lg:col-span-2 space-y-4" : "space-y-4"}>
+      {/* ───────────────────── Body layout ─────────────────────
+          On lg+ the HR sidebar is positioned absolutely on the right so
+          it doesn't contribute to page flow. This keeps the scrollable
+          page height equal to the main column's content height — a grid
+          layout would force the row (and the page) to grow to the taller
+          of the two columns, producing a big blank canvas below the last
+          post when the feed has few items. */}
+      <div className={isHR ? "relative" : ""}>
+        {/* Main column — reserve 1/3 + gap on the right for the sidebar */}
+        <div className={isHR ? "space-y-4 lg:pr-[calc(33.333%+1.5rem)]" : "space-y-4"}>
           {/* Search + filter chips */}
           <div className="rounded-xl border border-gray-200 bg-white p-3 space-y-3">
             <form
@@ -187,9 +193,15 @@ export default function FeedPage() {
           )}
         </div>
 
-        {/* HR sidebar — sticky, mobile collapses to top */}
+        {/* HR sidebar.
+            - Mobile / tablet: stacks below main (normal flow, mt-6).
+            - lg+: absolutely positioned on the right so it does NOT
+              lengthen the page; internal wrapper uses sticky so it
+              follows scroll, and max-h + overflow cap it to the
+              viewport when the sidebar content is tall. */}
         {isHR && (
-          <aside className="space-y-4 lg:sticky lg:top-4 lg:self-start">
+          <aside className="mt-6 space-y-4 lg:mt-0 lg:absolute lg:right-0 lg:top-0 lg:w-1/3">
+            <div className="space-y-4 lg:sticky lg:top-4 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto lg:pr-1">
             {/* KPI grid */}
             {stats && (
               <div className="grid grid-cols-2 gap-3">
@@ -288,6 +300,7 @@ export default function FeedPage() {
                 </ul>
               </div>
             )}
+            </div>
           </aside>
         )}
       </div>

--- a/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
+++ b/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
@@ -176,15 +176,27 @@ export default function SelfServiceDashboardPage() {
         media and replies; on smaller screens it collapses to a single column
         with the feed first.
       */}
-      <div className="grid grid-cols-1 lg:grid-cols-5 gap-6 items-start">
-        {/* Left column — Company Feed */}
-        <div className="lg:col-span-3">
+      {/* #1530 — the right column (self-service cards) was previously a grid
+          cell that forced the grid row to match its height. When the feed on
+          the left had few items the row grew to match the card stack, leaving
+          a large empty gap below the feed and an outer scrollbar past the
+          content. Fix: take the right column out of document flow on `lg+`
+          via absolute positioning, keep sticky + internal scroll intact, and
+          have the left column reserve its gutter. Mobile still stacks in
+          natural flow. */}
+      <div className="lg:relative">
+        {/* Left column — Company Feed. Reserves 2/5 width + gap on the right
+            for the absolutely positioned card stack. */}
+        <div className="lg:pr-[calc(40%+1.5rem)]">
           <CompanyFeedWidget />
         </div>
 
-        {/* Right column — stacked dashboard cards. Sticky so short content
-            doesn't leave a big empty gap beside the feed when the user scrolls. */}
-        <div className="lg:col-span-2 space-y-6 lg:sticky lg:top-4 lg:self-start">
+        {/* Right column — stacked dashboard cards. Absolute on lg+ so the
+            page height is driven by the feed column only. Inner wrapper is
+            sticky + internally scrollable so tall card stacks remain
+            accessible. */}
+        <div className="mt-6 lg:mt-0 lg:absolute lg:right-0 lg:top-0 lg:w-2/5">
+          <div className="space-y-6 lg:sticky lg:top-4 lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto lg:pr-1">
         {/* Attendance Today */}
         <div className="bg-white border border-gray-200 rounded-xl p-6">
           <div className="flex items-center gap-2 mb-4">
@@ -383,6 +395,7 @@ export default function SelfServiceDashboardPage() {
             </ul>
           </div>
         )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Fixes **#1558** (on `/feed`) and **#1530** (on `/self-service`) â€” two instances of the same root-cause layout bug where the page showed a large blank canvas and a phantom scroll extending past the visible content.

## Root cause
Both pages used a 2-column CSS Grid with a sticky "sidebar" cell:
- `/feed`: composer + posts on the left, KPIs/categories/contributors on the right
- `/self-service`: company feed on the left, attendance + leave + docs + announcements cards on the right

CSS Grid sizes the row to `max(children height)`. Whenever one column was taller than the other, the shorter column got padded down to match, producing the visible empty gap and an outer scrollbar that let the user scroll into the emptiness. `align-items: start` and `max-h` on the sidebar don't help â€” they only affect how the item sits *inside* the row; they don't reduce the row height itself.

## Fix (same technique on both pages)
Take the right column out of document flow on `lg+`:

- Outer wrapper becomes `lg:relative`
- Left column reserves a right gutter with `lg:pr-[calc(<sidebar-width>+1.5rem)]`
- Right column is `lg:absolute lg:right-0 lg:top-0 lg:w-<sidebar-width>` â€” no longer contributes to page flow
- Inner wrapper keeps `lg:sticky lg:top-4` so it follows scroll, and `lg:max-h-[calc(100vh-6rem)] lg:overflow-y-auto` so tall sidebars remain reachable via their own internal scroll
- Mobile / tablet (below `lg`) is untouched â€” the sidebar stacks below via `mt-6` with `lg:` prefixes guarding the desktop-only rules

Page height is now driven entirely by the left (main) column on both pages.

## Files
- `packages/client/src/pages/feed/FeedPage.tsx` (+19 / âˆ’6)
- `packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx` (+19 / âˆ’6)

## Test plan
**`/feed` (HR user)**
- [ ] Few posts â†’ no blank canvas below last post; outer scrollbar length matches actual content
- [ ] Sidebar visible on the right (KPIs, categories, top contributors, trending)
- [ ] Scroll main area â†’ sidebar stays pinned at top
- [ ] Sidebar taller than viewport â†’ scrolls internally; all items reachable
- [ ] Mobile (< lg) â†’ sidebar stacks under composer/posts as before
- [ ] `/feed` as employee (non-HR) â†’ unchanged single-column layout

**`/self-service`**
- [ ] Feed longer than card stack â†’ card stack pinned in view, no gap
- [ ] Card stack longer than feed â†’ feed column ends without phantom scroll; card stack scrolls internally
- [ ] Mobile (< lg) â†’ card stack stacks below feed
- [ ] Check-in / check-out header action unaffected

Closes #1558
Closes #1530
