### PR TITLE
fix(assets): enforce assets:view permission on asset listing and deta…

### DIFF
--- a/packages/server/src/api/routes/asset.routes.ts
+++ b/packages/server/src/api/routes/asset.routes.ts
@@ -152,6 +152,7 @@ router.post(
 router.get(
   "/my",
   authenticate,
+  requirePermission("assets:view", "assets:manage"),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const assets = await assetService.getMyAssets(req.user!.org_id, req.user!.sub);
@@ -401,6 +402,7 @@ router.get(
 router.get(
   "/",
   authenticate,
+  requirePermission("assets:view", "assets:manage"),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const hr = isHRUser(req);
@@ -432,6 +434,7 @@ router.get(
 router.get(
   "/:id",
   authenticate,
+  requirePermission("assets:view", "assets:manage"),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const asset = await assetService.getAsset(


### PR DESCRIPTION
…il routes

GET /assets, GET /assets/my and GET /assets/:id were gated only by authenticate, so an employee whose role had no asset permissions could still see their assigned assets through these endpoints. Add requirePermission to all three, allowing assets:manage as an OR alternative so HR users with only manage continue to work.

Closes #2011