### PR TITLE
fix(chatbot): hide AI Assistant UI for users without chatbot:use perm…

### DIFF
--- a/packages/client/src/components/ChatWidget.tsx
+++ b/packages/client/src/components/ChatWidget.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import api from "@/api/client";
+import { usePermissions } from "@/lib/use-permissions";
 import {
   MessageCircle,
   Send,
@@ -110,6 +111,8 @@ export default function ChatWidget() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { i18n } = useTranslation();
+  const { has } = usePermissions();
+  const canUseChatbot = has("chatbot:use");
   const [isOpen, setIsOpen] = useState(false);
   const [convoId, setConvoId] = useState<number | null>(null);
   const [input, setInput] = useState("");
@@ -121,7 +124,7 @@ export default function ChatWidget() {
   const { data: aiStatus } = useQuery<{ engine: string; provider: string }>({
     queryKey: ["chatbot-ai-status"],
     queryFn: () => api.get("/chatbot/ai-status").then((r) => r.data.data),
-    enabled: isOpen,
+    enabled: isOpen && canUseChatbot,
     staleTime: 60_000,
   });
 
@@ -129,14 +132,14 @@ export default function ChatWidget() {
   const { data: suggestions = [] } = useQuery<string[]>({
     queryKey: ["chatbot-suggestions"],
     queryFn: () => api.get("/chatbot/suggestions").then((r) => r.data.data),
-    enabled: isOpen,
+    enabled: isOpen && canUseChatbot,
   });
 
   // Fetch messages
   const { data: messages = [] } = useQuery<Message[]>({
     queryKey: ["chatbot-widget-messages", convoId],
     queryFn: () => api.get(`/chatbot/conversations/${convoId}`).then((r) => r.data.data),
-    enabled: !!convoId,
+    enabled: !!convoId && canUseChatbot,
   });
 
   // Create conversation
@@ -191,6 +194,8 @@ export default function ChatWidget() {
     setIsOpen(false);
     navigate("/chatbot");
   }, [navigate]);
+
+  if (!canUseChatbot) return null;
 
   if (!isOpen) {
     return (

--- a/packages/client/src/components/layout/navigation.config.ts
+++ b/packages/client/src/components/layout/navigation.config.ts
@@ -74,7 +74,7 @@ export type NavItem = {
 export const employeeNavItems: NavItem[] = [
   { path: "/", label: "Dashboard", i18nKey: "nav.dashboard", icon: LayoutDashboard },
   { path: "/my-profile", label: "My Profile", i18nKey: "nav.myProfile", icon: Contact },
-  { path: "/chatbot", label: "AI Assistant", i18nKey: "nav.chatbot", icon: BotMessageSquare, badge: "AI" },
+  { path: "/chatbot", label: "AI Assistant", i18nKey: "nav.chatbot", icon: BotMessageSquare, badge: "AI", requiredPermissions: ["chatbot:use"] },
   { path: "/manager", label: "My Team", i18nKey: "nav.myTeam", icon: UsersRound },
   { path: "/attendance/my", label: "Attendance", i18nKey: "nav.attendance", icon: Clock },
   { path: "/leave", label: "Leave & Time Off", i18nKey: "nav.leave", icon: CalendarDays, children: [
@@ -129,7 +129,7 @@ export const adminNavItems: NavItem[] = [
     { path: "/employees/probation", label: "Probation", i18nKey: "nav.probation", icon: UserCheck, requiredPermissions: ["employees:view_all", "employees:edit_all"] },
     { path: "/org-chart", label: "Org Chart", i18nKey: "nav.orgChart", icon: Network },
   ]},
-  { path: "/chatbot", label: "AI Assistant", i18nKey: "nav.chatbot", icon: BotMessageSquare, badge: "AI" },
+  { path: "/chatbot", label: "AI Assistant", i18nKey: "nav.chatbot", icon: BotMessageSquare, badge: "AI", requiredPermissions: ["chatbot:use"] },
   { path: "/manager", label: "My Team", i18nKey: "nav.myTeam", icon: UsersRound },
   { path: "/attendance", label: "Attendance", i18nKey: "nav.attendance", icon: Clock, requiredPermissions: ["attendance:view_team", "attendance:view_all", "attendance:approve_regularization_team", "attendance:approve_regularization_all", "attendance:manage"], children: [
     // The "View Attendance" page (AttendanceDashboardPage) renders the


### PR DESCRIPTION
…ission

The floating ChatWidget and both 'AI Assistant' sidebar items rendered unconditionally — so a user whose role had chatbot:use revoked still saw the chat bubble and the nav link even though the API correctly returned
403. Read the permission claim from the JWT via usePermissions(), early- return null from ChatWidget when chatbot:use is missing, and add requiredPermissions: ['chatbot:use'] to both nav entries so the existing nav-filter hides them.

Closes #2001