### PR TITLE
feat(chat): auto-focus composer on conversation open

### DIFF
--- a/packages/client/src/pages/messages/MessageThread.tsx
+++ b/packages/client/src/pages/messages/MessageThread.tsx
@@ -309,6 +309,18 @@ export default function MessageThread({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
 
+  // Auto-focus the composer when a conversation opens, so the user can start
+  // typing immediately. rAF defers until after the thread renders; skip on
+  // touch devices (focusing pops the virtual keyboard unexpectedly).
+  useEffect(() => {
+    const isTouch =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(pointer: coarse)").matches;
+    if (isTouch) return;
+    const id = requestAnimationFrame(() => textareaRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [conversationId]);
+
   // Auto-grow the composer to fit its content (capped by the textarea's
   // max-height; it scrolls beyond that). Runs on every draft change, including
   // programmatic edits (mention insert, emoji, reset after send).


### PR DESCRIPTION
## Summary
Auto-focuses the message composer ("Type a message…") when a conversation opens, so the user can start typing immediately without clicking into the input first.

## Behavior
- Opening / switching to any conversation focuses the composer textarea
- Deferred via `requestAnimationFrame` so it runs after the thread renders
- **Skipped on touch devices** (`pointer: coarse`) — auto-focusing there would pop the virtual keyboard unexpectedly

## Implementation
- One `useEffect` keyed on `conversationId` in `MessageThread.tsx`, reusing the existing `textareaRef`. No new refs, no other changes.

## Verification (CDP headless)
- On opening a conversation, `document.activeElement` is the `TEXTAREA` with placeholder "Type a message…" → **PASS**
- 0 TypeScript errors

Branched off `main`.