### PR TITLE
fix: round 3 — shift schedule overlap, day/night mutex, comp-off credit UI

### DIFF
--- a/packages/client/src/pages/attendance/ShiftSchedulePage.tsx
+++ b/packages/client/src/pages/attendance/ShiftSchedulePage.tsx
@@ -640,7 +640,11 @@ export default function ShiftSchedulePage() {
             <table className="min-w-full">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3 sticky left-0 bg-gray-50 min-w-[180px]">
+                  {/* #1963 — sticky employee column needs an explicit z-index
+                      and a non-translucent border-right; without those, the
+                      scrolling shift badges painted over the employee name
+                      when the user scrolled the table horizontally. */}
+                  <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3 sticky left-0 z-20 bg-gray-50 border-r border-gray-200 min-w-[180px] shadow-[2px_0_4px_-2px_rgba(0,0,0,0.08)]">
                     {t('attendance.shiftSchedule.team.employee')}
                   </th>
                   {week.dates.map((date) => (
@@ -672,7 +676,7 @@ export default function ShiftSchedulePage() {
                 ) : (
                   pagedSchedule.map((emp: any) => (
                     <tr key={emp.user_id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 sticky left-0 bg-white">
+                      <td className="px-4 py-3 sticky left-0 z-10 bg-white group-hover:bg-gray-50 border-r border-gray-200 shadow-[2px_0_4px_-2px_rgba(0,0,0,0.06)]">
                         <div className="text-sm font-medium text-gray-900">
                           {emp.first_name} {emp.last_name}
                         </div>

--- a/packages/client/src/pages/attendance/ShiftsPage.tsx
+++ b/packages/client/src/pages/attendance/ShiftsPage.tsx
@@ -248,13 +248,21 @@ export default function ShiftsPage() {
                 </div>
               </div>
 
-              {/* Shift Options */}
+              {/* Shift Options — #1957: night and default are mutually
+                  exclusive. The "default" shift is the org's standard day
+                  shift; tagging a night shift as default would override
+                  it on every new employee. Ticking one auto-clears the
+                  other. */}
               <div className="flex items-center gap-4">
                 <label className="flex items-center gap-2.5 px-4 py-2.5 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-50 transition">
                   <input
                     type="checkbox"
                     checked={form.is_night_shift}
-                    onChange={(e) => set("is_night_shift", e.target.checked)}
+                    onChange={(e) => {
+                      const next = e.target.checked;
+                      set("is_night_shift", next);
+                      if (next) set("is_default", false);
+                    }}
                     className="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
                   />
                   <Moon className="h-4 w-4 text-indigo-500" />
@@ -264,7 +272,11 @@ export default function ShiftsPage() {
                   <input
                     type="checkbox"
                     checked={form.is_default}
-                    onChange={(e) => set("is_default", e.target.checked)}
+                    onChange={(e) => {
+                      const next = e.target.checked;
+                      set("is_default", next);
+                      if (next) set("is_night_shift", false);
+                    }}
                     className="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
                   />
                   <Sun className="h-4 w-4 text-amber-500" />

--- a/packages/client/src/pages/leave/CompOffPage.tsx
+++ b/packages/client/src/pages/leave/CompOffPage.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
-import { PlusCircle, Clock, CheckCircle2, XCircle, CalendarDays } from "lucide-react";
+import { PlusCircle, Clock, CheckCircle2, XCircle, CalendarDays, Plus } from "lucide-react";
 
 interface CompOffRequest {
   id: number;
@@ -103,6 +103,59 @@ export default function CompOffPage() {
     },
   });
 
+  // #1933 — HR-only manual credit/debit of an employee's comp-off balance.
+  // Loads the org's employee directory once when the form is opened, then
+  // posts to /leave/comp-off/balance/adjust. Negative days debit; the
+  // server rejects debits that would take a balance negative.
+  const [showCredit, setShowCredit] = useState(false);
+  const [creditForm, setCreditForm] = useState({ user_id: 0, days: 1, reason: "" });
+  const [creditError, setCreditError] = useState<string | null>(null);
+  const { data: employeesData } = useQuery({
+    queryKey: ["comp-off-employees"],
+    queryFn: () =>
+      api.get("/employees", { params: { per_page: 500 } }).then((r) => r.data.data || []),
+    enabled: !!isHR && showCredit,
+  });
+  const employeeOptions: Array<{ id: number; first_name: string; last_name: string; email?: string }> =
+    Array.isArray(employeesData) ? employeesData : [];
+  const creditMut = useMutation({
+    mutationFn: (data: typeof creditForm) =>
+      api
+        .post("/leave/comp-off/balance/adjust", {
+          user_id: data.user_id,
+          days: data.days,
+          reason: data.reason || undefined,
+        })
+        .then((r) => r.data.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["comp-off-balance"] });
+      qc.invalidateQueries({ queryKey: ["comp-off-pending"] });
+      qc.invalidateQueries({ queryKey: ["comp-off-my"] });
+      setShowCredit(false);
+      setCreditForm({ user_id: 0, days: 1, reason: "" });
+      setCreditError(null);
+    },
+    onError: (err: any) => {
+      setCreditError(
+        err?.response?.data?.error?.message ||
+          "Failed to adjust balance. Check the days and try again.",
+      );
+    },
+  });
+  const handleCreditSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreditError(null);
+    if (!creditForm.user_id) {
+      setCreditError("Please pick an employee.");
+      return;
+    }
+    if (!Number.isFinite(creditForm.days) || creditForm.days === 0) {
+      setCreditError("Enter a non-zero number of days.");
+      return;
+    }
+    creditMut.mutate(creditForm);
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     submitMut.mutate(form);
@@ -128,13 +181,106 @@ export default function CompOffPage() {
             {t('leave.compOff.subtitle')}
           </p>
         </div>
-        <button
-          onClick={() => setShowForm(!showForm)}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
-        >
-          <PlusCircle className="h-4 w-4" /> {t('leave.compOff.request')}
-        </button>
+        <div className="flex items-center gap-2">
+          {/* #1933 — HR-only Credit Balance entry point. Lets admins grant
+              comp-off days without going through the request/approve flow. */}
+          {isHR && (
+            <button
+              onClick={() => setShowCredit((v) => !v)}
+              className="flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-emerald-700"
+            >
+              <Plus className="h-4 w-4" /> Credit Balance
+            </button>
+          )}
+          <button
+            onClick={() => setShowForm(!showForm)}
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          >
+            <PlusCircle className="h-4 w-4" /> {t('leave.compOff.request')}
+          </button>
+        </div>
       </div>
+
+      {/* Credit Balance Form (HR-only, #1933) */}
+      {isHR && showCredit && (
+        <form
+          onSubmit={handleCreditSubmit}
+          className="bg-white rounded-xl border border-emerald-200 p-6 mb-8"
+        >
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Credit / Debit Comp-Off Balance</h2>
+          <p className="text-xs text-gray-500 mb-4">
+            Manually grant days to an employee's comp-off balance. Use a negative number to debit.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="lg:col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Employee <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={creditForm.user_id || ""}
+                onChange={(e) => setCreditForm({ ...creditForm, user_id: Number(e.target.value) })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+                required
+              >
+                <option value="">— Select employee —</option>
+                {employeeOptions.map((emp) => (
+                  <option key={emp.id} value={emp.id}>
+                    {emp.first_name} {emp.last_name}
+                    {emp.email ? ` · ${emp.email}` : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Days <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                step="0.5"
+                value={creditForm.days}
+                onChange={(e) => setCreditForm({ ...creditForm, days: Number(e.target.value) })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                required
+              />
+              <p className="text-xs text-gray-400 mt-1">Positive to credit, negative to debit.</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Reason</label>
+              <input
+                type="text"
+                value={creditForm.reason}
+                onChange={(e) => setCreditForm({ ...creditForm, reason: e.target.value })}
+                placeholder="e.g. Year-end carry forward"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              />
+            </div>
+          </div>
+          {creditError && (
+            <p className="mt-3 text-sm text-red-600">{creditError}</p>
+          )}
+          <div className="flex justify-end gap-3 mt-4">
+            <button
+              type="button"
+              onClick={() => {
+                setShowCredit(false);
+                setCreditError(null);
+                setCreditForm({ user_id: 0, days: 1, reason: "" });
+              }}
+              className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={creditMut.isPending}
+              className="flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-emerald-700 disabled:opacity-50"
+            >
+              {creditMut.isPending ? "Saving..." : "Apply Adjustment"}
+            </button>
+          </div>
+        </form>
+      )}
 
       {/* Balance Card */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">

--- a/packages/server/src/api/routes/leave.routes.ts
+++ b/packages/server/src/api/routes/leave.routes.ts
@@ -399,6 +399,33 @@ router.get("/comp-off/pending", authenticate, async (req: Request, res: Response
   } catch (err) { next(err); }
 });
 
+// POST /api/v1/leave/comp-off/balance/adjust — HR-only manual credit/debit
+// of an employee's comp-off balance (bypasses the request/approve flow).
+// #1933 — admins had no way to grant comp-off without an employee request.
+router.post("/comp-off/balance/adjust", authenticate, requireHR, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = Number(req.body.user_id);
+    const days = Number(req.body.days);
+    const reason = typeof req.body.reason === "string" ? req.body.reason.trim() || undefined : undefined;
+    if (!Number.isFinite(userId) || userId <= 0) {
+      throw new ValidationError("user_id is required");
+    }
+    const result = await compOffService.adjustCompOffBalance(req.user!.org_id, userId, days, reason);
+
+    await logAudit({
+      organizationId: req.user!.org_id,
+      userId: req.user!.sub,
+      action: AuditAction.LEAVE_BALANCE_ADJUSTED,
+      resourceType: "leave_balance",
+      resourceId: `comp_off:user:${userId}`,
+      ipAddress: req.ip,
+      userAgent: req.headers["user-agent"],
+      details: { days, reason: reason ?? null, ...result },
+    });
+    sendSuccess(res, result);
+  } catch (err) { next(err); }
+});
+
 // GET /api/v1/leave/comp-off/balance — My comp-off leave balance
 router.get("/comp-off/balance", authenticate, async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/packages/server/src/services/attendance/shift.service.ts
+++ b/packages/server/src/services/attendance/shift.service.ts
@@ -41,6 +41,16 @@ export async function updateShift(orgId: number, shiftId: number, data: Partial<
   const shift = await db("shifts").where({ id: shiftId, organization_id: orgId }).first();
   if (!shift) throw new NotFoundError("Shift");
 
+  // #1957 — guard the partial-update case: a PATCH that only flips one of
+  // (is_default, is_night_shift) wouldn't be caught by the validator's
+  // both-fields-present refine, but combined with the existing row's value
+  // could still end up with a shift that's both default AND night.
+  const willBeDefault = data.is_default ?? !!shift.is_default;
+  const willBeNight = data.is_night_shift ?? !!shift.is_night_shift;
+  if (willBeDefault && willBeNight) {
+    throw new ValidationError("A shift cannot be both the default shift and a night shift");
+  }
+
   if (data.is_default) {
     await db("shifts")
       .where({ organization_id: orgId, is_default: true })

--- a/packages/server/src/services/leave/comp-off.service.ts
+++ b/packages/server/src/services/leave/comp-off.service.ts
@@ -188,6 +188,94 @@ export async function approveCompOff(
   return getCompOff(orgId, id);
 }
 
+// #1933 — admin credit/debit of an employee's comp-off balance without
+// going through the request-approve flow (e.g. carry-forward at year start,
+// one-off goodwill grant, correcting a stale balance). Days can be negative
+// to debit. Creates the COMP_OFF leave_type row on demand if the org is
+// missing one, mirroring the behaviour of approveCompOff.
+export async function adjustCompOffBalance(
+  orgId: number,
+  targetUserId: number,
+  days: number,
+  // `reason` is captured by the route audit log; the leave_balances table
+  // has no remarks column, so we don't persist it on the row itself.
+  _reason?: string,
+): Promise<{ balance: number; total_allocated: number; year: number }> {
+  if (!Number.isFinite(days) || days === 0) {
+    throw new ValidationError("Days must be a non-zero number");
+  }
+  const db = getDB();
+  const targetUser = await db("users")
+    .where({ id: targetUserId, organization_id: orgId })
+    .first();
+  if (!targetUser) throw new NotFoundError("Employee");
+
+  let compOffType = await db("leave_types")
+    .where({ organization_id: orgId, code: "COMP_OFF" })
+    .first();
+  if (!compOffType) {
+    const [id] = await db("leave_types").insert({
+      organization_id: orgId,
+      name: "Compensatory Off",
+      code: "COMP_OFF",
+      is_paid: true,
+      is_carry_forward: true,
+      max_carry_forward_days: 30,
+      is_active: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    compOffType = await db("leave_types").where({ id }).first();
+  }
+
+  const year = new Date().getFullYear();
+  const balance = await db("leave_balances")
+    .where({
+      organization_id: orgId,
+      user_id: targetUserId,
+      leave_type_id: compOffType.id,
+      year,
+    })
+    .first();
+
+  if (balance) {
+    const nextAllocated = Number(balance.total_allocated) + days;
+    const nextBalance = Number(balance.balance) + days;
+    if (nextBalance < 0) {
+      throw new ValidationError(
+        `Adjustment would make balance negative (current: ${balance.balance} day(s), requested: ${days})`,
+      );
+    }
+    await db("leave_balances").where({ id: balance.id }).update({
+      total_allocated: nextAllocated,
+      balance: nextBalance,
+      updated_at: new Date(),
+    });
+    return {
+      balance: nextBalance,
+      total_allocated: nextAllocated,
+      year,
+    };
+  } else {
+    if (days < 0) {
+      throw new ValidationError("Cannot debit comp-off balance — no balance allocated yet");
+    }
+    await db("leave_balances").insert({
+      organization_id: orgId,
+      user_id: targetUserId,
+      leave_type_id: compOffType.id,
+      year,
+      total_allocated: days,
+      total_used: 0,
+      total_carry_forward: 0,
+      balance: days,
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    return { balance: days, total_allocated: days, year };
+  }
+}
+
 export async function rejectCompOff(
   orgId: number,
   approverId: number,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -106,6 +106,7 @@ export enum AuditAction {
   LEAVE_APPROVED = "leave_approved",
   LEAVE_REJECTED = "leave_rejected",
   LEAVE_CANCELLED = "leave_cancelled",
+  LEAVE_BALANCE_ADJUSTED = "leave_balance_adjusted",
   DOCUMENT_UPLOADED = "document_uploaded",
   DOCUMENT_VERIFIED = "document_verified",
   ANNOUNCEMENT_CREATED = "announcement_created",

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -581,10 +581,18 @@ const shiftBaseSchema = z.object({
   half_days: halfDaysField.default(""),
 });
 
-export const createShiftSchema = shiftBaseSchema.refine(
-  (data) => data.start_time !== data.end_time,
-  { message: "Start time and end time cannot be the same", path: ["end_time"] }
-);
+export const createShiftSchema = shiftBaseSchema
+  .refine(
+    (data) => data.start_time !== data.end_time,
+    { message: "Start time and end time cannot be the same", path: ["end_time"] }
+  )
+  // #1957 — A shift cannot be both `is_default` (the org's standard day shift
+  // assigned to new employees) AND `is_night_shift`. Tagging a night shift
+  // as default would silently override the day shift on every new hire.
+  .refine(
+    (data) => !(data.is_default && data.is_night_shift),
+    { message: "A shift cannot be both the default shift and a night shift", path: ["is_night_shift"] }
+  );
 
 // #1356 — updateShiftSchema must NOT inherit defaults from shiftBaseSchema
 // (partial() keeps defaults, which overwrite unchanged fields on PATCH)
@@ -609,6 +617,18 @@ export const updateShiftSchema = z
       return true;
     },
     { message: "Start time and end time cannot be the same", path: ["end_time"] }
+  )
+  // #1957 — same mutex as createShiftSchema for the PATCH path. Only
+  // applies when both flags are present in the request body; partial
+  // updates that touch one flag at a time still work.
+  .refine(
+    (data) => {
+      if (data.is_default !== undefined && data.is_night_shift !== undefined) {
+        return !(data.is_default && data.is_night_shift);
+      }
+      return true;
+    },
+    { message: "A shift cannot be both the default shift and a night shift", path: ["is_night_shift"] }
   );
 
 export const assignShiftSchema = z.object({


### PR DESCRIPTION
## Summary

Closes #1933, closes #1957, closes #1963.

Three open issues against the attendance / leave area. No schema changes; one new audit-action enum value, one new HR-only POST endpoint, the rest are surgical UI / validator tweaks. All TypeScript builds clean.

Also re-commented (no code change yet, awaiting reporter info): #1857, #1930, #1946.
Already acknowledged feature requests (no code in this PR): #1642, #1643, #1645.

## Highlights

### #1963 Shift Schedule sticky-column overlap
The sticky Employee column had no `z-index`, so when the user scrolled the schedule horizontally the colored shift badges painted on top of the employee name. Added `z-20` on the header / `z-10` on the body cells, plus a `1px` right border and a soft right-side shadow so the separation is visible at every scroll position.

### #1957 Default + Night shift are now mutually exclusive
- **Frontend** — Add/Edit Shift modal: ticking either box auto-clears the other.
- **Validators** — `createShiftSchema` and `updateShiftSchema` reject `is_default && is_night_shift` (with the right precondition for partial PATCHes).
- **Service** — `updateShift` re-checks against the existing row's value so a PATCH that flips one flag in isolation can't end up at both-true through composition.

Why this matters: the "default" shift is the org's standard day shift (auto-assigned to new employees). Tagging a night shift as default would silently override the day shift for every new hire.

### #1933 Admin comp-off balance credit UI
HR users now have a `Credit Balance` button on the Comp-Off page that opens a form: employee picker + days + optional reason. Negative days debit; the server rejects debits that would take a balance negative.

- New endpoint: `POST /leave/comp-off/balance/adjust` (requires `hr_admin` or higher)
- New service: `compOffService.adjustCompOffBalance(orgId, userId, days, reason)`
- New audit action: `LEAVE_BALANCE_ADJUSTED` with the days/reason in the audit log details
- The `COMP_OFF` leave_type row is created on demand if the org doesn't have one yet (mirrors the on-demand creation in `approveCompOff`)

## Test plan

- [ ] Open Shift Schedule, scroll horizontally — employee names stay visible, no shift badges painted over them
- [ ] Add Shift modal: tick "Default" → "Night" auto-unchecks (and vice versa)
- [ ] POST `/attendance/shifts` with `{is_default: true, is_night_shift: true}` via curl — 400 with the mutex message
- [ ] PATCH a night shift to `{is_default: true}` — 400 with the same message
- [ ] As HR, open Comp-Off → click "Credit Balance" → pick employee + 5 days → submit → balance card on that user's view shows the new total
- [ ] As HR, debit 100 days from a 0-balance user — server returns a 400 explaining the negative-balance guard
- [ ] Audit Log shows the `LEAVE_BALANCE_ADJUSTED` event with the right days/reason
- [ ] Submit credit as a non-HR user — 403