### PR TITLE
fix(attendance-settings): inline validation, ConfirmDialog deletes, map tile fix, toast position

### DIFF
--- a/packages/client/src/components/maps/GeofenceMapPicker.tsx
+++ b/packages/client/src/components/maps/GeofenceMapPicker.tsx
@@ -97,6 +97,7 @@ export default function GeofenceMapPicker({
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
+        <InvalidateOnMount />
         <ClickHandler onPick={(latlng) => onChange({ latitude: latlng.lat, longitude: latlng.lng })} />
         {hasPoint && (
           <>
@@ -134,6 +135,26 @@ function ClickHandler({ onPick }: { onPick: (latlng: L.LatLng) => void }) {
       onPick(e.latlng);
     },
   });
+  return null;
+}
+
+// When MapContainer mounts inside a modal/dialog, the modal's open animation
+// can leave Leaflet computing tile coverage against the pre-animation
+// container size (often 0×0 or stale). The visible symptom is a solid blue
+// rectangle — Leaflet thinks it doesn't need to fetch any tiles. Calling
+// invalidateSize() after the next animation frame (and again at 150ms in
+// case the modal uses a longer transition) forces a re-measure and re-tile.
+function InvalidateOnMount() {
+  const map = useMap();
+  useEffect(() => {
+    const fire = () => map.invalidateSize();
+    const raf = requestAnimationFrame(fire);
+    const t = setTimeout(fire, 150);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(t);
+    };
+  }, [map]);
   return null;
 }
 

--- a/packages/client/src/components/ui/Toast.tsx
+++ b/packages/client/src/components/ui/Toast.tsx
@@ -62,13 +62,13 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 max-w-sm">
+    <div className="fixed top-4 right-4 z-[9999] flex flex-col gap-2 max-w-sm">
       {toasts.map((toast) => {
         const Icon = ICONS[toast.type];
         return (
           <div
             key={toast.id}
-            className={`flex items-start gap-3 px-4 py-3 rounded-lg border shadow-lg animate-in slide-in-from-right ${COLORS[toast.type]}`}
+            className={`flex items-start gap-3 px-4 py-3 rounded-lg border shadow-lg animate-in fade-in slide-in-from-top-2 ${COLORS[toast.type]}`}
             role="alert"
           >
             <Icon className={`h-5 w-5 shrink-0 mt-0.5 ${ICON_COLORS[toast.type]}`} />

--- a/packages/client/src/pages/attendance/AttendanceSettingsPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceSettingsPage.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import api from "@/api/client";
 import { showToast } from "@/components/ui/Toast";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import GeofenceMapPicker from "@/components/maps/GeofenceMapPicker";
 
 type Channel = "dashboard" | "biometric" | "app";
@@ -222,12 +223,17 @@ function GeofencesSection({ geofences, isLoading }: { geofences: Geofence[]; isL
   const qc = useQueryClient();
   const [editing, setEditing] = useState<Geofence | null>(null);
   const [creating, setCreating] = useState(false);
+  // Pending deletion target. The trash icon sets this; ConfirmDialog (rendered
+  // at the bottom of the section) reads it. Replaces window.confirm() which
+  // surfaces an unstyled browser alert.
+  const [pendingDelete, setPendingDelete] = useState<Geofence | null>(null);
 
   const removeFence = useMutation({
     mutationFn: (id: number) => api.delete(`/attendance/geo-fences/${id}`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["attendance-geo-fences"] });
       showToast("success", "Geofence removed");
+      setPendingDelete(null);
     },
     onError: (err: any) =>
       showToast("error", err?.response?.data?.error?.message ?? "Could not remove geofence"),
@@ -284,15 +290,7 @@ function GeofencesSection({ geofences, isLoading }: { geofences: Geofence[]; isL
                   <Pencil className="h-4 w-4" />
                 </button>
                 <button
-                  onClick={() => {
-                    if (
-                      confirm(
-                        `Remove geofence "${f.name}"? Any per-user overrides pinned to it will fall back to inheriting org defaults.`,
-                      )
-                    ) {
-                      removeFence.mutate(f.id);
-                    }
-                  }}
+                  onClick={() => setPendingDelete(f)}
                   className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded"
                   aria-label="Delete geofence"
                 >
@@ -325,6 +323,24 @@ function GeofencesSection({ geofences, isLoading }: { geofences: Geofence[]; isL
           }}
         />
       )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Remove geofence?"
+        description={
+          pendingDelete
+            ? `"${pendingDelete.name}" will be deleted. Any per-user overrides pinned to it will fall back to inheriting org defaults.`
+            : ""
+        }
+        confirmText="Remove"
+        cancelText="Cancel"
+        variant="danger"
+        loading={removeFence.isPending}
+        onConfirm={() => {
+          if (pendingDelete) removeFence.mutate(pendingDelete.id);
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
     </section>
   );
 }
@@ -347,6 +363,17 @@ function GeofenceModal({ mode, existing, onClose, onSaved }: GeofenceModalProps)
   const [radius, setRadius] = useState<string>(
     existing ? String(existing.radius_meters) : "200",
   );
+  // Field-level validation errors. The toast at the bottom-right is easy to
+  // miss for inline form mistakes (especially on the geofence dialog where
+  // the user is focused on the map). Render the message right under the
+  // offending field instead — keyed by field name so each input can show
+  // / clear its own error independently.
+  const [errors, setErrors] = useState<{
+    name?: string;
+    latitude?: string;
+    longitude?: string;
+    radius?: string;
+  }>({});
 
   const save = useMutation({
     mutationFn: () => {
@@ -370,16 +397,19 @@ function GeofenceModal({ mode, existing, onClose, onSaved }: GeofenceModalProps)
   });
 
   const submit = () => {
-    if (!name.trim()) return showToast("error", "Name is required");
     const lat = Number(latitude);
     const lng = Number(longitude);
     const rad = Number(radius);
-    if (Number.isNaN(lat) || lat < -90 || lat > 90)
-      return showToast("error", "Latitude must be between -90 and 90");
-    if (Number.isNaN(lng) || lng < -180 || lng > 180)
-      return showToast("error", "Longitude must be between -180 and 180");
-    if (Number.isNaN(rad) || rad < 10 || rad > 50000)
-      return showToast("error", "Radius must be between 10 and 50000 metres");
+    const next: typeof errors = {};
+    if (!name.trim()) next.name = "Name is required";
+    if (Number.isNaN(lat) || lat < -90 || lat > 90) next.latitude = "Latitude must be between -90 and 90";
+    if (Number.isNaN(lng) || lng < -180 || lng > 180) next.longitude = "Longitude must be between -180 and 180";
+    if (Number.isNaN(rad) || rad < 10 || rad > 50000) next.radius = "Radius must be between 10 and 50000 metres";
+    if (Object.keys(next).length > 0) {
+      setErrors(next);
+      return;
+    }
+    setErrors({});
     save.mutate();
   };
 
@@ -411,11 +441,22 @@ function GeofenceModal({ mode, existing, onClose, onSaved }: GeofenceModalProps)
             <input
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (errors.name) setErrors((p) => ({ ...p, name: undefined }));
+              }}
               placeholder="HQ Bangalore"
               maxLength={100}
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+              aria-invalid={!!errors.name}
+              className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 outline-none ${
+                errors.name
+                  ? "border-red-300 focus:ring-red-300 focus:border-red-400"
+                  : "border-gray-200 focus:ring-brand-500 focus:border-brand-500"
+              }`}
             />
+            {errors.name && (
+              <p className="mt-1 text-xs text-red-600">{errors.name}</p>
+            )}
           </div>
 
           {/* Map picker — click anywhere or drag the marker to set the
@@ -448,10 +489,21 @@ function GeofenceModal({ mode, existing, onClose, onSaved }: GeofenceModalProps)
                 type="number"
                 step="0.0000001"
                 value={latitude}
-                onChange={(e) => setLatitude(e.target.value)}
+                onChange={(e) => {
+                  setLatitude(e.target.value);
+                  if (errors.latitude) setErrors((p) => ({ ...p, latitude: undefined }));
+                }}
                 placeholder="12.9716"
-                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                aria-invalid={!!errors.latitude}
+                className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 outline-none ${
+                  errors.latitude
+                    ? "border-red-300 focus:ring-red-300 focus:border-red-400"
+                    : "border-gray-200 focus:ring-brand-500 focus:border-brand-500"
+                }`}
               />
+              {errors.latitude && (
+                <p className="mt-1 text-xs text-red-600">{errors.latitude}</p>
+              )}
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Longitude</label>
@@ -459,10 +511,21 @@ function GeofenceModal({ mode, existing, onClose, onSaved }: GeofenceModalProps)
                 type="number"
                 step="0.0000001"
                 value={longitude}
-                onChange={(e) => setLongitude(e.target.value)}
+                onChange={(e) => {
+                  setLongitude(e.target.value);
+                  if (errors.longitude) setErrors((p) => ({ ...p, longitude: undefined }));
+                }}
                 placeholder="77.5946"
-                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                aria-invalid={!!errors.longitude}
+                className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 outline-none ${
+                  errors.longitude
+                    ? "border-red-300 focus:ring-red-300 focus:border-red-400"
+                    : "border-gray-200 focus:ring-brand-500 focus:border-brand-500"
+                }`}
               />
+              {errors.longitude && (
+                <p className="mt-1 text-xs text-red-600">{errors.longitude}</p>
+              )}
             </div>
           </div>
 
@@ -475,13 +538,25 @@ function GeofenceModal({ mode, existing, onClose, onSaved }: GeofenceModalProps)
               min={10}
               max={50000}
               value={radius}
-              onChange={(e) => setRadius(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+              onChange={(e) => {
+                setRadius(e.target.value);
+                if (errors.radius) setErrors((p) => ({ ...p, radius: undefined }));
+              }}
+              aria-invalid={!!errors.radius}
+              className={`w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 outline-none ${
+                errors.radius
+                  ? "border-red-300 focus:ring-red-300 focus:border-red-400"
+                  : "border-gray-200 focus:ring-brand-500 focus:border-brand-500"
+              }`}
             />
-            <p className="text-xs text-gray-500 mt-1">
-              Mobile app considers the user "inside" if they're within this distance of the
-              coordinates.
-            </p>
+            {errors.radius ? (
+              <p className="mt-1 text-xs text-red-600">{errors.radius}</p>
+            ) : (
+              <p className="text-xs text-gray-500 mt-1">
+                Mobile app considers the user "inside" if they're within this distance of the
+                coordinates.
+              </p>
+            )}
           </div>
         </div>
 
@@ -575,11 +650,16 @@ function OverridesSection({ geofences }: { geofences: Geofence[] }) {
     },
   });
 
+  // Pending deletion target for the override list. See GeofencesSection for
+  // the same pattern — ConfirmDialog at the bottom reads this.
+  const [pendingDelete, setPendingDelete] = useState<OverrideRow | null>(null);
+
   const removeOverride = useMutation({
     mutationFn: (id: number) => api.delete(`/attendance/overrides/${id}`),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["attendance-overrides-all"] });
       showToast("success", "Override removed");
+      setPendingDelete(null);
     },
     onError: (err: any) =>
       showToast("error", err?.response?.data?.error?.message ?? "Could not remove override"),
@@ -705,11 +785,7 @@ function OverridesSection({ geofences }: { geofences: Geofence[] }) {
                         <Pencil className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => {
-                          if (confirm("Remove this override? The user will fall back to the org default immediately.")) {
-                            removeOverride.mutate(row.id);
-                          }
-                        }}
+                        onClick={() => setPendingDelete(row)}
                         className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded"
                         aria-label="Delete override"
                       >
@@ -750,6 +826,24 @@ function OverridesSection({ geofences }: { geofences: Geofence[] }) {
           }}
         />
       )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Remove per-user override?"
+        description={
+          pendingDelete
+            ? `${pendingDelete.user?.first_name ?? "This user"}'s override will be removed. They will fall back to the org default immediately.`
+            : ""
+        }
+        confirmText="Remove"
+        cancelText="Cancel"
+        variant="danger"
+        loading={removeOverride.isPending}
+        onConfirm={() => {
+          if (pendingDelete) removeOverride.mutate(pendingDelete.id);
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Four small UX fixes on `/attendance/settings`. Each one was a paper-cut that made the page feel sloppy in different ways. 3 files changed, +150 / −35.

### 1. Geofence form — inline field validation instead of bottom toast

The Add / Edit dialog called `showToast("error", "Name is required")` etc. The toast lives at the bottom-right corner, often under the AI chatbot bubble, and is easy to miss when the user's eye is on the form. Now each field has its own error state — red border, red helper text directly below the input — and the error clears as soon as the user edits that field. The save mutation's server errors still go through the toast (those aren't field-level).

### 2. Geofence + per-user override deletes — styled ConfirmDialog instead of browser `confirm()`

Both trash buttons fired `window.confirm()` which renders the unstyled `localhost:5173 says…` chrome alert. Swapped both for the project's `<ConfirmDialog>` primitive with `variant="danger"` and a loading state on the Remove button while the DELETE is in flight. Same primitive that backs the leave-cancel dialog.

### 3. Map tiles render properly when opening the Edit dialog

Leaflet's `MapContainer` inside a modal rendered a solid blue rectangle — tiles never loaded because the map computed its size against the pre-animation 0×0 container. Added an `<InvalidateOnMount />` child that calls `map.invalidateSize()` on `requestAnimationFrame` + at 150 ms so the tiles re-fetch once the modal has its real dimensions.

### 4. Global toast position moved to top-right

The toast container was `fixed bottom-4 right-4` which put success messages directly behind the persistent AI chatbot bubble in the bottom-right corner. Moved to `top-4 right-4` with a `slide-in-from-top` animation. **Applies app-wide** — every `showToast()` now lands above the fold instead of behind another widget.

## Test plan

- [ ] `/attendance/settings` → **Add geofence** → click Add geofence with an empty Name → inline `Name is required` text below the field; no bottom toast; the red border clears the moment you type a character
- [ ] Enter Latitude=200 → submit → inline `Latitude must be between -90 and 90` next to that field; other fields stay clean
- [ ] Click trash on a geofence → styled red ConfirmDialog opens, **not** `localhost:5173 says…`; confirming shows a loading spinner on the Remove button until the DELETE returns; success toast slides in from the top-right
- [ ] Same for trash on a per-user override
- [ ] Open **Edit geofence** on an existing geofence → the map tiles render (no solid blue rectangle)
- [ ] Any other `showToast` in the app (e.g. leave apply / cancel) — toast appears at top-right
- [ ] `pnpm --filter @empcloud/client exec tsc --noEmit` clean