### PR TITLE
fix: round 2 issue fixes — leave/comp-off/shift-schedule/attendance UX

### DIFF
--- a/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
@@ -335,7 +335,7 @@ export default function AttendanceDashboardPage() {
                       <tr className="text-left text-xs text-gray-500 uppercase border-b border-gray-200">
                         <th className="py-2 font-medium">{t('common.name')}</th>
                         <th className="py-2 font-medium">{t('attendance.department')}</th>
-                        <th className="py-2 font-medium">{t('attendance.checkIn')}</th>
+                        <th className="py-2 font-medium whitespace-nowrap">{t('attendance.checkIn')}</th>
                         {breakdownOpen === "total" && <th className="py-2 font-medium">{t('common.status')}</th>}
                         {breakdownOpen === "late" && <th className="py-2 font-medium">{t('attendance.breakdown.lateBy')}</th>}
                       </tr>
@@ -621,8 +621,8 @@ export default function AttendanceDashboardPage() {
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('common.name')}</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('attendance.department')}</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('common.date')}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('attendance.checkIn')}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('attendance.checkOut')}</th>
+              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3 whitespace-nowrap">{t('attendance.checkIn')}</th>
+              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3 whitespace-nowrap">{t('attendance.checkOut')}</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('attendance.tableWorked')}</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('common.status')}</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t('attendance.late')}</th>
@@ -729,7 +729,27 @@ function RecordRow({ record: r, t }: { record: any; t: (k: string, opts?: any) =
         <td className="px-6 py-4 text-sm text-gray-600">{r.check_in ? new Date(r.check_in).toLocaleTimeString() : "-"}</td>
         <td className="px-6 py-4 text-sm text-gray-600">{r.check_out ? new Date(r.check_out).toLocaleTimeString() : "-"}</td>
         <td className="px-6 py-4 text-sm text-gray-600">
-          {r.worked_minutes != null ? `${Math.floor(r.worked_minutes / 60)}h ${r.worked_minutes % 60}m` : "-"}
+          {(() => {
+            // #1949 — `worked_minutes` is only filled in at check-out, so the
+            // column read 0 for everyone still on the clock. For checked-in
+            // rows, derive a running total from check_in to now and tag it
+            // with "(so far)" so it's clear the value isn't final.
+            if (r.status === "checked_in" && r.check_in) {
+              const live = Math.max(
+                0,
+                Math.floor((Date.now() - new Date(r.check_in).getTime()) / 60000),
+              );
+              return (
+                <span className="inline-flex items-center gap-1">
+                  {`${Math.floor(live / 60)}h ${live % 60}m`}
+                  <span className="text-[10px] text-gray-400">(so far)</span>
+                </span>
+              );
+            }
+            return r.worked_minutes != null
+              ? `${Math.floor(r.worked_minutes / 60)}h ${r.worked_minutes % 60}m`
+              : "-";
+          })()}
         </td>
         <td className="px-6 py-4">
           <span className={`text-xs px-2 py-1 rounded-full font-medium ${

--- a/packages/client/src/pages/attendance/AttendancePage.tsx
+++ b/packages/client/src/pages/attendance/AttendancePage.tsx
@@ -36,6 +36,16 @@ export default function AttendancePage() {
     queryFn: () => api.get("/attendance/me/history", { params: { month, year, page } }).then((r) => r.data),
   });
 
+  // #1919 — Employees had no way to see what they'd already submitted
+  // (pending / approved / rejected) without bouncing to the admin
+  // Regularizations page, which most employees can't reach. Surface their
+  // own request history right under the Request Regularization form.
+  const { data: regHistoryData, isLoading: regHistLoading } = useQuery({
+    queryKey: ["my-regularizations"],
+    queryFn: () => api.get("/attendance/regularizations/me", { params: { per_page: 10 } }).then((r) => r.data),
+  });
+  const myRegRequests: any[] = regHistoryData?.data || [];
+
   const onAttendanceError = (err: any) =>
     alert(err?.response?.data?.error?.message ?? "Could not record attendance. Please try again.");
   const checkIn = useMutation({
@@ -81,6 +91,7 @@ export default function AttendancePage() {
         .then((r) => r.data.data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["attendance-history"] });
+      qc.invalidateQueries({ queryKey: ["my-regularizations"] });
       setShowRegForm(false);
       setRegForm({ date: "", requested_check_in: "", requested_check_out: "", reason: "" });
       setRegFormError(null);
@@ -232,6 +243,7 @@ export default function AttendancePage() {
                 type="date"
                 value={regForm.date}
                 onChange={(e) => setRegField("date", e.target.value)}
+                max={new Date().toISOString().slice(0, 10)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
                 required
               />
@@ -299,6 +311,68 @@ export default function AttendancePage() {
           </div>
         </form>
       )}
+
+      {/* My Regularization Requests — #1919 */}
+      <div className="bg-white rounded-xl border border-gray-200 mb-6">
+        <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">My Regularization Requests</h2>
+          {myRegRequests.length > 0 && (
+            <span className="text-xs text-gray-400">Showing latest {myRegRequests.length}</span>
+          )}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full">
+            <thead className="bg-gray-50 border-b border-gray-100">
+              <tr>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Date</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Reason</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3 whitespace-nowrap">Requested Check In</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3 whitespace-nowrap">Requested Check Out</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {regHistLoading ? (
+                <tr><td colSpan={5} className="px-6 py-6 text-center text-gray-400">Loading…</td></tr>
+              ) : myRegRequests.length === 0 ? (
+                <tr><td colSpan={5} className="px-6 py-6 text-center text-gray-400">No regularization requests yet.</td></tr>
+              ) : (
+                myRegRequests.map((r) => {
+                  const fmtTime = (v?: string | null) => {
+                    if (!v) return "-";
+                    const m = String(v).match(/(\d{2}):(\d{2})/);
+                    return m ? `${m[1]}:${m[2]}` : String(v);
+                  };
+                  return (
+                    <tr key={r.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-3 text-sm font-medium text-gray-900 whitespace-nowrap">
+                        {r.date ? new Date(r.date).toLocaleDateString() : "-"}
+                      </td>
+                      <td className="px-6 py-3 text-sm text-gray-600 max-w-xs truncate" title={r.reason}>
+                        {r.reason || "-"}
+                      </td>
+                      <td className="px-6 py-3 text-sm text-gray-600 whitespace-nowrap">{fmtTime(r.requested_check_in)}</td>
+                      <td className="px-6 py-3 text-sm text-gray-600 whitespace-nowrap">{fmtTime(r.requested_check_out)}</td>
+                      <td className="px-6 py-3">
+                        <span className={`text-xs px-2 py-1 rounded-full font-medium ${
+                          r.status === "approved" ? "bg-green-50 text-green-700"
+                            : r.status === "rejected" ? "bg-red-50 text-red-700"
+                            : "bg-amber-50 text-amber-700"
+                        }`}>{r.status}</span>
+                        {r.rejection_reason && (
+                          <p className="text-xs text-red-500 mt-1" title={r.rejection_reason}>
+                            {r.rejection_reason}
+                          </p>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
 
       {/* Month/Year Filters */}
       <div className="flex items-center gap-3 mb-4">

--- a/packages/client/src/pages/attendance/RegularizationsPage.tsx
+++ b/packages/client/src/pages/attendance/RegularizationsPage.tsx
@@ -129,7 +129,7 @@ export default function RegularizationsPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">{t('attendance.regularizations.date')} <span className="text-red-500">*</span></label>
-              <input type="date" value={form.date} onChange={(e) => setField("date", e.target.value)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" required />
+              <input type="date" value={form.date} onChange={(e) => setField("date", e.target.value)} max={new Date().toISOString().slice(0, 10)} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" required />
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">{t('attendance.regularizations.reason')} <span className="text-red-500">*</span></label>

--- a/packages/client/src/pages/attendance/ShiftSchedulePage.tsx
+++ b/packages/client/src/pages/attendance/ShiftSchedulePage.tsx
@@ -43,9 +43,20 @@ function formatDate(dateStr: string, locale: string): string {
   return d.toLocaleDateString(locale, { weekday: "short", month: "short", day: "numeric" });
 }
 
+// #1954 — `effective_from` / `effective_to` may arrive from the API as full
+// ISO strings ("2026-04-26T00:00:00.000Z"), but `date` is YYYY-MM-DD. Naive
+// `date < from` then treats the start day itself as out-of-range (the 'T'
+// suffix sorts after ''), so an assignment created for Sunday only rendered
+// from Monday onwards. Normalize both sides to the day part before comparing.
+function ymd(value: string | null | undefined): string {
+  return typeof value === "string" ? value.slice(0, 10) : "";
+}
+
 function isDateInRange(date: string, from: string, to: string | null): boolean {
-  if (date < from) return false;
-  if (to && date > to) return false;
+  const f = ymd(from);
+  const t = ymd(to);
+  if (date < f) return false;
+  if (t && date > t) return false;
   return true;
 }
 
@@ -452,7 +463,7 @@ export default function ShiftSchedulePage() {
             <select
               value={assignShiftId}
               onChange={(e) => setAssignShiftId(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-4"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm mb-2"
               required
             >
               <option value="">{t('attendance.shiftSchedule.bulk.selectShift')}</option>
@@ -462,6 +473,28 @@ export default function ShiftSchedulePage() {
                 </option>
               ))}
             </select>
+            {/* #1952 — warn when the picked shift doesn't include the chosen
+                day-of-week so admins don't silently create "Off" assignments. */}
+            {(() => {
+              const picked = shifts.find((s: any) => String(s.id) === assignShiftId);
+              if (!picked) return null;
+              const dow = new Date(showAssign.date + "T00:00:00").getDay();
+              const wd = String(picked.working_days ?? "1,2,3,4,5")
+                .split(",")
+                .filter(Boolean)
+                .map((d: string) => Number(d));
+              if (wd.length > 0 && !wd.includes(dow)) {
+                return (
+                  <p className="mb-3 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2">
+                    {t('attendance.shiftSchedule.quick.offDayWarning', {
+                      defaultValue:
+                        'This shift is off on the selected day. The schedule cell will show "Off" until you change the shift\'s working days.',
+                    })}
+                  </p>
+                );
+              }
+              return null;
+            })()}
             <div className="flex justify-end gap-2">
               <button type="button" onClick={() => setShowAssign(null)} className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg">
                 {t('common.cancel')}
@@ -651,15 +684,39 @@ export default function ShiftSchedulePage() {
                         const assignment = emp.assignments.find((a: any) =>
                           isDateInRange(date, a.effective_from, a.effective_to),
                         );
+                        // #1952 — A shift with working_days="1,2,3,4,5" is OFF on
+                        // weekends. Render "Off" on those cells so the schedule
+                        // reflects what the shift definition actually says.
+                        // dayOfWeek: 0=Sun..6=Sat (matches shift.working_days CSV).
+                        const dayOfWeek = new Date(date + "T00:00:00").getDay();
+                        const workingDays = (assignment?.working_days ?? "")
+                          .toString()
+                          .split(",")
+                          .filter(Boolean)
+                          .map((d: string) => Number(d));
+                        const isOffDay =
+                          assignment && workingDays.length > 0 && !workingDays.includes(dayOfWeek);
                         return (
                           <td key={date} className="px-2 py-3 text-center">
                             {assignment ? (
                               <div className="group relative inline-flex items-center gap-1">
-                                <span
-                                  className={`text-xs px-2 py-1 rounded-full font-medium ${shiftColors[assignment.shift_id] || "bg-gray-100 text-gray-700"}`}
-                                >
-                                  {assignment.shift_name}
-                                </span>
+                                {isOffDay ? (
+                                  <span
+                                    className="text-xs px-2 py-1 rounded-full font-medium bg-gray-100 text-gray-500"
+                                    title={t('attendance.shiftSchedule.team.offTooltip', {
+                                      defaultValue: '{{shift}} is off on this day',
+                                      shift: assignment.shift_name,
+                                    })}
+                                  >
+                                    {t('attendance.shiftSchedule.team.off', { defaultValue: 'Off' })}
+                                  </span>
+                                ) : (
+                                  <span
+                                    className={`text-xs px-2 py-1 rounded-full font-medium ${shiftColors[assignment.shift_id] || "bg-gray-100 text-gray-700"}`}
+                                  >
+                                    {assignment.shift_name}
+                                  </span>
+                                )}
                                 <span className="hidden group-hover:inline-flex items-center gap-0.5">
                                   <button
                                     onClick={() =>

--- a/packages/client/src/pages/events/EventsListPage.tsx
+++ b/packages/client/src/pages/events/EventsListPage.tsx
@@ -234,11 +234,16 @@ export default function EventsListPage() {
                           Join Online
                         </a>
                       )}
-                      <span className="flex items-center gap-1">
-                        <Users className="h-3.5 w-3.5" />
-                        {event.attending_count || 0} attending
-                        {event.max_attendees ? ` / ${event.max_attendees} max` : ""}
-                      </span>
+                      {/* #1948 — Hide the "0 attending" line when there are
+                          no RSVPs and no capacity cap; an unconditional "0"
+                          read as visual noise on cards for new events. */}
+                      {(event.attending_count > 0 || event.max_attendees) && (
+                        <span className="flex items-center gap-1">
+                          <Users className="h-3.5 w-3.5" />
+                          {event.attending_count || 0} attending
+                          {event.max_attendees ? ` / ${event.max_attendees} max` : ""}
+                        </span>
+                      )}
                     </div>
                   </div>
 

--- a/packages/client/src/pages/leave/CompOffPage.tsx
+++ b/packages/client/src/pages/leave/CompOffPage.tsx
@@ -16,6 +16,9 @@ interface CompOffRequest {
   approved_by: number | null;
   rejection_reason: string | null;
   created_at: string;
+  user_first_name?: string | null;
+  user_last_name?: string | null;
+  user_email?: string | null;
 }
 
 const STATUS_STYLES: Record<string, { bg: string; text: string; icon: typeof Clock }> = {
@@ -193,6 +196,7 @@ export default function CompOffPage() {
                 type="date"
                 value={form.worked_date}
                 onChange={(e) => handleWorkedDateChange(e.target.value)}
+                max={new Date().toISOString().slice(0, 10)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
                 required
               />
@@ -368,10 +372,19 @@ export default function CompOffPage() {
                   </td>
                 </tr>
               ) : (
-                pendingRequests.map((req) => (
+                pendingRequests.map((req) => {
+                  const fullName = [req.user_first_name, req.user_last_name]
+                    .filter(Boolean)
+                    .join(" ")
+                    .trim();
+                  const displayName =
+                    fullName ||
+                    req.user_email ||
+                    t('leave.compOff.userHash', { id: req.user_id });
+                  return (
                   <tr key={req.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4 text-sm font-medium text-gray-900">
-                      {t('leave.compOff.userHash', { id: req.user_id })}
+                      {displayName}
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-700">{req.worked_date}</td>
                     <td className="px-6 py-4 text-sm text-gray-700">{Number(req.days)}</td>
@@ -414,7 +427,8 @@ export default function CompOffPage() {
                       </div>
                     </td>
                   </tr>
-                ))
+                  );
+                })
               )}
             </tbody>
           </table>

--- a/packages/client/src/pages/leave/LeaveDashboardPage.tsx
+++ b/packages/client/src/pages/leave/LeaveDashboardPage.tsx
@@ -276,7 +276,24 @@ export default function LeaveDashboardPage() {
                 <option value={0} disabled>{t('leave.dashboard.selectType')}</option>
                 {leaveTypes
                   .filter((lt) => Boolean(lt.is_active))
-                  .filter((lt, i, arr) => arr.findIndex((x) => x.name === lt.name) === i)
+                  // #1917 / #1924 — When the org has duplicate leave_types rows
+                  // with the same display name (e.g. an old "SL" with 0 quota
+                  // and a re-added "Sick Leave" with the actual policy), this
+                  // dropdown previously kept the FIRST occurrence by name. The
+                  // dashboard balance card prefers the row that has an
+                  // allocated balance, so users saw "6 days available" but the
+                  // form silently submitted the empty type id, getting back
+                  // "No leave balance allocated". Use the same prefer-allocated
+                  // dedup logic as the card to keep the two views aligned.
+                  .filter((lt, _i, arr) => {
+                    const sameName = arr.filter((x) => x.name === lt.name);
+                    if (sameName.length === 1) return true;
+                    const withAllocation = sameName.find((x) => {
+                      const b = balances.find((bb) => bb.leave_type_id === x.id);
+                      return b && Number(b.total_allocated) > 0;
+                    });
+                    return withAllocation ? withAllocation.id === lt.id : sameName[0].id === lt.id;
+                  })
                   .map((lt) => (
                     <option key={lt.id} value={lt.id}>{leaveTypeLabel(t, lt)}</option>
                   ))}

--- a/packages/client/src/pages/settings/SettingsPage.tsx
+++ b/packages/client/src/pages/settings/SettingsPage.tsx
@@ -467,7 +467,7 @@ function LocationsCard({ locations }: { locations: any[] }) {
   const [deleteError, setDeleteError] = useState("");
 
   const addLoc = useMutation({
-    mutationFn: (data: { name: string; timezone?: string }) =>
+    mutationFn: (data: { name: string; timezone: string }) =>
       api.post("/organizations/me/locations", data).then((r) => r.data.data),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["locations"] });
@@ -548,12 +548,14 @@ function LocationsCard({ locations }: { locations: any[] }) {
           onSubmit={(e) => {
             e.preventDefault();
             setAddError("");
-            if (locForm.name.trim()) {
-              addLoc.mutate({
-                name: locForm.name.trim(),
-                timezone: locForm.timezone.trim() || undefined,
-              });
+            const name = locForm.name.trim();
+            const timezone = locForm.timezone.trim();
+            if (!name) return;
+            if (!timezone) {
+              setAddError("Timezone is required.");
+              return;
             }
+            addLoc.mutate({ name, timezone });
           }}
           className="flex gap-2"
         >
@@ -567,10 +569,12 @@ function LocationsCard({ locations }: { locations: any[] }) {
           />
           <select
             value={locForm.timezone}
-            onChange={(e) => setLocForm({ ...locForm, timezone: e.target.value })}
+            onChange={(e) => { setLocForm({ ...locForm, timezone: e.target.value }); setAddError(""); }}
             className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+            required
+            aria-required="true"
           >
-            <option value="">Select timezone</option>
+            <option value="">Select timezone *</option>
             {TIMEZONES.map((tz) => (
               <option key={tz} value={tz}>{tz}</option>
             ))}

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -362,8 +362,14 @@ export async function getDashboard(orgId: number) {
     .whereIn("status", ["present", "half_day", "checked_in"])
     .count("* as count");
 
+  // #1928 — The dashboard "Late today" count must match the breakdown drilldown.
+  // Breakdown only flags users whose record is present/half_day/checked_in AND
+  // has positive late_minutes; counting ALL records with late_minutes>0 here
+  // also pulled in stale rows whose status had since flipped to on_leave or
+  // absent, which made the card count bigger than the drilldown list.
   const [lateCount] = await db("attendance_records")
     .where({ organization_id: orgId, date: today })
+    .whereIn("status", ["present", "half_day", "checked_in"])
     .where("late_minutes", ">", 0)
     .count("* as count");
 

--- a/packages/server/src/services/leave/comp-off.service.ts
+++ b/packages/server/src/services/leave/comp-off.service.ts
@@ -69,14 +69,28 @@ export async function listCompOffs(
   const page = params.page || 1;
   const perPage = params.perPage || 20;
 
-  let query = db("comp_off_requests").where({ organization_id: orgId });
-  if (params.userId) query = query.where({ user_id: params.userId });
-  if (params.status) query = query.where({ status: params.status });
+  let countQuery = db("comp_off_requests").where({ organization_id: orgId });
+  if (params.userId) countQuery = countQuery.where({ user_id: params.userId });
+  if (params.status) countQuery = countQuery.where({ status: params.status });
 
-  const [{ count }] = await query.clone().count("* as count");
+  // #1932 — admin/HR view rendered "User #<id>" because the request rows
+  // weren't joined with users; surface first_name / last_name / email so the
+  // pending-approvals table can show real names.
+  let query = db("comp_off_requests as r")
+    .leftJoin("users as u", "r.user_id", "u.id")
+    .where("r.organization_id", orgId);
+  if (params.userId) query = query.where("r.user_id", params.userId);
+  if (params.status) query = query.where("r.status", params.status);
+
+  const [{ count }] = await countQuery.count("* as count");
   const requests = await query
-    .select()
-    .orderBy("created_at", "desc")
+    .select(
+      "r.*",
+      "u.first_name as user_first_name",
+      "u.last_name as user_last_name",
+      "u.email as user_email",
+    )
+    .orderBy("r.created_at", "desc")
     .limit(perPage)
     .offset((page - 1) * perPage);
 

--- a/packages/server/src/services/leave/leave-application.service.ts
+++ b/packages/server/src/services/leave/leave-application.service.ts
@@ -74,8 +74,16 @@ export async function applyLeave(
     .select("probation_status")
     .first();
   if (applicant && applicant.probation_status === "on_probation") {
-    const allowedCodes = ["sl", "sick", "eml", "emergency"];
-    if (!allowedCodes.includes(leaveType.code.toLowerCase())) {
+    // #1920 — Hard-matching on `leaveType.code` against ["sl","sick","eml","emergency"]
+    // missed the legitimate sick-leave rows whose codes admins had typed as
+    // "SICK_LEAVE", "SL_440514", "SICKLV", etc. Probationers were then told
+    // their sick-leave application was a non-sick leave. Match by name OR
+    // code substring so any leave whose label/code contains "sick" or
+    // "emergency" passes the probation gate.
+    const haystack = `${leaveType.name ?? ""} ${leaveType.code ?? ""}`.toLowerCase();
+    const allowedKeywords = ["sick", "emergency", "sl", "eml"];
+    const isAllowed = allowedKeywords.some((kw) => haystack.includes(kw));
+    if (!isAllowed) {
       throw new ValidationError(
         "Employees on probation can only apply for Sick Leave or Emergency Leave",
       );

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -325,7 +325,7 @@ export const updateDepartmentSchema = z.object({
 export const createLocationSchema = z.object({
   name: z.string().min(1).max(100),
   address: z.string().max(1000).optional(),
-  timezone: z.string().max(50).optional(),
+  timezone: z.string().min(1, "Timezone is required").max(50),
 });
 
 export const updateLocationSchema = z.object({
@@ -824,8 +824,16 @@ export const approveLeaveSchema = z.object({
   remarks: z.string().optional(),
 });
 
+// #1921 — worked_date represents a day already worked; must not be future.
+// Compare in YYYY-MM-DD form so timezone offsets don't accept "tomorrow in
+// UTC, today locally" or vice versa.
+const todayYmd = () => new Date().toISOString().slice(0, 10);
 export const createCompOffSchema = z.object({
-  worked_date: z.string(),
+  worked_date: z
+    .string()
+    .refine((v) => v.slice(0, 10) <= todayYmd(), {
+      message: "Worked date cannot be in the future",
+    }),
   expires_on: z.string(),
   reason: z.string().min(1),
   days: z.number().min(0.5).max(2).default(1),


### PR DESCRIPTION
## Summary

Addresses 14 of the currently-open issues against the dashboard / attendance / leave / comp-off flows. No schema changes; one cross-cutting validator update in `@empcloud/shared`. All TypeScript builds clean (server / shared / client).

Closes #1917, closes #1918, closes #1919, closes #1920, closes #1921, closes #1924, closes #1928, closes #1929, closes #1931, closes #1932, closes #1948, closes #1949, closes #1952, closes #1954.

Issues investigated but not changed (commented separately): #1857, #1946, #1933, #1930.
Already fixed in #1867 / now in main, awaiting reporter verification: #1817, #1818, #1816, #1822, #1560, #1651, #1650.

## Highlights

### Validation guards
- `createLocationSchema` makes timezone required (was `.optional()`); add-location form has `<select required>` + asterisk placeholder. (#1931)
- `createCompOffSchema.worked_date.refine` rejects future dates with a clear message; comp-off form uses `max=today`. (#1921)
- Regularization form uses `max=today` on both the admin page and the employee `/attendance/my` page (server-side guard already exists from #1386). (#1918)

### Shift schedule
- Fixed `isDateInRange` (string compare on ISO timestamp vs `YYYY-MM-DD` excluded the start day). Sunday assignments now render on Sunday. (#1954)
- Cells whose date-of-week falls outside the shift's `working_days` now render an explicit "Off" badge instead of pretending the shift is active. Quick Assign modal shows an inline warning when the picked shift has the chosen day off. (#1952)

### Leave / comp-off
- Apply-leave dropdown was de-duping by name picking the FIRST occurrence; the dashboard balance card preferred the row with an allocated balance, so users saw "6 days available" but the form silently submitted a zero-balance type id. Aligned the form to the card's dedup logic. (#1917, #1924)
- Probation gate now matches `sick` / `emergency` by substring against name OR code, so codes like `SICK_LEAVE`, `SL_440514`, `SICKLV` pass. (#1920)
- Comp-off pending approvals listing now LEFT-JOINs `users` and shows real names instead of `User #<id>`. (#1932)

### Attendance dashboard
- "Worked" column now shows a live `Date.now() - check_in` duration with a `(so far)` hint while a user is still checked in (was rendering 0 until checkout). (#1949)
- "Late today" KPI matched the breakdown drilldown â€” both now require `status IN (present, half_day, checked_in)` AND `late_minutes > 0`. (#1928)
- Header `Check In` / `Check Out` no longer wraps across two lines (`whitespace-nowrap`). (#1929)
- New `My Regularization Requests` section on `/attendance/my` so employees can see their pending / approved / rejected requests without hitting the admin page. (#1919)

### Community
- Hide the bare `0 attending` line on event cards when nobody has RSVP'd and there's no `max_attendees`. (#1948)

## Test plan

- [ ] Add Location with no timezone â€” submit blocked client and server side
- [ ] Submit comp-off with `worked_date` in the future â€” blocked both sides
- [ ] Submit regularization with future `date` â€” blocked client side
- [ ] Open Shift Schedule, click + on Sunday for a user, assign a shift with `working_days=1,2,3,4,5` â€” Sunday cell shows "Off", Monâ€“Fri show shift name
- [ ] Same flow with a 7-day shift â€” Sunday cell shows shift name (regression check on #1954)
- [ ] Multi-Sick-Leave org: dashboard card shows 6 days, apply form picks the populated row, submission succeeds
- [ ] Probationer applies sick leave whose `code` is `SICK_LEAVE` â€” accepted (was rejected before)
- [ ] Employee `/attendance/my` page lists their previously submitted regularization requests
- [ ] Currently checked-in user appears in attendance records with running worked time (e.g. `2h 14m (so far)`)
- [ ] Late count card matches drilldown list count
- [ ] Comp-off Pending Approvals tab shows employee names instead of `User #<id>`