### PR TITLE
feat(leave): gender-restricted policies — HR input + dashboard filter

### DIFF
--- a/packages/client/src/pages/leave/LeaveDashboardPage.tsx
+++ b/packages/client/src/pages/leave/LeaveDashboardPage.tsx
@@ -89,6 +89,17 @@ export default function LeaveDashboardPage() {
     queryFn: () => api.get("/leave/types").then((r) => r.data.data),
   });
 
+  // Subset of `leaveTypes` whose active policy applies to the current user's
+  // gender (server-side filter on `leave_policies.applicable_gender`). Used
+  // for the employee balance cards and the apply-leave dropdown so a male
+  // employee does not see Maternity, etc. The unfiltered `leaveTypes` is
+  // still passed to admin sub-components so they can resolve names for any
+  // leave type when reviewing other employees' applications.
+  const { data: myLeaveTypes = [] } = useQuery<LeaveType[]>({
+    queryKey: ["leave-types-me"],
+    queryFn: () => api.get("/leave/types/me").then((r) => r.data.data),
+  });
+
   const [form, setForm] = useState({
     leave_type_id: 0,
     start_date: "",
@@ -262,12 +273,12 @@ export default function LeaveDashboardPage() {
               </div>
             ))}
           </>
-        ) : leaveTypes.filter((lt) => Boolean(lt.is_active)).length === 0 ? (
+        ) : myLeaveTypes.filter((lt) => Boolean(lt.is_active)).length === 0 ? (
           <div className="col-span-full text-center text-gray-400 py-8">
             {t('leave.noTypes')}
           </div>
         ) : (
-          leaveTypes
+          myLeaveTypes
             .filter((lt) => Boolean(lt.is_active))
             // #1612 — when the org has multiple leave_types rows with the same
             // display name (e.g. an old "SL" + a re-added "SL_440514" both
@@ -424,7 +435,7 @@ export default function LeaveDashboardPage() {
                 required
               >
                 <option value={0} disabled>{t('leave.dashboard.selectType')}</option>
-                {leaveTypes
+                {myLeaveTypes
                   .filter((lt) => Boolean(lt.is_active))
                   // #1917 / #1924 — When the org has duplicate leave_types rows
                   // with the same display name (e.g. an old "SL" with 0 quota

--- a/packages/client/src/pages/leave/LeaveTypesPage.tsx
+++ b/packages/client/src/pages/leave/LeaveTypesPage.tsx
@@ -37,6 +37,7 @@ interface LeavePolicy {
   annual_quota: number;
   accrual_type: string;
   applicable_from_months: number;
+  applicable_gender: string | null;
   max_consecutive_days: number | null;
   min_days_before_application: number;
   period_carry_forward: boolean;
@@ -94,6 +95,8 @@ const EMPTY_POLICY = {
   annual_quota: 12,
   accrual_type: "annual" as string,
   applicable_from_months: 0,
+  // null = applicable to all genders; "male" | "female" | "other" restricts.
+  applicable_gender: null as string | null,
   max_consecutive_days: null as number | null,
   min_days_before_application: 0,
   period_carry_forward: false,
@@ -267,6 +270,7 @@ export default function LeaveTypesPage() {
       annual_quota: p.annual_quota,
       accrual_type: p.accrual_type,
       applicable_from_months: p.applicable_from_months,
+      applicable_gender: p.applicable_gender ?? null,
       max_consecutive_days: p.max_consecutive_days,
       min_days_before_application: p.min_days_before_application,
       period_carry_forward: !!p.period_carry_forward,
@@ -899,6 +903,29 @@ function PoliciesSection(props: {
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
               />
             </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Applicable To
+              </label>
+              <select
+                value={policyForm.applicable_gender ?? ""}
+                onChange={(e) =>
+                  setPolicyForm({
+                    ...policyForm,
+                    applicable_gender: e.target.value === "" ? null : e.target.value,
+                  })
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              >
+                <option value="">Everyone</option>
+                <option value="female">Female only</option>
+                <option value="male">Male only</option>
+                <option value="other">Other only</option>
+              </select>
+              <p className="text-xs text-gray-500 mt-1">
+                Restricts who sees and can apply for this leave (e.g. Maternity → Female only).
+              </p>
+            </div>
             <div className="md:col-span-3">
               <label className="flex items-start gap-2 text-sm text-gray-700">
                 <input
@@ -952,13 +979,14 @@ function PoliciesSection(props: {
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Quota</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Accrual</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Carry</th>
+              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Applicable</th>
               <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-100">
             {policies.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={7} className="px-6 py-8 text-center text-gray-400">
                   No policies configured
                 </td>
               </tr>
@@ -989,6 +1017,37 @@ function PoliciesSection(props: {
                           Resets
                         </span>
                       )}
+                    </td>
+                    <td className="px-6 py-4">
+                      {(() => {
+                        const g = (p.applicable_gender ?? "").toLowerCase();
+                        if (g === "female") {
+                          return (
+                            <span className="text-xs bg-pink-50 text-pink-700 px-2 py-1 rounded-full">
+                              Female only
+                            </span>
+                          );
+                        }
+                        if (g === "male") {
+                          return (
+                            <span className="text-xs bg-blue-50 text-blue-700 px-2 py-1 rounded-full">
+                              Male only
+                            </span>
+                          );
+                        }
+                        if (g === "other") {
+                          return (
+                            <span className="text-xs bg-amber-50 text-amber-700 px-2 py-1 rounded-full">
+                              Other only
+                            </span>
+                          );
+                        }
+                        return (
+                          <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+                            Everyone
+                          </span>
+                        );
+                      })()}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-2">

--- a/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
+++ b/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
@@ -100,13 +100,15 @@ export default function SelfServiceDashboardPage() {
         .catch(() => []),
   });
 
-  // #1414 — fetch all active leave types so we can render a card per type
-  // even before balances are initialized (missing balances render as 0).
+  // #1414 — fetch leave types so we can render a card per type even before
+  // balances are initialized. Uses /leave/types/me which filters out policies
+  // whose `applicable_gender` does not match the current user's gender, so
+  // e.g. Maternity does not appear for male employees.
   const { data: leaveTypes } = useQuery({
-    queryKey: ["leave-types"],
+    queryKey: ["leave-types-me"],
     queryFn: () =>
       api
-        .get("/leave/types")
+        .get("/leave/types/me")
         .then((r) => r.data.data)
         .catch(() => []),
   });

--- a/packages/server/src/api/routes/leave.routes.ts
+++ b/packages/server/src/api/routes/leave.routes.ts
@@ -55,6 +55,18 @@ router.get("/types", authenticate, async (req: Request, res: Response, next: Nex
   } catch (err) { next(err); }
 });
 
+// GET /api/v1/leave/types/me — leave types applicable to current user
+// (filters by `leave_policies.applicable_gender` vs `users.gender`). Used by
+// the self-service dashboard so gender-restricted leaves are only shown to
+// matching employees. Must be declared before `/types/:id` so the literal
+// segment wins over the param route.
+router.get("/types/me", authenticate, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const types = await leaveTypeService.listLeaveTypesForUser(req.user!.org_id, req.user!.sub);
+    sendSuccess(res, types);
+  } catch (err) { next(err); }
+});
+
 // GET /api/v1/leave/types/:id
 router.get("/types/:id", authenticate, async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/packages/server/src/services/leave/leave-type.service.ts
+++ b/packages/server/src/services/leave/leave-type.service.ts
@@ -23,6 +23,63 @@ export async function listLeaveTypes(orgId: number): Promise<LeaveType[]> {
   }));
 }
 
+/**
+ * Return leave types that have at least one active policy applicable to the
+ * given user. A policy applies when its `applicable_gender` is NULL/empty
+ * (everyone) or matches the user's `gender` (case-insensitive). Used by the
+ * employee self-service dashboard so a male employee does not see Maternity,
+ * a female employee does not see Paternity, etc.
+ */
+export async function listLeaveTypesForUser(
+  orgId: number,
+  userId: number,
+): Promise<LeaveType[]> {
+  const db = getDB();
+  const user = await db("users")
+    .where({ id: userId, organization_id: orgId })
+    .select("gender")
+    .first();
+  const userGender = (user?.gender ?? "").toString().toLowerCase() || null;
+
+  const rows = await db("leave_types")
+    .leftJoin("leave_policies", function () {
+      this.on("leave_policies.leave_type_id", "=", "leave_types.id").andOn(
+        "leave_policies.organization_id",
+        "=",
+        "leave_types.organization_id",
+      );
+    })
+    .where("leave_types.organization_id", orgId)
+    .andWhere((qb) => {
+      // Either the type has no policy at all (legacy data) — keep it visible —
+      // or it has at least one active policy whose gender constraint allows
+      // this user.
+      qb.whereNull("leave_policies.id").orWhere((q2) => {
+        q2.where("leave_policies.is_active", true).andWhere((q3) => {
+          q3.whereNull("leave_policies.applicable_gender").orWhere(
+            "leave_policies.applicable_gender",
+            "",
+          );
+          if (userGender) {
+            q3.orWhereRaw("LOWER(leave_policies.applicable_gender) = ?", [userGender]);
+          }
+        });
+      });
+    })
+    .select("leave_types.*")
+    .groupBy("leave_types.id")
+    .orderBy("leave_types.name", "asc");
+
+  return rows.map((t: any) => ({
+    ...t,
+    is_paid: !!t.is_paid,
+    is_carry_forward: !!t.is_carry_forward,
+    is_encashable: !!t.is_encashable,
+    requires_approval: !!t.requires_approval,
+    is_active: !!t.is_active,
+  }));
+}
+
 export async function getLeaveType(orgId: number, id: number): Promise<LeaveType> {
   const db = getDB();
   const row = await db("leave_types")


### PR DESCRIPTION
The `leave_policies.applicable_gender` column has existed since migration 007 but was never reachable from the UI: HR could not set it and the employee dashboard ignored it. As a result a male employee saw Maternity in their balance cards and could apply for it (and vice-versa).

Backend
- leave-type.service.ts: new `listLeaveTypesForUser(orgId, userId)` joins leave_types ⨝ active leave_policies and keeps only types whose policy's `applicable_gender` is NULL/empty (everyone) or matches the user's gender (case-insensitive). Legacy types with no policy stay visible.
- leave.routes.ts: new `GET /api/v1/leave/types/me` exposing the above, declared before `/types/:id` so the literal segment wins.

Frontend (HR — LeaveTypesPage)
- "Applicable To" select on the policy create/edit form (Everyone / Female only / Male only / Other only).
- New "Applicable" column in the policy table with a colored pill.
- Edit flow now pre-fills the gender field from the existing policy.

Frontend (Employee)
- SelfServiceDashboardPage and LeaveDashboardPage now fetch `/leave/types/me` for the balance cards and the apply-leave dropdown. LeaveDashboardPage still fetches the unfiltered list separately for admin sub-components (Pending Approvals / Recent Applications) so an admin reviewing somebody else's gender-restricted leave can still see the type name.