### PR TITLE
fix(auth): surface login errors, rate-limit, and hide placeholder invites

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -22,13 +22,28 @@ api.interceptors.request.use((config) => {
 // Mutex for token refresh — prevents concurrent 401s from triggering multiple refreshes
 let refreshPromise: Promise<string> | null = null;
 
+// Endpoints that mint or revoke tokens directly. They reject with 401 to
+// signal "wrong credentials" or "expired/invalid token" — both of which are
+// terminal for the request and must NOT trigger a refresh-then-retry. Without
+// this guard the LoginPage 401 would attempt a refresh against any stale
+// refresh_token in localStorage; if that refresh failed we fell through to
+// `window.location.href = "/login"`, which reloaded the page and silently
+// wiped the user's just-typed credentials and the inline error message
+// (#1638). The user saw a button click that "did nothing".
+const AUTH_ENDPOINTS = ["/auth/login", "/auth/register", "/auth/forgot-password", "/auth/reset-password", "/auth/sso"];
+const isAuthEndpoint = (url?: string) => !!url && AUTH_ENDPOINTS.some((p) => url.includes(p));
+
 // Handle 401 — attempt token refresh
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !isAuthEndpoint(originalRequest?.url)
+    ) {
       originalRequest._retry = true;
       const refreshToken = useAuthStore.getState().refreshToken;
 

--- a/packages/client/src/pages/auth/LoginPage.tsx
+++ b/packages/client/src/pages/auth/LoginPage.tsx
@@ -43,7 +43,27 @@ export default function LoginPage() {
       );
       navigate("/");
     } catch (err: any) {
-      setError(err.response?.data?.error?.message || "Login failed");
+      // #1648 — surface rate-limit 429s explicitly. express-rate-limit sets
+      // Retry-After (in seconds) and our middleware also returns a structured
+      // message. Always show *something* even if the response is empty so the
+      // button click never appears to do nothing.
+      if (err.response?.status === 429) {
+        const retryAfterSec = Number(err.response.headers?.["retry-after"]);
+        const baseMsg = err.response?.data?.error?.message
+          || "Too many login attempts. Please wait and try again.";
+        if (retryAfterSec > 0) {
+          const mins = Math.ceil(retryAfterSec / 60);
+          setError(`${baseMsg} (Retry in ~${mins} min)`);
+        } else {
+          setError(baseMsg);
+        }
+        return;
+      }
+      // Network errors (no response) and unstructured errors fall through
+      // to a clear default. Never leave the form blank.
+      const apiMsg = err.response?.data?.error?.message;
+      const networkMsg = !err.response ? "Can't reach the server. Check your connection and try again." : null;
+      setError(apiMsg || networkMsg || "Login failed. Please try again.");
     }
   };
 

--- a/packages/server/src/db/migrations/052_purge_placeholder_invitations.ts
+++ b/packages/server/src/db/migrations/052_purge_placeholder_invitations.ts
@@ -1,0 +1,29 @@
+// =============================================================================
+// MIGRATION 052 — Purge placeholder invitations
+//
+// Issue #1647: a number of tenants ended up with rows in `invitations` whose
+// email is shaped `invite-NNNNNN@<domain>` (six characters between the dash
+// and the `@`). They were created outside the regular inviteUser() path and
+// have no real recipient — admins on /employees see 16+ pending invites that
+// can never be resent or accepted. Drop the dead rows so the panel becomes
+// useful. The listInvitations() filter already excludes them at read-time,
+// but we still want them out of the table so re-invite-all and the seat-limit
+// math don't include phantom pending rows.
+//
+// Idempotent: matches only the placeholder shape; rerunning is a no-op.
+// =============================================================================
+
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable("invitations"))) return;
+
+  await knex("invitations")
+    .where("status", "pending")
+    .andWhere("email", "like", "invite-______@%")
+    .delete();
+}
+
+export async function down(_knex: Knex): Promise<void> {
+  // Re-creating dead rows would reintroduce the bug. No-op.
+}

--- a/packages/server/src/services/user/user.service.ts
+++ b/packages/server/src/services/user/user.service.ts
@@ -587,10 +587,19 @@ export { purgeUserHard as _purgeUserHard };
 // Invitations
 // ---------------------------------------------------------------------------
 
+// #1647 — Placeholder invitations of the form `invite-NNNNNN@<domain>` were
+// inserted into a few tenants outside of the regular invite path (e.g. via a
+// bulk seed script). They have no real recipient — admins can't identify or
+// re-send them — so hide them from the panel. Migration 052 deletes the
+// existing rows; this filter prevents any stragglers from leaking into the
+// UI even before the migration runs.
+const PLACEHOLDER_INVITE_LIKE = "invite-______@%";
+
 export async function listInvitations(orgId: number, status: string = "pending") {
   const db = getDB();
   return db("invitations")
     .where({ organization_id: orgId, status })
+    .whereNot("email", "like", PLACEHOLDER_INVITE_LIKE)
     .select("id", "email", "role", "status", "created_at", "expires_at")
     .orderBy("created_at", "desc");
 }


### PR DESCRIPTION
## Summary

Three connected auth-UX fixes that all surfaced as "the login button does nothing" or "the panel is full of garbage".

### Closes #1638 — silent login failure
The axios response interceptor was running the refresh-then-retry path on `/auth/login` itself. When a stale `refresh_token` sat in localStorage (from a prior session on the same browser), the refresh attempt would fail and the catch path triggered `window.location.href = "/login"` — a hard reload that wiped the form state and any inline error message. The user saw a button click that appeared to do nothing.

Fix: skip the refresh-on-401 path for `/auth/*` endpoints. A 401 from those routes means "wrong credentials" or "invalid token" and is terminal — there is nothing to refresh.

### Closes #1648 — silent rate-limiting
The form mutation rejected on 429 but the fallback string was only "Login failed", which under flaky network or empty response bodies could end up empty. Now:
- 429 is handled explicitly: read `Retry-After`, present `(Retry in ~X min)` alongside the server message.
- Network errors get a clear "Can't reach the server" message.
- The catch always sets a non-empty string, so the click never appears unresponsive.

### Closes #1647 — pending invitations show placeholder emails
The panel on `/employees` was showing 16+ rows shaped `invite-NNNNNN@<domain>` (six chars) that were never created through the regular `inviteUser()` path — likely a one-off seed script. They had no real recipient, so admins couldn't resend or cancel them.

Fix:
- `listInvitations()` filters out the placeholder shape at read-time so they vanish from the panel immediately.
- Migration `052_purge_placeholder_invitations.ts` deletes the dead rows so seat-limit math, re-invite-all, and the panel all see the same truth.

## Test plan

- [ ] Log out, type wrong password → "Invalid email or password" appears, page does not reload.
- [ ] In another browser with a stale refresh_token in localStorage, type wrong password → same behavior, no silent reload.
- [ ] Hammer login until rate-limited → message reads "Too many login attempts..." with `(Retry in ~X min)`.
- [ ] Disconnect network, click login → "Can't reach the server."
- [ ] On a tenant that had placeholder invites, run the migration → panel becomes useful; seat-limit math no longer counts dead rows.