### PR TITLE
fix(dashboard): show 3 module cards per row on desktop

### DIFF
--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -393,7 +393,7 @@ export default function DashboardPage() {
           </Link>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {activeSubscriptions.map((sub) => {
             const mod = moduleMap.get(sub.module_id);
             const isExpanded = expandedModule === sub.id;


### PR DESCRIPTION
## Summary
The dashboard **"Your Modules"** grid was capped at 2 columns (`md:grid-cols-2`). Add `lg:grid-cols-3` so it shows **3 module cards per row** on large screens.

## Details
- One-line change in `DashboardPage.tsx` — `md:grid-cols-2` → `md:grid-cols-2 lg:grid-cols-3`.
- Stays responsive: 1 card on mobile, 2 on tablet, 3 on desktop.

## Verification
Browser-tested at desktop width: the 9 active module cards now lay out 3 per row (verified by measuring card row positions). 0 TypeScript errors.