### PR TITLE
feat(audit): dual-month range picker on /audit + redesign shared Date…

### DIFF
--- a/packages/client/src/components/DateRangePicker.tsx
+++ b/packages/client/src/components/DateRangePicker.tsx
@@ -4,13 +4,14 @@ import { CalendarDays, ChevronDown, X } from "lucide-react";
 import { DayPicker, type DateRange } from "react-day-picker";
 import "react-day-picker/style.css";
 
-// Conservative panel-height estimate used on the FIRST paint before
-// the real DOM node has been measured. The placement logic re-runs in
-// a rAF after mount and replaces this with the actual offsetHeight, so
-// being a bit pessimistic here is fine -- it just means we may flip up
-// preemptively on the very first frame.
-const PICKER_HEIGHT_FALLBACK = 520;
-const PICKER_WIDTH = 340;
+// Conservative panel-size estimates used on the FIRST paint before the real
+// DOM node has been measured. The placement logic re-runs in a rAF after
+// mount and replaces these with the actual offset size, so being a bit
+// pessimistic here is fine -- it just means we may flip up / shift on the
+// very first frame. The dual-month + preset-sidebar layout is wide, so the
+// estimate is generous; actual width is measured once mounted.
+const PICKER_HEIGHT_FALLBACK = 420;
+const PICKER_WIDTH = 720;
 const VIEWPORT_MARGIN = 8;
 
 type Props = {
@@ -28,7 +29,8 @@ const fmt = (iso: string): string => {
   if (!iso) return "";
   const d = new Date(iso + "T00:00:00");
   if (isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+  // "June 05, 2026" — long month + zero-padded day, matching the reference UI.
+  return d.toLocaleDateString(undefined, { month: "long", day: "2-digit", year: "numeric" });
 };
 
 const isoOf = (d: Date): string => {
@@ -42,6 +44,53 @@ const parseIso = (iso: string): Date | undefined => {
   if (!iso) return undefined;
   const d = new Date(iso + "T00:00:00");
   return isNaN(d.getTime()) ? undefined : d;
+};
+
+// Preset definitions + range math, shared by the sidebar buttons and the
+// "which preset does the current selection match?" detection that drives the
+// active highlight.
+type PresetKey = "today" | "yesterday" | "last7" | "last30" | "thisMonth" | "lastMonth";
+
+const PRESETS: { key: PresetKey; label: string }[] = [
+  { key: "today", label: "Today" },
+  { key: "yesterday", label: "Yesterday" },
+  { key: "last7", label: "Last 7 Days" },
+  { key: "last30", label: "Last 30 Days" },
+  { key: "thisMonth", label: "This Month" },
+  { key: "lastMonth", label: "Last Month" },
+];
+
+const presetRange = (kind: PresetKey): { from: Date; to: Date } => {
+  const now = new Date();
+  let start: Date;
+  let end: Date = now;
+  switch (kind) {
+    case "today":
+      start = now;
+      break;
+    case "yesterday":
+      start = new Date(now);
+      start.setDate(now.getDate() - 1);
+      end = new Date(start);
+      break;
+    case "last7":
+      start = new Date(now);
+      start.setDate(now.getDate() - 6);
+      break;
+    case "last30":
+      start = new Date(now);
+      start.setDate(now.getDate() - 29);
+      break;
+    case "thisMonth":
+      start = new Date(now.getFullYear(), now.getMonth(), 1);
+      end = now;
+      break;
+    case "lastMonth":
+      start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      end = new Date(now.getFullYear(), now.getMonth(), 0);
+      break;
+  }
+  return { from: start, to: end };
 };
 
 export function DateRangePicker({
@@ -59,6 +108,9 @@ export function DateRangePicker({
     from: parseIso(from),
     to: parseIso(to),
   }));
+  // Which sidebar entry is highlighted. "custom" once the user touches the
+  // calendars directly; null when nothing is selected yet.
+  const [activePreset, setActivePreset] = useState<PresetKey | "custom" | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
@@ -72,9 +124,21 @@ export function DateRangePicker({
     { top: number; left: number; maxHeight: number } | null
   >(null);
 
+  // Detect which preset (if any) an ISO from/to pair corresponds to, so the
+  // sidebar can highlight it when the picker is reopened on an existing range.
+  const detectPreset = (f: string, t: string): PresetKey | "custom" | null => {
+    if (!f) return null;
+    for (const p of PRESETS) {
+      const r = presetRange(p.key);
+      if (isoOf(r.from) === f && isoOf(r.to) === t) return p.key;
+    }
+    return "custom";
+  };
+
   useEffect(() => {
     if (open) {
       setDraft({ from: parseIso(from), to: parseIso(to) });
+      setActivePreset(detectPreset(from, to));
     }
   }, [open, from, to]);
 
@@ -91,13 +155,14 @@ export function DateRangePicker({
     const vh = window.innerHeight;
     const vw = window.innerWidth;
 
-    // Real measured height once the panel has mounted; conservative
-    // fallback for the first frame. Using the real value is what makes
-    // the flip-up decision correct -- the old hard-coded estimate was
-    // smaller than the rendered panel, so it kept choosing "below" and
-    // the Apply button ended up off-screen.
-    const measured = panelRef.current?.offsetHeight ?? 0;
-    const panelH = measured > 0 ? measured : PICKER_HEIGHT_FALLBACK;
+    // Real measured size once the panel has mounted; conservative fallbacks
+    // for the first frame. Measuring width matters for the wide dual-month
+    // layout so right-alignment + the viewport clamp stay accurate regardless
+    // of the calendar's intrinsic size.
+    const measuredH = panelRef.current?.offsetHeight ?? 0;
+    const panelH = measuredH > 0 ? measuredH : PICKER_HEIGHT_FALLBACK;
+    const measuredW = panelRef.current?.offsetWidth ?? 0;
+    const panelW = measuredW > 0 ? measuredW : PICKER_WIDTH;
 
     const spaceBelow = vh - rect.bottom - VIEWPORT_MARGIN;
     const spaceAbove = rect.top - VIEWPORT_MARGIN;
@@ -124,11 +189,12 @@ export function DateRangePicker({
 
     // Horizontal placement: right-align with the trigger by default;
     // clamp to viewport so it never leaks off the screen edges.
-    let left = rect.right - PICKER_WIDTH;
+    let left = rect.right - panelW;
     if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
-    if (left + PICKER_WIDTH > vw - VIEWPORT_MARGIN) {
-      left = vw - PICKER_WIDTH - VIEWPORT_MARGIN;
+    if (left + panelW > vw - VIEWPORT_MARGIN) {
+      left = vw - panelW - VIEWPORT_MARGIN;
     }
+    if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
 
     setPanelPos({ top, left, maxHeight });
   };
@@ -138,10 +204,10 @@ export function DateRangePicker({
       setPanelPos(null);
       return;
     }
-    // Initial position with the fallback height estimate so the panel
-    // has somewhere to render. Then a rAF re-run picks up the real
-    // measured height and flips up if needed -- this two-pass dance is
-    // what guarantees Apply stays visible even in a tight modal.
+    // Initial position with the fallback size estimate so the panel has
+    // somewhere to render. Then a rAF re-run picks up the real measured
+    // size and flips up / shifts if needed -- this two-pass dance is what
+    // guarantees Apply stays visible even in a tight modal.
     recomputePosition();
     const raf = requestAnimationFrame(recomputePosition);
     const onScroll = () => recomputePosition();
@@ -182,32 +248,10 @@ export function DateRangePicker({
     };
   }, [open]);
 
-  const applyPreset = (kind: "today" | "last7" | "last30" | "thisMonth" | "lastMonth") => {
-    const now = new Date();
-    let start: Date;
-    let end: Date = now;
-    switch (kind) {
-      case "today":
-        start = now;
-        break;
-      case "last7":
-        start = new Date(now);
-        start.setDate(now.getDate() - 6);
-        break;
-      case "last30":
-        start = new Date(now);
-        start.setDate(now.getDate() - 29);
-        break;
-      case "thisMonth":
-        start = new Date(now.getFullYear(), now.getMonth(), 1);
-        end = now;
-        break;
-      case "lastMonth":
-        start = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-        end = new Date(now.getFullYear(), now.getMonth(), 0);
-        break;
-    }
+  const applyPreset = (kind: PresetKey) => {
+    const { from: start, to: end } = presetRange(kind);
     setDraft({ from: start, to: end });
+    setActivePreset(kind);
   };
 
   const handleApply = () => {
@@ -220,15 +264,20 @@ export function DateRangePicker({
 
   const handleClear = () => {
     setDraft(undefined);
+    setActivePreset(null);
     if (onClear) onClear();
     onApply("", "");
     setOpen(false);
   };
 
   const triggerLabel =
-    from && to ? `${fmt(from)} → ${fmt(to)}` : from ? `From ${fmt(from)}` : "Select date range";
+    from && to ? `${fmt(from)} - ${fmt(to)}` : from ? fmt(from) : "Select date range";
 
   const defaultMonth = useMemo(() => draft?.from ?? new Date(), [draft?.from]);
+
+  const footerLabel = draft?.from
+    ? `${fmt(isoOf(draft.from))}${draft?.to ? ` - ${fmt(isoOf(draft.to))}` : ""}`
+    : "—";
 
   return (
     <div ref={wrapRef} className={`relative inline-block ${className || ""}`}>
@@ -259,71 +308,79 @@ export function DateRangePicker({
             // Portalled to document.body so it escapes the overflow /
             // stacking context of any modal it's rendered inside. Fixed
             // positioning + z-[60] keeps it above modal backdrops (which
-            // typically sit at z-50). Width hard-locked to PICKER_WIDTH
-            // so the position calc stays accurate. maxHeight + overflow
-            // make sure the panel never spills past the viewport edge --
-            // the inner area scrolls and Apply remains clickable.
+            // typically sit at z-50). Width is intrinsic (sidebar + two
+            // months), capped to the viewport; maxHeight + overflow make
+            // sure the panel never spills past the viewport edge.
             style={{
               position: "fixed",
               top: panelPos.top,
               left: panelPos.left,
-              width: PICKER_WIDTH,
+              maxWidth: `calc(100vw - ${VIEWPORT_MARGIN * 2}px)`,
               maxHeight: panelPos.maxHeight,
-              overflowY: "auto",
+              overflow: "auto",
             }}
             className="z-[60] rounded-xl border border-gray-200 bg-white p-4 shadow-2xl"
           >
-            <div className="mb-3 flex flex-wrap gap-1.5">
-              {[
-                { key: "today", label: "Today" },
-                { key: "last7", label: "Last 7 days" },
-                { key: "last30", label: "Last 30 days" },
-                { key: "thisMonth", label: "This month" },
-                { key: "lastMonth", label: "Last month" },
-              ].map((p) => (
+            <div className="flex gap-3">
+              {/* Preset sidebar */}
+              <div className="flex w-32 shrink-0 flex-col gap-1 border-r border-gray-100 pr-2">
+                {PRESETS.map((p) => (
+                  <button
+                    key={p.key}
+                    type="button"
+                    onClick={() => applyPreset(p.key)}
+                    className={`rounded-md px-3 py-1.5 text-left text-sm transition ${
+                      activePreset === p.key
+                        ? "bg-brand-600 text-white"
+                        : "text-gray-600 hover:bg-gray-100"
+                    }`}
+                  >
+                    {p.label}
+                  </button>
+                ))}
                 <button
-                  key={p.key}
                   type="button"
-                  onClick={() => applyPreset(p.key as any)}
-                  className="rounded-full border border-gray-200 px-2.5 py-1 text-xs text-gray-600 hover:border-brand-300 hover:bg-brand-50 hover:text-brand-700"
+                  onClick={() => setActivePreset("custom")}
+                  className={`rounded-md px-3 py-1.5 text-left text-sm transition ${
+                    activePreset === "custom"
+                      ? "bg-brand-600 text-white"
+                      : "text-gray-600 hover:bg-gray-100"
+                  }`}
                 >
-                  {p.label}
+                  Custom Range
                 </button>
-              ))}
-            </div>
-
-            <div className="rdp-wrap text-sm">
-              <DayPicker
-                mode="range"
-                numberOfMonths={1}
-                defaultMonth={defaultMonth}
-                selected={draft}
-                onSelect={setDraft}
-                showOutsideDays
-                weekStartsOn={1}
-              />
-            </div>
-
-            <div className="mt-3 grid grid-cols-2 gap-3 text-xs text-gray-500">
-              <div>
-                <span className="font-medium uppercase">From</span>{" "}
-                <span className="text-gray-800">{draft?.from ? fmt(isoOf(draft.from)) : "—"}</span>
               </div>
-              <div>
-                <span className="font-medium uppercase">To</span>{" "}
-                <span className="text-gray-800">{draft?.to ? fmt(isoOf(draft.to)) : "—"}</span>
+
+              {/* Two-month calendar */}
+              <div className="rdp-wrap text-sm">
+                <DayPicker
+                  mode="range"
+                  numberOfMonths={2}
+                  defaultMonth={defaultMonth}
+                  selected={draft}
+                  onSelect={(r) => {
+                    setDraft(r);
+                    setActivePreset("custom");
+                  }}
+                  showOutsideDays
+                  weekStartsOn={0}
+                />
               </div>
             </div>
 
-            <div className="mt-4 flex items-center justify-between">
-              <button
-                type="button"
-                onClick={handleClear}
-                className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
-              >
-                <X className="h-3 w-3" />
-                Clear
-              </button>
+            <div className="mt-3 flex items-center justify-between border-t border-gray-100 pt-3">
+              <div className="flex items-center gap-2 text-xs text-gray-600">
+                <span>{footerLabel}</span>
+                {allowEmpty && (
+                  <button
+                    type="button"
+                    onClick={handleClear}
+                    className="inline-flex items-center gap-1 text-gray-400 hover:text-gray-600"
+                  >
+                    <X className="h-3 w-3" /> Clear
+                  </button>
+                )}
+              </div>
               <div className="flex gap-2">
                 <button
                   type="button"
@@ -336,7 +393,7 @@ export function DateRangePicker({
                   type="button"
                   onClick={handleApply}
                   disabled={!allowEmpty && !draft?.from}
-                  className="rounded-md bg-brand-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+                  className="rounded-md bg-brand-600 px-4 py-1.5 text-xs font-medium text-white hover:bg-brand-700 disabled:opacity-50"
                 >
                   Apply
                 </button>

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1418,6 +1418,8 @@
     "clearAll": "Clear all",
     "actionType": "Action Type",
     "allActions": "All actions",
+    "searchActions": "Search action type...",
+    "noActionMatches": "No matching action",
     "fromDate": "From Date",
     "toDate": "To Date",
     "showingResults": "Showing {{count}} of {{total}} filtered results",

--- a/packages/client/src/pages/audit/AuditPage.tsx
+++ b/packages/client/src/pages/audit/AuditPage.tsx
@@ -1,8 +1,149 @@
 import { useAuditLogs } from "@/api/hooks";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Search, Filter, Calendar, RotateCcw } from "lucide-react";
+import { Search, Filter, Calendar, RotateCcw, ChevronDown } from "lucide-react";
 import { DateRangePicker } from "@/components/DateRangePicker";
+
+// Searchable single-select for the Action Type filter — the action list is long
+// (30+ values), so a plain <select> is hard to scan. Type to filter; click or
+// Enter to choose. Kept local to the audit page since it's the only consumer.
+function ActionTypeSelect({
+  value,
+  options,
+  onChange,
+  searchPlaceholder,
+  noMatchLabel,
+}: {
+  value: string;
+  options: { value: string; label: string }[];
+  onChange: (value: string) => void;
+  searchPlaceholder: string;
+  noMatchLabel: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const activeRef = useRef<HTMLButtonElement | null>(null);
+
+  const selected = options.find((o) => o.value === value);
+  const q = query.trim().toLowerCase();
+  const filtered = q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options;
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  // Reset + focus the search box on open.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setActiveIndex(0);
+      const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+  }, [open]);
+
+  useEffect(() => setActiveIndex(0), [query]);
+  // Keep the keyboard-highlighted row in view.
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  const choose = (v: string) => {
+    onChange(v);
+    setOpen(false);
+  };
+
+  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const opt = filtered[activeIndex];
+      if (opt) choose(opt.value);
+    }
+  };
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className="truncate">{selected?.label}</span>
+        <ChevronDown className={`h-4 w-4 shrink-0 text-gray-400 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+
+      {open && (
+        <div className="absolute z-30 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg">
+          <div className="border-b border-gray-100 p-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={onInputKeyDown}
+                placeholder={searchPlaceholder}
+                className="w-full rounded-md border border-gray-300 py-1.5 pl-8 pr-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              />
+            </div>
+          </div>
+          <ul role="listbox" className="max-h-60 overflow-y-auto py-1">
+            {filtered.length === 0 ? (
+              <li className="px-3 py-2 text-sm text-gray-400">{noMatchLabel}</li>
+            ) : (
+              filtered.map((o, i) => {
+                const isSelected = o.value === value;
+                const isActive = i === activeIndex;
+                return (
+                  <li key={o.value}>
+                    <button
+                      ref={isActive ? activeRef : undefined}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => choose(o.value)}
+                      onMouseEnter={() => setActiveIndex(i)}
+                      className={`flex w-full items-center px-3 py-1.5 text-left text-sm ${
+                        isSelected ? "font-medium text-brand-700" : "text-gray-700"
+                      } ${isActive ? "bg-gray-100" : ""}`}
+                    >
+                      {o.label}
+                    </button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
 
 // Enum values stay frozen (these are what the server sends); the human
 // labels come from `audit.actions.<value>` per locale.
@@ -92,18 +233,16 @@ export default function AuditPage() {
           )}
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          {/* Action Type Filter */}
+          {/* Action Type Filter — searchable single-select */}
           <div>
             <label className="block text-xs font-medium text-gray-500 mb-1">{tx("actionType")}</label>
-            <select
+            <ActionTypeSelect
               value={action}
-              onChange={(e) => { setAction(e.target.value); setPage(1); }}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
-            >
-              {AUDIT_ACTION_VALUES.map((value) => (
-                <option key={value} value={value}>{actionLabel(value)}</option>
-              ))}
-            </select>
+              options={AUDIT_ACTION_VALUES.map((value) => ({ value, label: actionLabel(value) }))}
+              onChange={(v) => { setAction(v); setPage(1); }}
+              searchPlaceholder={tx("searchActions") as string}
+              noMatchLabel={tx("noActionMatches") as string}
+            />
           </div>
 
           {/* Date range — single composite control matching the /attendance filter.

--- a/packages/client/src/pages/audit/AuditPage.tsx
+++ b/packages/client/src/pages/audit/AuditPage.tsx
@@ -2,6 +2,7 @@ import { useAuditLogs } from "@/api/hooks";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Search, Filter, Calendar, RotateCcw } from "lucide-react";
+import { DateRangePicker } from "@/components/DateRangePicker";
 
 // Enum values stay frozen (these are what the server sends); the human
 // labels come from `audit.actions.<value>` per locale.
@@ -90,7 +91,7 @@ export default function AuditPage() {
             </button>
           )}
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {/* Action Type Filter */}
           <div>
             <label className="block text-xs font-medium text-gray-500 mb-1">{tx("actionType")}</label>
@@ -105,31 +106,22 @@ export default function AuditPage() {
             </select>
           </div>
 
-          {/* Start Date */}
+          {/* Date range — single composite control matching the /attendance filter.
+              Replaces the old separate From/To native date inputs; Apply drives
+              start_date / end_date so the query contract is unchanged. */}
           <div>
             <label className="block text-xs font-medium text-gray-500 mb-1">
-              <span className="flex items-center gap-1"><Calendar className="h-3 w-3" /> {tx("fromDate")}</span>
+              <span className="flex items-center gap-1"><Calendar className="h-3 w-3" /> {t("attendance.dateFrom")} &mdash; {t("attendance.dateTo")}</span>
             </label>
-            <input
-              type="date"
-              value={startDate}
-              onChange={(e) => { setStartDate(e.target.value); setPage(1); }}
-              max={endDate || undefined}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
-            />
-          </div>
-
-          {/* End Date */}
-          <div>
-            <label className="block text-xs font-medium text-gray-500 mb-1">
-              <span className="flex items-center gap-1"><Calendar className="h-3 w-3" /> {tx("toDate")}</span>
-            </label>
-            <input
-              type="date"
-              value={endDate}
-              onChange={(e) => { setEndDate(e.target.value); setPage(1); }}
-              min={startDate || undefined}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            <DateRangePicker
+              from={startDate}
+              to={endDate}
+              onApply={(f, to2) => {
+                setStartDate(f);
+                setEndDate(to2);
+                setPage(1);
+              }}
+              allowEmpty
             />
           </div>
         </div>


### PR DESCRIPTION
…RangePicker

The /audit page used two separate native date inputs (From Date / To Date). Swap them for the shared DateRangePicker so the audit filter matches the /attendance "Date From — Date To" experience.

Also redesign the shared DateRangePicker (used by /audit, the /attendance filter, and the attendance export modal) into a larger, easier-to-scan layout:

- Two months side by side (numberOfMonths=2)
- Preset sidebar: Today, Yesterday, Last 7 Days, Last 30 Days, This Month, Last Month, Custom Range — with the active preset highlighted
- Trigger text "June 05, 2026 - June 11, 2026"; Sunday-first weeks
- Footer shows the selected range + Cancel/Apply (Clear kept when clearable)
- Popover now measures its own width for placement so the wide layout stays correctly positioned and viewport-clamped (incl. inside modals)

No API/contract change — the audit query still drives start_date/end_date.