### PR TITLE
fix: enforce seat cap on module webhook + SLA % must include open breaches

### DIFF
--- a/packages/server/src/services/helpdesk/helpdesk.service.ts
+++ b/packages/server/src/services/helpdesk/helpdesk.service.ts
@@ -638,22 +638,46 @@ export async function getHelpdeskDashboard(orgId: number) {
     .where("resolved_at", ">=", todayStart)
     .count("id as count");
 
-  // SLA compliance: resolved tickets where resolved_at <= sla_resolution_due
-  const [{ count: totalResolved }] = await db("helpdesk_tickets")
+  // #1633 — SLA compliance must include open-but-breached tickets in the
+  // denominator. Previously the metric only looked at resolved tickets,
+  // which made it possible to show "100% compliance" while 36 still-open
+  // tickets had already blown past their resolution due date.
+  //
+  // Compliant   = resolved AND resolved_at <= sla_resolution_due
+  // Breached    = resolved AND resolved_at >  sla_resolution_due
+  //             + still-open AND NOW()      >  sla_resolution_due
+  // Compliance  = compliant / (compliant + breached)
+  //
+  // Tickets without an sla_resolution_due (e.g. legacy rows pre-SLA-rollout)
+  // are excluded from both buckets so they don't distort the rate.
+  const [{ count: compliantCount }] = await db("helpdesk_tickets")
     .where({ organization_id: orgId })
     .whereNotNull("resolved_at")
-    .count("id as count");
-
-  const [{ count: withinSLA }] = await db("helpdesk_tickets")
-    .where({ organization_id: orgId })
-    .whereNotNull("resolved_at")
+    .whereNotNull("sla_resolution_due")
     .whereRaw("resolved_at <= sla_resolution_due")
     .count("id as count");
 
-  const slaCompliance =
-    Number(totalResolved) > 0
-      ? Math.round((Number(withinSLA) / Number(totalResolved)) * 100)
-      : 100;
+  const [{ count: resolvedLateCount }] = await db("helpdesk_tickets")
+    .where({ organization_id: orgId })
+    .whereNotNull("resolved_at")
+    .whereNotNull("sla_resolution_due")
+    .whereRaw("resolved_at > sla_resolution_due")
+    .count("id as count");
+
+  // Re-uses the same overdue criterion as the `overdue` KPI so the two
+  // numbers always agree: any ticket the dashboard counts as "SLA breached"
+  // is also counted as a breach for compliance purposes.
+  const [{ count: openBreachedCount }] = await db("helpdesk_tickets")
+    .where({ organization_id: orgId })
+    .whereIn("status", ["open", "in_progress", "awaiting_response", "reopened"])
+    .whereNotNull("sla_resolution_due")
+    .where("sla_resolution_due", "<", now)
+    .count("id as count");
+
+  const compliant = Number(compliantCount);
+  const breached = Number(resolvedLateCount) + Number(openBreachedCount);
+  const slaTotal = compliant + breached;
+  const slaCompliance = slaTotal > 0 ? Math.round((compliant / slaTotal) * 100) : 100;
 
   // Average resolution time (in hours)
   const [avgResult] = await db("helpdesk_tickets")

--- a/packages/server/src/services/module/module-sync.service.ts
+++ b/packages/server/src/services/module/module-sync.service.ts
@@ -365,6 +365,25 @@ export async function handleModuleSeatWebhook(data: {
       .first();
     if (existing) return;
 
+    // #1632 — Webhooks from sub-modules were inserting seat rows without
+    // checking the subscription's total_seats cap, so a module that did its
+    // own bulk-enable could push EmpCloud into "28 of 10 seats assigned".
+    // Mirror the count-based check that assignSeat / enableUserForModule
+    // already use so this third entry point can't bypass the cap.
+    const [{ seatCount }] = await db("org_module_seats")
+      .where({ subscription_id: sub.id })
+      .count("* as seatCount");
+    const currentSeats = Number(seatCount);
+    if (sub.total_seats != null && currentSeats >= sub.total_seats) {
+      logger.warn(
+        `Seat webhook rejected: module=${data.module_slug} user=${user.id} ` +
+        `currentSeats=${currentSeats} total_seats=${sub.total_seats}`,
+      );
+      throw new ConflictError(
+        `Seat limit exceeded for module '${data.module_slug}'. Subscription allows ${sub.total_seats} seats; ${currentSeats} are already assigned.`,
+      );
+    }
+
     await db("org_module_seats").insert({
       subscription_id: sub.id,
       organization_id: orgId,


### PR DESCRIPTION
## Summary

Two compliance / data-integrity fixes that were both producing visibly wrong numbers in the admin UI.

### Closes #1632 — module seat assignments exceed purchased limits
`handleModuleSeatWebhook` was the third seat-write entry point but the only one without a count-based seat-cap check. `assignSeat()` and `enableUserForModule()` both COUNT actual `org_module_seats` rows before inserting; the webhook just inserted unconditionally. A sub-module that did its own bulk-enable on its side could push EmpCloud into "28 of 10 seats assigned" with no warning.

Fix: mirror the same authoritative count check on the webhook path. Reject with `ConflictError` when `currentSeats >= sub.total_seats`.

This prevents *new* over-assignment; recovering existing over-assigned tenants is a separate cleanup task — admins can run the existing `syncUsedSeats()` to recompute the cache and revoke seats individually as needed.

### Closes #1633 — Helpdesk SLA Compliance shows 100% despite 36 SLA-breached tickets
The SLA compliance metric only looked at *resolved* tickets:
```
withinSLA / totalResolved
```
so open-but-overdue tickets were silently excluded. If 100 resolved tickets were all on time and 36 still-open tickets had already breached SLA, the metric still read 100%, contradicting the "36 SLA Breached" KPI right next to it on the same dashboard.

New formula:
```
compliant  = resolved AND resolved_at <= sla_resolution_due
breached   = resolved AND resolved_at >  sla_resolution_due
           + still-open AND NOW()      >  sla_resolution_due
compliance = compliant / (compliant + breached)
```
The "open and overdue" denominator term reuses the *exact* criterion the dashboard's `overdue` KPI already uses, so the two numbers can no longer disagree. Tickets without `sla_resolution_due` (legacy pre-SLA rows) are excluded from both buckets so they don't distort the rate.

## Test plan

- [ ] Tenant with 36 breached open tickets → SLA % drops below 100% and roughly matches `compliant / (compliant + 36)`.
- [ ] Tenant with no breaches (all resolved on time, none overdue) → SLA % stays at 100%.
- [ ] Tenant with no SLA-tracked tickets at all → SLA % defaults to 100% (no division by zero).
- [ ] Module sub-app calls the seat webhook past the cap → returns 409, no row inserted, `used_seats` stays accurate.
- [ ] Webhook within cap → seat inserted, `used_seats` increments by 1.