### PR TITLE
fix(chat): show why "Create group" is disabled (missing name hint)

### DIFF
--- a/packages/client/src/pages/messages/NewChatModal.tsx
+++ b/packages/client/src/pages/messages/NewChatModal.tsx
@@ -275,7 +275,13 @@ export default function NewChatModal({
         {mode === "group" && (
           <div className="px-5 py-4 border-t border-gray-100 flex items-center justify-between gap-3">
             <span className="text-xs text-gray-500">
-              {selectedIds.length} selected{selectedIds.length < 2 ? " · need ≥ 2" : ""}
+              {!groupName.trim() ? (
+                <span className="text-amber-600">Enter a group name to continue</span>
+              ) : selectedIds.length < 2 ? (
+                <span className="text-amber-600">{selectedIds.length} selected · need ≥ 2</span>
+              ) : (
+                `${selectedIds.length} selected`
+              )}
             </span>
             <button
               onClick={createGroup}


### PR DESCRIPTION
## Problem
Users reported being "not able to create a group." The **Create group** button is disabled until a group name is entered (`disabled={... || !groupName.trim() || selectedIds.length < 2}`), but the footer gave **no indication why** — so clicking the faded button did nothing and looked broken.

(The backend is fine — `POST /chat/conversations/group` returns 201 with a valid group. This was purely missing UI feedback.)

## Fix
The footer status text now explains what's blocking creation:
- Empty name → **"Enter a group name to continue"** (amber)
- Fewer than 2 selected → **"N selected · need ≥ 2"** (amber)
- Otherwise → "N selected"

## Verification
- create-group API confirmed working (201) end-to-end
- 0 TypeScript errors

Branched off `main`.