### PR TITLE
feat(users): emp_code uniqueness + permissive format regex

### DIFF
--- a/packages/server/src/db/migrations/053_cleanup_duplicate_emp_codes.ts
+++ b/packages/server/src/db/migrations/053_cleanup_duplicate_emp_codes.ts
@@ -1,0 +1,71 @@
+// =============================================================================
+// MIGRATION 053 — Clean up duplicate emp_code values within an org
+//
+// Issue #1658 — production tenants reported two employees in the same org
+// sharing the same emp_code (EM526 used by both "Arjun sharma" and
+// "Vikash Yadav"). The follow-up migration 054 adds
+// UNIQUE(organization_id, emp_code), which would fail on this dirty
+// dataset. This prerequisite cleans things up:
+//
+//   - For each (organization_id, emp_code) with > 1 row, keep the row
+//     with the earliest created_at and suffix the rest's emp_code with
+//     "-DUP-<id>" so admins can recognise and re-key them.
+//   - Empty / null emp_code is left alone — UNIQUE(_, NULL) allows
+//     multiple in MySQL, so missing codes don't conflict.
+//
+// Idempotent: a second pass against an already-clean dataset matches
+// no rows and is a no-op.
+// =============================================================================
+
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable("users"))) return;
+
+  // Step 0: empty-string emp_codes are treated as a *value* by a MySQL
+  // UNIQUE index (only NULL repeats freely). Normalise blanks/whitespace
+  // to NULL so the new constraint doesn't collide on tenants where many
+  // users have just never been assigned a code.
+  await knex("users")
+    .whereNotNull("emp_code")
+    .andWhereRaw("TRIM(emp_code) = ''")
+    .update({ emp_code: null, updated_at: new Date() });
+
+  // Find every (org_id, emp_code) pair that's used by more than one
+  // active user. Limiting to non-null/non-empty emp_codes since NULL is
+  // permitted to repeat under the new constraint.
+  const dups = (await knex("users")
+    .whereNotNull("emp_code")
+    .andWhere("emp_code", "!=", "")
+    .select("organization_id", "emp_code")
+    .count("* as count")
+    .groupBy("organization_id", "emp_code")
+    .having(knex.raw("COUNT(*) > 1"))) as unknown as Array<{
+    organization_id: number;
+    emp_code: string;
+  }>;
+
+  if (dups.length === 0) return;
+
+  for (const { organization_id, emp_code } of dups) {
+    // For this org+code, fetch all the rows ordered by created_at asc.
+    // First row keeps the original code; later rows get suffixed.
+    const rows = await knex("users")
+      .where({ organization_id, emp_code })
+      .orderBy("created_at", "asc")
+      .select("id");
+
+    for (let i = 1; i < rows.length; i++) {
+      const u = rows[i];
+      const newCode = `${emp_code}-DUP-${u.id}`;
+      await knex("users").where({ id: u.id }).update({
+        emp_code: newCode,
+        updated_at: new Date(),
+      });
+    }
+  }
+}
+
+export async function down(_knex: Knex): Promise<void> {
+  // One-way data fix; restoring duplicates would reintroduce the bug.
+}

--- a/packages/server/src/db/migrations/054_users_emp_code_unique.ts
+++ b/packages/server/src/db/migrations/054_users_emp_code_unique.ts
@@ -1,0 +1,41 @@
+// =============================================================================
+// MIGRATION 054 — UNIQUE(organization_id, emp_code) on users
+//
+// Issue #1658 — emp_code must be unique per org. Migration 053 already
+// suffixed any existing duplicates so this constraint can land safely.
+//
+// MySQL allows multiple NULLs in a UNIQUE index, so users without an
+// emp_code (HR hasn't set one yet) don't collide. Once HR enters the
+// code, the constraint enforces "one code per org" at the storage
+// layer rather than relying on the app-level race-prone check in
+// employee.service.ts.
+//
+// Idempotent: skipped if the index already exists.
+// =============================================================================
+
+import type { Knex } from "knex";
+
+const INDEX_NAME = "idx_users_org_emp_code_uniq";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable("users"))) return;
+
+  const idx = await knex.raw(
+    `SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+       WHERE table_schema = DATABASE()
+         AND table_name = 'users'
+         AND index_name = ?`,
+    [INDEX_NAME],
+  );
+  const exists = Array.isArray(idx[0]) && idx[0].length > 0;
+  if (exists) return;
+
+  await knex.raw(
+    `CREATE UNIQUE INDEX ${INDEX_NAME} ON users (organization_id, emp_code)`,
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable("users"))) return;
+  await knex.raw(`DROP INDEX ${INDEX_NAME} ON users`).catch(() => {});
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -200,13 +200,27 @@ export const updateOrgSchema = z.object({
 
 const nameField = z.string().min(1).max(64).regex(/[a-zA-Z]/, "Name must contain at least one letter");
 
+// #1658 — emp_code is permissive on format because orgs use widely
+// different conventions (letters, numbers, dots, dashes, underscores).
+// We reject only whitespace and other punctuation to keep "garbage" data
+// like "rkgr2r1114512 " out. Uniqueness within an org is enforced by
+// migration 054's UNIQUE(organization_id, emp_code) index.
+const empCodeField = z
+  .string()
+  .trim()
+  .max(50)
+  .regex(
+    /^[A-Za-z0-9._-]+$/,
+    "Employee code may only contain letters, digits, dots, dashes or underscores",
+  );
+
 export const createUserSchema = z.object({
   first_name: nameField,
   last_name: nameField,
   email: z.string().email().max(128),
   password: z.string().min(8).max(128).optional(),
   role: z.nativeEnum(UserRole).default(UserRole.EMPLOYEE),
-  emp_code: z.string().max(50).optional(),
+  emp_code: empCodeField.optional(),
   contact_number: z.string().max(20).optional(),
   date_of_birth: z.string().optional(),
   gender: z.string().max(10).optional(),
@@ -236,7 +250,7 @@ export const bulkImportUserRowSchema = z.object({
   // Password is optional — if blank, user must use forgot-password flow.
   password: z.string().min(8).max(128).optional().or(z.literal("")),
   role: z.nativeEnum(UserRole).optional(),
-  emp_code: z.string().max(50).optional(),
+  emp_code: empCodeField.optional(),
   designation: z.string().max(100).optional(),
   department_name: z.string().max(100).optional(),
   location_name: z.string().max(100).optional(),
@@ -385,7 +399,9 @@ export const upsertEmployeeProfileSchema = z.object({
   // emp-payroll#246 — emp_code lives on users too. Without an editable field
   // on the EmpCloud profile form, HR couldn't set it post-creation, and
   // payroll showed an empty Employee Code as a result.
-  emp_code: z.string().max(50).optional().nullable(),
+  // #1658 — same permissive regex as createUserSchema; uniqueness is
+  // enforced at the DB layer by migration 054.
+  emp_code: empCodeField.optional().nullable(),
   // #1423 — shift_id is not a users-table column; the service creates a
   // user_shift_assignments row instead when this field is supplied.
   shift_id: z.coerce.number().int().positive().optional().nullable(),


### PR DESCRIPTION
## Summary

Closes #1658. PR11.2b — companion to emp-payroll PR #277 (PR11.2a). emp_code lives on EmpCloud's `users` table, so the uniqueness fix has to land here.

## What this changes (3 layers)

**1. Migration 053 — cleanup**
   - Normalises empty/whitespace-only `emp_code` to `NULL`. (Empty string is a *value* under a MySQL UNIQUE index; only `NULL` repeats freely. This is the same trap PR11.1 hit on payroll.)
   - For any remaining `(organization_id, emp_code)` duplicates, keeps the row with the earliest `created_at` and suffixes the rest with `-DUP-<id>` so admins can recognise and re-key them.

**2. Migration 054 — constraint**
   - Adds `UNIQUE(organization_id, emp_code)` named `idx_users_org_emp_code_uniq`. Idempotent (skipped if the index already exists).

**3. Validators — permissive regex**
   - Extracted a shared `empCodeField` schema and applied it to `createUserSchema`, `bulkImportUserRowSchema`, and `upsertEmployeeProfileSchema`.
   - Pattern: `/^[A-Za-z0-9._-]+$/` — letters, digits, dots, dashes, underscores. Whitespace and other punctuation rejected. No letter-prefix requirement (per the agreed rule).

## Verified locally

- Migration 053 normalised 6 empty-string emp_codes to NULL on the dev database.
- Migration 054 created `idx_users_org_emp_code_uniq` successfully against the cleaned data.
- `INSERT` of two users with `emp_code = "EM-TEST-1"` in org 1 → `ER_DUP_ENTRY 1062 "1-EM-TEST-1"`. Constraint fires.
- TypeScript build/typecheck clean across shared + server.

## What this PR does NOT do

- No frontend changes — the EmployeeProfilePage already passes emp_code through; the new server-side validation gives the appropriate 400 error and the existing inline-error display surfaces it.
- Doesn't change the app-level race-prone duplicate check in `employee.service.ts` — leaving it as a fast-path; the DB constraint is now the source of truth.

## Test plan

- [ ] Run migrations on a tenant that has empty-string emp_codes → all become NULL; index applies.
- [ ] Run migrations on a tenant with duplicate emp_codes (e.g. EM526 × 2) → oldest kept, newer suffixed; index applies.
- [ ] Try to set two users to the same emp_code in the same org via UI → second save returns 409.
- [ ] Try to set emp_code to "abc 123" (with space) → server returns 400 with clear message.
- [ ] Set emp_code to "EM-001.A_2" (mixed allowed chars) → succeeds.
