### PR TITLE
fix(announcements): hide announcement UI for users without announceme…

### DIFF
--- a/packages/client/src/components/layout/navigation.config.ts
+++ b/packages/client/src/components/layout/navigation.config.ts
@@ -84,7 +84,7 @@ export const employeeNavItems: NavItem[] = [
   ]},
   { path: "/documents", label: "Company", i18nKey: "nav.company", icon: Building2, children: [
     { path: "/documents", label: "Documents", i18nKey: "nav.documents", icon: FileText },
-    { path: "/announcements", label: "Announcements", i18nKey: "nav.announcements", icon: Megaphone },
+    { path: "/announcements", label: "Announcements", i18nKey: "nav.announcements", icon: Megaphone, requiredPermissions: ["announcements:view", "announcements:create", "announcements:manage"] },
     { path: "/policies", label: "Policies", i18nKey: "nav.policies", icon: BookOpen },
   ]},
   { path: "/org-chart", label: "Org Chart", i18nKey: "nav.orgChart", icon: Network },
@@ -156,7 +156,7 @@ export const adminNavItems: NavItem[] = [
   ]},
   { path: "/documents", label: "Company", i18nKey: "nav.company", icon: Building2, children: [
     { path: "/documents", label: "Documents", i18nKey: "nav.documents", icon: FileText },
-    { path: "/announcements", label: "Announcements", i18nKey: "nav.announcements", icon: Megaphone },
+    { path: "/announcements", label: "Announcements", i18nKey: "nav.announcements", icon: Megaphone, requiredPermissions: ["announcements:view", "announcements:create", "announcements:manage"] },
     { path: "/policies", label: "Policies", i18nKey: "nav.policies", icon: BookOpen },
   ]},
   { path: "/helpdesk/my-tickets", label: "Workplace", i18nKey: "nav.workplace", icon: Headphones, children: [

--- a/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
+++ b/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
+import { usePermissions } from "@/lib/use-permissions";
 import { leaveTypeLabel } from "@/lib/leave-type-label";
 import { useAttendancePolicy } from "@/lib/use-attendance-policy";
 import { showToast } from "@/components/ui/Toast";
@@ -43,6 +44,12 @@ export default function SelfServiceDashboardPage() {
   const user = useAuthStore((s) => s.user);
   const qc = useQueryClient();
   const { dashboardAllowed } = useAttendancePolicy();
+  const { has } = usePermissions();
+  const canViewAnnouncements = has(
+    "announcements:view",
+    "announcements:create",
+    "announcements:manage",
+  );
 
   // Attendance today
   const { data: attendanceData } = useQuery({
@@ -122,6 +129,7 @@ export default function SelfServiceDashboardPage() {
         .get("/announcements", { params: { page: 1, per_page: 5 } })
         .then((r) => r.data.data)
         .catch(() => []),
+    enabled: canViewAnnouncements,
   });
 
   // Policies to acknowledge
@@ -363,7 +371,7 @@ export default function SelfServiceDashboardPage() {
         </div>
 
         {/* Recent Announcements — only render when there are items */}
-        {announcementList.length > 0 && (
+        {canViewAnnouncements && announcementList.length > 0 && (
           <div className="bg-white border border-gray-200 rounded-xl p-6">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
…nts:view

The 'Recent Announcements' card on SelfServiceDashboardPage and both 'Announcements' sidebar items (employee + admin) rendered unconditionally — so a user whose role had every announcements:* permission revoked still saw the card on their dashboard and the entry in the sidebar. Read the permission claim from the JWT via usePermissions(), gate the dashboard query + card on announcements:view / create / manage, and add requiredPermissions to the two nav entries so the existing nav-filter hides them.

Closes #2000