### PR TITLE
fix(announcements): reject SSTI/XSS probe payloads at write time

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -783,9 +783,22 @@ export const rejectDocumentSchema = z.object({
 // HRMS — Announcement Validators
 // ---------------------------------------------------------------------------
 
+// #270 — Reject obvious SSTI/XSS probe payloads (arithmetic inside template
+// markers). Output sanitisation already neutralises these on render, but
+// admins were seeing them sit visibly in the Announcements feed because
+// nothing stopped them from being stored. The regex is deliberately tight:
+// it matches `{{7*7}}`, `${7*7}`, `<%=7*7%>`, `#{7*7}` and similar arithmetic
+// probes — not legitimate uses like `{{user_name}}` or `${BUDGET}`.
+const SSTI_PROBE_RE =
+  /(\{\{|\$\{|<%=|#\{)\s*\d+\s*[+\-*/]\s*\d+\s*(\}\}|\}|%>)/;
+const ssTiCheck = (val: string) => !SSTI_PROBE_RE.test(val);
+const ssTiMessage =
+  "Content looks like a template-injection probe (e.g. {{7*7}}). " +
+  "If this is intentional, escape the markers or paraphrase.";
+
 export const createAnnouncementSchema = z.object({
-  title: z.string().min(1).max(255),
-  content: z.string().min(1),
+  title: z.string().min(1).max(255).refine(ssTiCheck, ssTiMessage),
+  content: z.string().min(1).refine(ssTiCheck, ssTiMessage),
   priority: z.enum(["low", "normal", "high", "urgent"]).default("normal"),
   target_type: z.enum(["all", "department", "role"]).default("all"),
   target_ids: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary

Closes EmpCloud/emp-payroll#270 (issue is on the payroll repo but the fix has to land here — payroll dropped its local announcements table in migration 022 and now reads from EmpCloud).

Production had visible probe payloads sitting in the announcements feed (`#{7*7}`, `{{7*7}}`, `${7*7}`, `<%=7*7%>`). The existing sanitize-html output filter already neutralises them — they render as inert text — but nothing stopped them from being stored, so they cluttered the live feed.

## Fix

Add a tight refinement to createAnnouncementSchema (propagates to updateAnnouncementSchema via .partial()): a regex matching arithmetic inside template markers — {{N op N}}, ${N op N}, <%=N op N%>, #{N op N}. Deliberately narrow so legitimate content like {{user_name}} or ${BUDGET} is unaffected.

**Sanity check** (verified locally): 9 probe variants reject ({{7*7}}, ${7*7}, <%=7*7%>, #{7*7}, {{ 7 * 7 }}, {{7+7}}, ${1-1}, <%=2/2%>, embedded probes); 6 legitimate uses pass ({{user_name}}, ${BUDGET}, plain text, etc.).

## Operational follow-up

Out of scope for this PR but worth doing: an admin should delete the existing probe rows from the production announcements table. This PR only stops new ones.

## Test plan

- [ ] Try to create an announcement with {{7*7}} in title or body → server returns 400 with a clear message.
- [ ] Try to create an announcement with Hello {{employee_name}} → succeeds.
- [ ] Existing announcements load and render normally.
