### PR TITLE
feat(attendance): full-month My Attendance with holiday / week-off / absent classification

### DIFF
--- a/packages/client/src/pages/attendance/AttendancePage.tsx
+++ b/packages/client/src/pages/attendance/AttendancePage.tsx
@@ -532,21 +532,30 @@ export default function AttendancePage() {
               <tr><td colSpan={8} className="px-6 py-8 text-center text-gray-400">No records for this month</td></tr>
             ) : (
               records.map((r: any) => {
-                const expanded = expandedRowId === r.id;
+                // Synthesized rows (holiday / week_off / absent with no real
+                // attendance_records row) have no punches timeline to show,
+                // so we hide the chevron entirely. The server marks them with
+                // `synthesized: true`; we also fall back to a negative-id
+                // check in case an older response lacks that flag.
+                const isSynth = r.synthesized === true || (typeof r.id === "number" && r.id < 0);
+                const canExpand = !isSynth;
+                const expanded = canExpand && expandedRowId === r.id;
                 return (
                   <Fragment key={r.id}>
                   <tr className="hover:bg-gray-50">
                     <td className="px-3 py-4 w-10">
-                      <button
-                        type="button"
-                        onClick={() => setExpandedRowId(expanded ? null : r.id)}
-                        className="inline-flex items-center justify-center p-1.5 rounded text-gray-500 hover:bg-gray-100"
-                        aria-label={expanded ? "Collapse timeline" : "Expand timeline"}
-                        title={expanded ? "Hide timeline" : "Show timeline"}
-                        aria-expanded={expanded}
-                      >
-                        {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-                      </button>
+                      {canExpand && (
+                        <button
+                          type="button"
+                          onClick={() => setExpandedRowId(expanded ? null : r.id)}
+                          className="inline-flex items-center justify-center p-1.5 rounded text-gray-500 hover:bg-gray-100"
+                          aria-label={expanded ? "Collapse timeline" : "Expand timeline"}
+                          title={expanded ? "Hide timeline" : "Show timeline"}
+                          aria-expanded={expanded}
+                        >
+                          {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+                        </button>
+                      )}
                     </td>
                     <td className="px-6 py-4 text-sm font-medium text-gray-900">{new Date(r.date).toLocaleDateString()}</td>
                     <td className="px-6 py-4 text-sm text-gray-600">{r.check_in ? new Date(r.check_in).toLocaleTimeString() : "-"}</td>
@@ -560,9 +569,15 @@ export default function AttendancePage() {
                           : r.status === "checked_in" ? "bg-brand-50 text-brand-700"
                           : r.status === "half_day" ? "bg-yellow-50 text-yellow-700"
                           : r.status === "on_leave" ? "bg-blue-50 text-blue-700"
+                          : r.status === "holiday" ? "bg-purple-50 text-purple-700"
+                          : r.status === "week_off" ? "bg-gray-100 text-gray-600"
                           : "bg-red-50 text-red-700"
                       }`}>
-                        {r.status === "checked_in" ? "checked in" : r.status.replace(/_/g, " ")}
+                        {r.status === "checked_in"
+                          ? "checked in"
+                          : r.status === "holiday" && r.holiday_name
+                            ? r.holiday_name
+                            : r.status.replace(/_/g, " ")}
                       </span>
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-600">{r.late_minutes ? `${Math.floor(r.late_minutes / 60)}h ${r.late_minutes % 60}m` : "-"}</td>
@@ -577,15 +592,20 @@ export default function AttendancePage() {
                         >
                           <Pencil className="w-4 h-4" />
                         </button>
-                        <button
-                          type="button"
-                          onClick={() => setDetailRecord(r)}
-                          className="inline-flex items-center justify-center p-1.5 rounded text-brand-600 hover:bg-brand-50"
-                          aria-label="View attendance details"
-                          title="View details"
-                        >
-                          <Eye className="w-4 h-4" />
-                        </button>
+                        {/* View-details opens the modal that fetches the
+                            punches timeline by record id; synthesized rows
+                            have no real id, so the modal would 404. Hide it. */}
+                        {canExpand && (
+                          <button
+                            type="button"
+                            onClick={() => setDetailRecord(r)}
+                            className="inline-flex items-center justify-center p-1.5 rounded text-brand-600 hover:bg-brand-50"
+                            aria-label="View attendance details"
+                            title="View details"
+                          >
+                            <Eye className="w-4 h-4" />
+                          </button>
+                        )}
                       </div>
                     </td>
                   </tr>

--- a/packages/server/src/api/routes/attendance.routes.ts
+++ b/packages/server/src/api/routes/attendance.routes.ts
@@ -483,16 +483,20 @@ router.get("/me/today", authenticate, requirePermission("attendance:view", "atte
 });
 
 // GET /api/v1/attendance/me/history
+//
+// Returns one row per calendar day in the requested month (defaults to the
+// current month). Days with no attendance_records row come back synthesized
+// with status="absent" so the My Attendance page never has gaps. Because
+// the response is bounded (28-31 days), pagination is no-op here — we emit
+// total_pages=1 by setting per_page = records.length.
 router.get("/me/history", authenticate, requirePermission("attendance:view", "attendance:view_team", "attendance:view_all", "attendance:manage"), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const params = attendanceQuerySchema.parse(req.query);
     const result = await attendanceService.getMyHistory(req.user!.org_id, req.user!.sub, {
-      page: params.page,
-      perPage: params.per_page,
       month: params.month,
       year: params.year,
     });
-    sendPaginated(res, result.records, result.total, params.page, params.per_page);
+    sendPaginated(res, result.records, result.total, 1, Math.max(result.records.length, 1));
   } catch (err) { next(err); }
 });
 

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -481,15 +481,23 @@ export async function getMyHistory(
     return String(v).slice(0, 10);
   };
 
-  // Fetch existing attendance_records, holidays, and the user's active shift in
-  // parallel — three independent queries.
+  // Fetch existing records + holidays from BOTH sources + the user's shift
+  // assignments in parallel.
   //
-  // Holidays live in `company_events` rows where event_type='holiday'. The same
-  // table powers /events/holidays and is the canonical source the rest of the
-  // app reads from. We pull anything whose date range *overlaps* the requested
-  // month so multi-day holidays (e.g. Diwali week) light up every day they cover,
-  // not just the start_date.
-  const [existing, holidays, shiftRow] = await Promise.all([
+  // Holidays:
+  //   - `company_events` rows where event_type='holiday' is the canonical
+  //     source (powers /events/holidays).
+  //   - `organization_holidays` is a legacy table the Attendance Grid still
+  //     reads. We union both so a holiday stored only in the legacy table
+  //     still shows up here (parity with the Grid).
+  //
+  // Shift:
+  //   - Match the Grid's lookup exactly — order by created_at desc (latest
+  //     intent wins), tiebreak on id desc — and surface `is_weekoff` so the
+  //     per-assignment "Mark as Week-off" toggle is honored. The Grid then
+  //     uses first-write-wins per (user, date). We replicate that here for
+  //     a single user.
+  const [existing, eventHolidays, legacyHolidays, assignments] = await Promise.all([
     db("attendance_records")
       .where({ organization_id: orgId, user_id: userId })
       .whereBetween("date", [startDate, endDate])
@@ -502,19 +510,26 @@ export async function getMyHistory(
         this.where("end_date", ">=", `${startDate} 00:00:00`).orWhereNull("end_date");
       })
       .select("title", "start_date", "end_date"),
-    // Pull the user's currently-effective shift to know their weekly off days.
-    // Falls back to Mon-Fri (1-5) if the user has no assignment.
+    // Legacy fallback table. Some older deployments still write here only.
+    // Returning [] on schema-mismatch / missing-table is what the Grid does
+    // too — see getMonthlyGrid above.
+    db("organization_holidays")
+      .where({ organization_id: orgId })
+      .whereBetween("holiday_date", [startDate, endDate])
+      .select("holiday_date", "holiday_name")
+      .catch(() => [] as Array<{ holiday_date: any; holiday_name: string }>),
     db("shift_assignments as sa")
+      .join("shifts as s", "sa.shift_id", "s.id")
       .where("sa.organization_id", orgId)
       .andWhere("sa.user_id", userId)
-      .andWhere("sa.effective_from", "<=", endDate)
+      .whereRaw("DATE(sa.effective_from) <= ?", [endDate])
       .andWhere(function () {
-        this.whereNull("sa.effective_to").orWhere("sa.effective_to", ">=", startDate);
+        this.whereNull("sa.effective_to").orWhereRaw("DATE(sa.effective_to) >= ?", [startDate]);
       })
-      .leftJoin("shifts as s", "sa.shift_id", "s.id")
-      .orderBy("sa.effective_from", "desc")
-      .select("s.working_days as working_days")
-      .first(),
+      .whereRaw("(sa.effective_to IS NULL OR DATE(sa.effective_to) >= DATE(sa.effective_from))")
+      .orderBy("sa.created_at", "desc")
+      .orderBy("sa.id", "desc")
+      .select("sa.effective_from", "sa.effective_to", "s.working_days", "s.is_weekoff"),
   ]);
 
   const byDate = new Map<string, any>();
@@ -528,15 +543,14 @@ export async function getMyHistory(
   // requested [startDate, endDate] window so we don't iterate beyond what
   // we'll render.
   const holidayByDate = new Map<string, string>();
-  const monthStart = new Date(year, month - 1, 1);
-  const monthEnd = new Date(year, month - 1, daysInMonth);
-  for (const h of holidays as any[]) {
+  const monthStartDate = new Date(year, month - 1, 1);
+  const monthEndDate = new Date(year, month - 1, daysInMonth);
+  for (const h of eventHolidays as any[]) {
     const start = new Date(h.start_date);
     const end = h.end_date ? new Date(h.end_date) : new Date(h.start_date);
     if (isNaN(start.getTime()) || isNaN(end.getTime())) continue;
-    const from = start < monthStart ? new Date(monthStart) : new Date(start);
-    const to = end > monthEnd ? new Date(monthEnd) : new Date(end);
-    // Walk day-by-day in local time. setHours(0) prevents DST drift.
+    const from = start < monthStartDate ? new Date(monthStartDate) : new Date(start);
+    const to = end > monthEndDate ? new Date(monthEndDate) : new Date(end);
     from.setHours(0, 0, 0, 0);
     to.setHours(0, 0, 0, 0);
     for (let d = new Date(from); d <= to; d.setDate(d.getDate() + 1)) {
@@ -549,16 +563,48 @@ export async function getMyHistory(
       if (!holidayByDate.has(key)) holidayByDate.set(key, h.title);
     }
   }
+  // Layer the legacy table on top — only fills gaps so company_events wins
+  // when both have the same date.
+  for (const h of legacyHolidays as any[]) {
+    const key = toDateKey(h.holiday_date);
+    if (!holidayByDate.has(key)) holidayByDate.set(key, h.holiday_name);
+  }
 
-  // Working-day set as a Set<weekday-number> where 0=Sunday, 1=Monday, …, 6=Saturday.
-  // Schema stores e.g. "1,2,3,4,5" (Mon-Fri). Default to Mon-Fri when missing.
-  const workingDaysRaw = (shiftRow?.working_days as string | undefined) ?? "1,2,3,4,5";
-  const workingDays = new Set(
-    workingDaysRaw
+  // Per-day week-off resolution — matches getMonthlyGrid (lines ~995-1070):
+  // walk assignments in created_at-desc order and write the (user, date) slot
+  // first-write-wins. An assignment marks a date as week-off when either:
+  //   - is_weekoff flag is set on the assignment (the "Mark as Week-off"
+  //     toggle on the Shift Schedule's Edit Assignment modal), or
+  //   - the day-of-week is NOT in the shift's `working_days` CSV.
+  // Days with no covering assignment get NO synthesized week_off (matching
+  // the Grid's behavior — see the "no shift → blank cell" comment there).
+  const weekOffByDate = new Map<string, boolean>();
+  for (const a of assignments as any[]) {
+    const from = toDateKey(a.effective_from);
+    const to = a.effective_to ? toDateKey(a.effective_to) : null;
+    const workingDays = String(a.working_days || "")
       .split(",")
-      .map((s) => parseInt(s.trim(), 10))
-      .filter((n) => Number.isFinite(n)),
-  );
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => Number(s));
+    const isWeekoffShift = !!a.is_weekoff;
+    for (let d = 1; d <= daysInMonth; d++) {
+      const dateKey = `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+      if (dateKey < from) continue;
+      if (to && dateKey > to) continue;
+      if (weekOffByDate.has(dateKey)) continue; // first-write-wins
+      const dow = new Date(year, month - 1, d).getDay();
+      const off =
+        isWeekoffShift || (workingDays.length > 0 && !workingDays.includes(dow));
+      weekOffByDate.set(dateKey, off);
+    }
+  }
+
+  // Today key for the "don't mark future working days as absent" guard.
+  // Recomputed in the user's-via-server local tz; close enough for HR display
+  // purposes and matches how the rest of the file treats dates.
+  const today = new Date();
+  const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
   // Walk every calendar day in the month. Days with a real record use it as-is;
   // missing days get classified as holiday > week_off > absent. We use a
@@ -576,17 +622,24 @@ export async function getMyHistory(
     }
 
     const holidayName = holidayByDate.get(dateKey);
-    // JS Date.getDay() returns 0=Sun…6=Sat. We parse the YYYY-MM-DD locally so
-    // the weekday isn't shifted by the server's timezone.
-    const weekday = new Date(year, month - 1, d).getDay();
+    const isWeekOff = weekOffByDate.get(dateKey) === true;
 
     let synthStatus: "holiday" | "week_off" | "absent";
     if (holidayName) {
       synthStatus = "holiday";
-    } else if (!workingDays.has(weekday)) {
+    } else if (isWeekOff) {
       synthStatus = "week_off";
     } else {
       synthStatus = "absent";
+    }
+
+    // Don't mark FUTURE working days as absent — those haven't happened yet,
+    // so calling them absent is misleading. Holidays and week-offs ARE
+    // calendar facts regardless of "now", so those still render for future
+    // dates. (E.g. May 25 a future Sunday: still shows as week_off; May 23
+    // a future Saturday with a holiday: still shows as holiday.)
+    if (synthStatus === "absent" && dateKey > todayKey) {
+      continue;
     }
 
     records.push({

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -461,27 +461,132 @@ export async function getMyHistory(
   params?: { page?: number; perPage?: number; month?: number; year?: number }
 ) {
   const db = getDB();
-  const page = params?.page || 1;
-  const perPage = params?.perPage || 20;
   const now = new Date();
   const month = params?.month || now.getMonth() + 1;
   const year = params?.year || now.getFullYear();
 
   const startDate = `${year}-${String(month).padStart(2, "0")}-01`;
-  const endDate = new Date(year, month, 0).toISOString().slice(0, 10);
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const endDate = `${year}-${String(month).padStart(2, "0")}-${String(daysInMonth).padStart(2, "0")}`;
 
-  let query = db("attendance_records")
-    .where({ organization_id: orgId, user_id: userId })
-    .whereBetween("date", [startDate, endDate]);
+  // Normalize date values (driver may hydrate to Date or string) to YYYY-MM-DD
+  // for stable keying when we merge calendar days against fetched rows.
+  const toDateKey = (v: unknown): string => {
+    if (v instanceof Date) {
+      const y = v.getFullYear();
+      const m = String(v.getMonth() + 1).padStart(2, "0");
+      const d = String(v.getDate()).padStart(2, "0");
+      return `${y}-${m}-${d}`;
+    }
+    return String(v).slice(0, 10);
+  };
 
-  const [{ count }] = await query.clone().count("* as count");
-  const records = await query
-    .select()
-    .orderBy("date", "desc")
-    .limit(perPage)
-    .offset((page - 1) * perPage);
+  // Fetch existing attendance_records, holidays, and the user's active shift in
+  // parallel — three independent queries.
+  const [existing, holidays, shiftRow] = await Promise.all([
+    db("attendance_records")
+      .where({ organization_id: orgId, user_id: userId })
+      .whereBetween("date", [startDate, endDate])
+      .select(),
+    db("organization_holidays")
+      .where({ organization_id: orgId })
+      .whereBetween("holiday_date", [startDate, endDate])
+      .select("holiday_date", "holiday_name"),
+    // Pull the user's currently-effective shift to know their weekly off days.
+    // Falls back to Mon-Fri (1-5) if the user has no assignment.
+    db("shift_assignments as sa")
+      .where("sa.organization_id", orgId)
+      .andWhere("sa.user_id", userId)
+      .andWhere("sa.effective_from", "<=", endDate)
+      .andWhere(function () {
+        this.whereNull("sa.effective_to").orWhere("sa.effective_to", ">=", startDate);
+      })
+      .leftJoin("shifts as s", "sa.shift_id", "s.id")
+      .orderBy("sa.effective_from", "desc")
+      .select("s.working_days as working_days")
+      .first(),
+  ]);
 
-  return { records, total: Number(count) };
+  const byDate = new Map<string, any>();
+  for (const row of existing) {
+    byDate.set(toDateKey(row.date), row);
+  }
+
+  const holidayByDate = new Map<string, string>();
+  for (const h of holidays as any[]) {
+    holidayByDate.set(toDateKey(h.holiday_date), h.holiday_name);
+  }
+
+  // Working-day set as a Set<weekday-number> where 0=Sunday, 1=Monday, …, 6=Saturday.
+  // Schema stores e.g. "1,2,3,4,5" (Mon-Fri). Default to Mon-Fri when missing.
+  const workingDaysRaw = (shiftRow?.working_days as string | undefined) ?? "1,2,3,4,5";
+  const workingDays = new Set(
+    workingDaysRaw
+      .split(",")
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => Number.isFinite(n)),
+  );
+
+  // Walk every calendar day in the month. Days with a real record use it as-is;
+  // missing days get classified as holiday > week_off > absent. We use a
+  // unique negative `id` per synthesized row (derived from the date) so the
+  // client can use it as a React key without collisions and so its
+  // `expandedRowId === r.id` predicate doesn't accidentally match `null` for
+  // every synthesized row.
+  const records: any[] = [];
+  for (let d = 1; d <= daysInMonth; d++) {
+    const dateKey = `${year}-${String(month).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+    const existingRow = byDate.get(dateKey);
+    if (existingRow) {
+      records.push(existingRow);
+      continue;
+    }
+
+    const holidayName = holidayByDate.get(dateKey);
+    // JS Date.getDay() returns 0=Sun…6=Sat. We parse the YYYY-MM-DD locally so
+    // the weekday isn't shifted by the server's timezone.
+    const weekday = new Date(year, month - 1, d).getDay();
+
+    let synthStatus: "holiday" | "week_off" | "absent";
+    if (holidayName) {
+      synthStatus = "holiday";
+    } else if (!workingDays.has(weekday)) {
+      synthStatus = "week_off";
+    } else {
+      synthStatus = "absent";
+    }
+
+    records.push({
+      // Negative pseudo-id derived from YYYYMMDD so React keys are unique and
+      // the client doesn't expand every synthesized row when the default
+      // expandedRowId is null.
+      id: -(year * 10000 + month * 100 + d),
+      organization_id: orgId,
+      user_id: userId,
+      date: dateKey,
+      shift_id: null,
+      check_in: null,
+      check_out: null,
+      check_in_source: null,
+      check_out_source: null,
+      check_in_lat: null,
+      check_in_lng: null,
+      check_out_lat: null,
+      check_out_lng: null,
+      status: synthStatus,
+      holiday_name: holidayName ?? null,
+      worked_minutes: null,
+      overtime_minutes: null,
+      late_minutes: null,
+      early_departure_minutes: null,
+      synthesized: true,
+    });
+  }
+
+  // Ascending by date — 1st of the month at the top, last day at the bottom.
+  records.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  return { records, total: records.length };
 }
 
 export async function listRecords(

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -483,15 +483,25 @@ export async function getMyHistory(
 
   // Fetch existing attendance_records, holidays, and the user's active shift in
   // parallel — three independent queries.
+  //
+  // Holidays live in `company_events` rows where event_type='holiday'. The same
+  // table powers /events/holidays and is the canonical source the rest of the
+  // app reads from. We pull anything whose date range *overlaps* the requested
+  // month so multi-day holidays (e.g. Diwali week) light up every day they cover,
+  // not just the start_date.
   const [existing, holidays, shiftRow] = await Promise.all([
     db("attendance_records")
       .where({ organization_id: orgId, user_id: userId })
       .whereBetween("date", [startDate, endDate])
       .select(),
-    db("organization_holidays")
-      .where({ organization_id: orgId })
-      .whereBetween("holiday_date", [startDate, endDate])
-      .select("holiday_date", "holiday_name"),
+    db("company_events")
+      .where({ organization_id: orgId, event_type: "holiday" })
+      // overlap with [startDate, endDate]: start_date <= endDate AND (end_date >= startDate OR end_date IS NULL)
+      .where("start_date", "<=", `${endDate} 23:59:59`)
+      .andWhere(function () {
+        this.where("end_date", ">=", `${startDate} 00:00:00`).orWhereNull("end_date");
+      })
+      .select("title", "start_date", "end_date"),
     // Pull the user's currently-effective shift to know their weekly off days.
     // Falls back to Mon-Fri (1-5) if the user has no assignment.
     db("shift_assignments as sa")
@@ -512,9 +522,32 @@ export async function getMyHistory(
     byDate.set(toDateKey(row.date), row);
   }
 
+  // Expand each holiday's [start_date, end_date] range into per-day entries
+  // so a multi-day holiday flags every day it covers. If end_date is NULL,
+  // treat it as a single-day holiday. The expansion is clamped to the
+  // requested [startDate, endDate] window so we don't iterate beyond what
+  // we'll render.
   const holidayByDate = new Map<string, string>();
+  const monthStart = new Date(year, month - 1, 1);
+  const monthEnd = new Date(year, month - 1, daysInMonth);
   for (const h of holidays as any[]) {
-    holidayByDate.set(toDateKey(h.holiday_date), h.holiday_name);
+    const start = new Date(h.start_date);
+    const end = h.end_date ? new Date(h.end_date) : new Date(h.start_date);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) continue;
+    const from = start < monthStart ? new Date(monthStart) : new Date(start);
+    const to = end > monthEnd ? new Date(monthEnd) : new Date(end);
+    // Walk day-by-day in local time. setHours(0) prevents DST drift.
+    from.setHours(0, 0, 0, 0);
+    to.setHours(0, 0, 0, 0);
+    for (let d = new Date(from); d <= to; d.setDate(d.getDate() + 1)) {
+      const yy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, "0");
+      const dd = String(d.getDate()).padStart(2, "0");
+      // First-write-wins so if two holidays overlap (rare but possible) the
+      // earlier-inserted name sticks instead of flickering.
+      const key = `${yy}-${mm}-${dd}`;
+      if (!holidayByDate.has(key)) holidayByDate.set(key, h.title);
+    }
   }
 
   // Working-day set as a Set<weekday-number> where 0=Sunday, 1=Monday, …, 6=Saturday.


### PR DESCRIPTION
## Summary

The My Attendance page (`/attendance/my`) was only rendering days where an `attendance_records` row existed — typically check-in days and explicit `on_leave` rows seeded by the leave flow. Every other day in the month was invisible, so employees couldn't tell at a glance which days they were genuinely absent vs. simply on a weekend.

Now the table returns **one row per calendar day in the month** (up to and including today), with absent days correctly distinguished from weekends and holidays. Future working days are intentionally omitted from the absent list — they haven't happened yet.

4 files changed, +260 / −42.

## Server

### `getMyHistory` (attendance.service.ts)

For each calendar day in the requested month, return a row in priority order:

| Priority | Status | Source |
|---|---|---|
| 1 | Real `attendance_records` row | `attendance_records` (joined as-is, includes existing `on_leave` rows) |
| 2 | `holiday` | `company_events` where `event_type='holiday'` (canonical, used by `/events/holidays`) **OR** legacy `organization_holidays` table (fallback; the Attendance Grid reads this too — kept for parity). `company_events` wins on conflict. |
| 3 | `week_off` | Resolved from the user's shift assignment the **same way `getMonthlyGrid` does**: walk `shift_assignments` ordered by `created_at DESC, id DESC` (latest intent wins), first-write-wins per (user, date). A date is week-off when either the assignment's `is_weekoff` flag is set OR the day-of-week is not in `working_days`. Users with no assignment for a date get no synthesized week-off (parity with the Grid's "no shift → blank cell" rule). |
| 4 | `absent` | Otherwise — but only for dates **up to and including today**. Future working days are skipped so we never label a day someone hasn't lived yet as absent. |

All four lookups (existing records, `company_events` holidays, `organization_holidays` holidays, shift assignments) run in parallel via `Promise.all`. The legacy holiday query is wrapped in `.catch(() => [])` so older deployments without the table don't error.

Synthesized rows get a unique **negative pseudo-id** derived from `YYYYMMDD` so React keys stay stable and the client's `expandedRowId === r.id` predicate stops accidentally matching `null` for every synthesized row at once.

Multi-day holidays (e.g. `start_date=2026-05-10`, `end_date=2026-05-12`) flag every day in the range, not just `start_date`.

### `/attendance/me/history` route

No longer paginates — the response is bounded to ≤ 31 rows. Passes `per_page = records.length` to `sendPaginated` so `total_pages = 1` and the existing pagination chrome stays hidden when a month is selected.

## Client (`AttendancePage.tsx`)

- **New status pills**:
  - `holiday` → purple badge, shows the holiday name (e.g. "Labour Day") in the badge
  - `week_off` → neutral gray
  - `absent` → red (existing)
- **Hides the expand chevron** on synthesized rows. No punches request fires for those, so no `"Could not load timeline for this record"` noise under every empty day.
- **Hides the eye / view-details button** on synthesized rows (the modal also fetches by record id and would 404).
- **Keeps the pencil/regularize button visible** on absent days — it only needs the date and is the most useful action for an empty day.

Rows are returned **ascending (1st → today / 31st)** so the table reads top-down as the user lived the month.

## Test plan

- [ ] Log in as a non-admin employee and visit `/attendance/my`
- [ ] Pick a past month — table shows all 28-31 rows
- [ ] Pick the current month — table shows rows from 1 → today (future working days omitted)
- [ ] Sat / Sun rows show `week off` (gray badge) **only if the user's shift defines them as off** (matches the Grid)
- [ ] Approved leave date: row reads `on leave` (blue)
- [ ] Any past working day with no record: row reads `absent` (red); chevron / eye hidden
- [ ] Future working day: not in the table at all
- [ ] Insert a holiday via the canonical table: `INSERT INTO company_events (organization_id, title, event_type, start_date, end_date, is_all_day, created_by, status) VALUES (<org>, 'Labour Day', 'holiday', '2026-05-01 00:00:00', '2026-05-01 23:59:59', 1, <user>, 'upcoming');` → that date renders with `Labour Day` purple badge
- [ ] Insert a holiday via the legacy table: `INSERT INTO organization_holidays (organization_id, holiday_name, holiday_date) VALUES (<org>, 'Legacy Day', '2026-05-25');` → that date also renders purple (fallback works)
- [ ] Multi-day holiday (`start_date=2026-05-10`, `end_date=2026-05-12`) flags all three days
- [ ] No `Could not load timeline for this record` text anywhere on the page
- [ ] On a day with a real check-in: chevron expands to show punches, eye opens the detail modal — both still work
- [ ] `pnpm --filter @empcloud/server exec tsc --noEmit` clean
- [ ] `pnpm --filter @empcloud/client exec tsc --noEmit` clean