### PR TITLE
feat(chat): reply from desktop notification (inline reply)

### DIFF
--- a/packages/client/public/chat-sw.js
+++ b/packages/client/public/chat-sw.js
@@ -1,0 +1,90 @@
+/* =============================================================================
+ * EMP Cloud — Chat notification Service Worker
+ * Enables INLINE REPLY from a desktop chat notification (Chrome/Edge: type a
+ * reply in the notification; other browsers fall back to click-to-open).
+ *
+ * It reads the auth token + API origin from IndexedDB (the page syncs them via
+ * src/realtime/sw-bridge.ts — the SW can't read localStorage), then POSTs the
+ * reply to the chat send-message endpoint.
+ * ========================================================================== */
+
+const DB_NAME = "empcloud-chat-sw";
+const STORE = "kv";
+
+// --- tiny IndexedDB key/value helper (no libs in a SW) -----------------------
+function idbGet(key) {
+  return new Promise((resolve) => {
+    const open = indexedDB.open(DB_NAME, 1);
+    open.onupgradeneeded = () => open.result.createObjectStore(STORE);
+    open.onsuccess = () => {
+      const db = open.result;
+      const tx = db.transaction(STORE, "readonly");
+      const req = tx.objectStore(STORE).get(key);
+      req.onsuccess = () => resolve(req.result ?? null);
+      req.onerror = () => resolve(null);
+    };
+    open.onerror = () => resolve(null);
+  });
+}
+
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));
+
+self.addEventListener("notificationclick", (event) => {
+  const notif = event.notification;
+  const data = notif.data || {};
+  const conversationId = data.conversationId;
+  const replyText = (event.reply || "").trim(); // present only for the inline reply action
+
+  notif.close();
+
+  // Inline reply: send it to the chat API, then notify the page so it can
+  // refresh the thread if it's open.
+  if (event.action === "reply" && replyText && conversationId) {
+    event.waitUntil(sendReply(conversationId, replyText, data.origin));
+    return;
+  }
+
+  // Otherwise (click body, or a browser without inline reply): focus/open the app
+  // on that conversation.
+  const target = (data.origin || self.location.origin) + "/messages/" + (conversationId ?? "");
+  event.waitUntil(focusOrOpen(target));
+});
+
+async function sendReply(conversationId, body, origin) {
+  const token = await idbGet("accessToken");
+  const apiBase = (origin || self.location.origin) + "/api/v1";
+  try {
+    const res = await fetch(`${apiBase}/chat/conversations/${conversationId}/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) {
+      // Token may be stale / chat disabled — fall back to opening the app so the
+      // user can resend in-context rather than silently losing the message.
+      await focusOrOpen((origin || self.location.origin) + "/messages/" + conversationId);
+      return;
+    }
+    // Tell any open tab to refetch the thread + conversation list.
+    const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+    for (const c of clients) c.postMessage({ type: "chat:reply-sent", conversationId });
+  } catch {
+    await focusOrOpen((origin || self.location.origin) + "/messages/" + conversationId);
+  }
+}
+
+async function focusOrOpen(url) {
+  const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  for (const c of clients) {
+    // Reuse an existing tab on the same origin.
+    if ("focus" in c) {
+      c.navigate?.(url).catch(() => {});
+      return c.focus();
+    }
+  }
+  return self.clients.openWindow ? self.clients.openWindow(url) : undefined;
+}

--- a/packages/client/public/chat-sw.js
+++ b/packages/client/public/chat-sw.js
@@ -39,8 +39,10 @@ self.addEventListener("notificationclick", (event) => {
   notif.close();
 
   // Inline reply: send it to the chat API, then notify the page so it can
-  // refresh the thread if it's open.
-  if (event.action === "reply" && replyText && conversationId) {
+  // refresh the thread if it's open. Be lenient on `event.action` — some
+  // browsers fire the reply with an empty action string, so treat "has reply
+  // text + a conversation" as a reply regardless of the action label.
+  if (replyText && conversationId) {
     event.waitUntil(sendReply(conversationId, replyText, data.origin));
     return;
   }

--- a/packages/client/src/realtime/SocketProvider.tsx
+++ b/packages/client/src/realtime/SocketProvider.tsx
@@ -16,6 +16,7 @@ import type { ChatMessage, MessageTick, MessageReaction, ConversationSummary } f
 import { useAuthStore } from "@/lib/auth-store";
 import { queryClient } from "@/main";
 import { notifyNewMessage } from "./desktop-notify";
+import { registerChatServiceWorker, syncTokenToServiceWorker } from "./sw-bridge";
 
 const WS_ENABLED = import.meta.env.VITE_CHAT_WS === "true";
 
@@ -136,6 +137,19 @@ export function SocketProvider({ children }: { children: ReactNode }) {
     // and leaves permission stuck at "default" (no notifications ever show). The
     // user grants it via the explicit "Enable desktop alerts" button in the bell
     // dropdown instead.
+
+    // Register the chat service worker + sync the token so the SW can send an
+    // inline reply straight from a desktop notification. Listen for its
+    // "reply-sent" message to refresh the thread the reply landed in.
+    registerChatServiceWorker().then(() => syncTokenToServiceWorker(accessToken));
+    const onSwMessage = (e: MessageEvent) => {
+      if (e.data?.type === "chat:reply-sent") {
+        const cid = e.data.conversationId;
+        queryClient.invalidateQueries({ queryKey: ["chat-conversations"] });
+        if (cid) queryClient.invalidateQueries({ queryKey: msgKey(cid) });
+      }
+    };
+    navigator.serviceWorker?.addEventListener("message", onSwMessage);
 
     // Function-form auth re-reads the freshest token on every (re)connect.
     const socket = io("/chat", {
@@ -302,6 +316,7 @@ export function SocketProvider({ children }: { children: ReactNode }) {
       socket.disconnect();
       socketRef.current = null;
       setConnected(false);
+      navigator.serviceWorker?.removeEventListener("message", onSwMessage);
       typingTimers.current.forEach((t) => clearTimeout(t));
       typingTimers.current.clear();
       setTyping({});

--- a/packages/client/src/realtime/desktop-notify.ts
+++ b/packages/client/src/realtime/desktop-notify.ts
@@ -93,9 +93,14 @@ export function notifyNewMessage(
         // `actions`/`renotify` exist at runtime but aren't all in the TS lib type.
         actions: [{ action: "reply", type: "text", title: "Reply", placeholder: "Type a reply…" }],
         renotify: true,
+        // Keep it on screen until the user acts — without this Windows/Chrome can
+        // auto-dismiss (or suppress) the popup, especially while the tab is
+        // focused, which makes the reply box easy to miss.
+        requireInteraction: true,
       } as NotificationOptions & {
         actions?: { action: string; type?: string; title: string; placeholder?: string }[];
         renotify?: boolean;
+        requireInteraction?: boolean;
       })
       .catch(() => fallbackNotification(title, body, tag, onClick));
     return;

--- a/packages/client/src/realtime/desktop-notify.ts
+++ b/packages/client/src/realtime/desktop-notify.ts
@@ -8,6 +8,7 @@
 // worker. Requires the tab to be open somewhere (background is fine).
 
 import type { ChatMessage } from "@empcloud/shared";
+import { getChatSwRegistration } from "./sw-bridge";
 
 const SUPPORTED = typeof window !== "undefined" && "Notification" in window;
 // Only nag for permission once per session if the user dismissed it.
@@ -51,6 +52,10 @@ const recentlyNotified = new Set<number>();
  * Show a desktop notification for an incoming message. `conversationTitle` is
  * the group name or the sender's name (for direct chats). `onClick` is invoked
  * when the user clicks the notification (focus tab + open the conversation).
+ *
+ * Prefers the Service Worker's showNotification when available — that's the only
+ * way to attach a "Reply" action (inline reply box in Chrome/Edge). Falls back
+ * to the plain Notification (no reply action) when no SW is registered.
  */
 export function notifyNewMessage(
   message: ChatMessage,
@@ -72,13 +77,39 @@ export function notifyNewMessage(
     conversationTitle === message.sender_name
       ? message.sender_name
       : `${message.sender_name} · ${conversationTitle}`;
+  const body = previewOf(message);
+  const tag = `chat-${message.conversation_id}`;
 
+  // --- Preferred path: SW notification with an inline "Reply" action ---
+  const reg = getChatSwRegistration();
+  if (reg) {
+    reg
+      .showNotification(title, {
+        body,
+        tag,
+        icon: "/favicon.ico",
+        // Carry what the SW needs to send the reply / open the right thread.
+        data: { conversationId: message.conversation_id, origin: window.location.origin },
+        // `actions`/`renotify` exist at runtime but aren't all in the TS lib type.
+        actions: [{ action: "reply", type: "text", title: "Reply", placeholder: "Type a reply…" }],
+        renotify: true,
+      } as NotificationOptions & {
+        actions?: { action: string; type?: string; title: string; placeholder?: string }[];
+        renotify?: boolean;
+      })
+      .catch(() => fallbackNotification(title, body, tag, onClick));
+    return;
+  }
+
+  // --- Fallback: plain Notification (no reply action) ---
+  fallbackNotification(title, body, tag, onClick);
+}
+
+function fallbackNotification(title: string, body: string, tag: string, onClick: () => void): void {
   try {
     const n = new Notification(title, {
-      body: previewOf(message),
-      // Group notifications from the same conversation so they stack/replace.
-      tag: `chat-${message.conversation_id}`,
-      // `renotify` is valid at runtime but missing from the TS lib's options.
+      body,
+      tag,
       renotify: true,
       icon: "/favicon.ico",
     } as NotificationOptions & { renotify?: boolean });
@@ -87,7 +118,6 @@ export function notifyNewMessage(
       onClick();
       n.close();
     };
-    // Auto-dismiss after a few seconds (some browsers keep them sticky).
     setTimeout(() => n.close(), 6000);
   } catch {
     /* notification construction can throw on some platforms — ignore */

--- a/packages/client/src/realtime/sw-bridge.ts
+++ b/packages/client/src/realtime/sw-bridge.ts
@@ -33,9 +33,15 @@ function idbSet(key: string, value: unknown): Promise<void> {
 /** Register the chat SW (idempotent). Returns the registration or null. */
 export async function registerChatServiceWorker(): Promise<ServiceWorkerRegistration | null> {
   if (!SW_SUPPORTED) return null;
-  if (registration) return registration;
+  if (registration?.active) return registration;
   try {
-    registration = await navigator.serviceWorker.register("/chat-sw.js", { scope: "/" });
+    await navigator.serviceWorker.register("/chat-sw.js", { scope: "/" });
+    // Wait until a worker is actually ACTIVE before we treat the SW as usable —
+    // a registration with no active worker can't reliably own showNotification
+    // (and its notificationclick wouldn't route back to it). navigator.
+    // serviceWorker.ready resolves with the active registration controlling
+    // this page.
+    registration = await navigator.serviceWorker.ready;
     await idbSet("origin", window.location.origin);
     return registration;
   } catch {

--- a/packages/client/src/realtime/sw-bridge.ts
+++ b/packages/client/src/realtime/sw-bridge.ts
@@ -1,0 +1,57 @@
+// =============================================================================
+// EMP Cloud — Chat Service Worker bridge (page side)
+// Registers /chat-sw.js and mirrors the auth token + origin into IndexedDB so
+// the SW can authenticate the inline-reply POST (a SW can't read localStorage).
+// Notification action buttons (inline reply) require a Service Worker; this is
+// what makes "reply from the notification" possible in Chrome/Edge.
+// =============================================================================
+
+const DB_NAME = "empcloud-chat-sw";
+const STORE = "kv";
+
+const SW_SUPPORTED =
+  typeof navigator !== "undefined" &&
+  "serviceWorker" in navigator &&
+  typeof indexedDB !== "undefined";
+
+let registration: ServiceWorkerRegistration | null = null;
+
+function idbSet(key: string, value: unknown): Promise<void> {
+  return new Promise((resolve) => {
+    const open = indexedDB.open(DB_NAME, 1);
+    open.onupgradeneeded = () => open.result.createObjectStore(STORE);
+    open.onsuccess = () => {
+      const tx = open.result.transaction(STORE, "readwrite");
+      tx.objectStore(STORE).put(value, key);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => resolve();
+    };
+    open.onerror = () => resolve();
+  });
+}
+
+/** Register the chat SW (idempotent). Returns the registration or null. */
+export async function registerChatServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!SW_SUPPORTED) return null;
+  if (registration) return registration;
+  try {
+    registration = await navigator.serviceWorker.register("/chat-sw.js", { scope: "/" });
+    await idbSet("origin", window.location.origin);
+    return registration;
+  } catch {
+    return null;
+  }
+}
+
+/** Keep the SW's copy of the access token fresh (call on login + token refresh). */
+export async function syncTokenToServiceWorker(token: string | null): Promise<void> {
+  if (!SW_SUPPORTED) return;
+  await idbSet("accessToken", token ?? "");
+}
+
+/** The active registration, if registered. */
+export function getChatSwRegistration(): ServiceWorkerRegistration | null {
+  return registration;
+}
+
+export const chatServiceWorkerSupported = SW_SUPPORTED;


### PR DESCRIPTION
## Summary
Adds an inline **"Reply"** action to chat desktop notifications, so a user can reply to a message **straight from the notification** without opening the app.

## How it works
- **`public/chat-sw.js`** — a service worker (notification action buttons require one). On `notificationclick` with the `reply` action it reads the typed reply, the auth token (from IndexedDB), and the conversation id (from the notification `data`), then `POST`s to `/api/v1/chat/conversations/:id/messages`. If the send fails (stale token, etc.) it falls back to focusing the app on that thread.
- **`src/realtime/sw-bridge.ts`** — registers the SW and mirrors the access token + origin into IndexedDB (a SW can't read localStorage), refreshed on every (re)connect / token change.
- **`desktop-notify.ts`** — prefers the SW's `showNotification` with a `{ action: "reply", type: "text" }` action; falls back to the plain `Notification` (no reply action) when no SW is registered.
- **`SocketProvider`** — registers the SW + syncs the token, and refreshes the thread when the SW posts back `chat:reply-sent`.

## Browser support / caveats
- **Inline text reply** works in **Chrome/Edge** (desktop & Android). **Firefox/Safari** don't support notification text input — they fall back to click-to-open (the previous behavior).
- Service workers require **HTTPS** (works on the test server + localhost; not plain HTTP).
- The token is mirrored to IndexedDB **only for the SW's own reply call** — never logged or sent anywhere else.

## Verification (CDP)
- SW registers (`/chat-sw.js` active) ✅
- Access token synced to IndexedDB ✅
- `showNotification` renders with the inline **Reply** action (`reply-action-shown`) ✅
- The exact SW reply call (`POST .../messages {body}`) returns **201** and posts the message ✅
- 0 TypeScript errors.

Branched off `main`.