### PR TITLE
fix: keep deep links to legacy/shared route URLs working

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -148,6 +148,11 @@ export default function App() {
         >
           <Route path="/" element={<RootRedirect />} />
           <Route path="/my-profile" element={<MyProfileRedirect />} />
+          {/* Legacy / commonly-shared URLs that don't match a real route — keep deep links working
+              instead of falling through to the catch-all root redirect. */}
+          <Route path="/attendance/shift-settings" element={<Navigate to="/attendance/shifts" replace />} />
+          <Route path="/leave/holidays" element={<Navigate to="/holidays" replace />} />
+          <Route path="/probation" element={<Navigate to="/employees/probation" replace />} />
           {hrmsRoutes}
           {helpdeskRoutes}
           {surveyRoutes}


### PR DESCRIPTION
## Summary

Closes #1635. Three URLs that get shared, bookmarked, and pasted into docs were silently bouncing to `/` because no route matched them and the catch-all `*` route falls back to root.

Add explicit redirects so each one lands on its canonical page:

- `/attendance/shift-settings` → `/attendance/shifts`
- `/leave/holidays` → `/holidays`
- `/probation` → `/employees/probation`

Sidebar navigation already points at the canonical routes, so this only changes behavior for direct URL hits.

## Test plan

- [ ] Log in, paste each legacy URL into the address bar, confirm it lands on the canonical page (not `/`).
- [ ] Sidebar links still work as before.
- [ ] An unknown URL (e.g. `/nope`) still falls through to the catch-all `→ /` redirect.