### PR TITLE
fix(chat/dashboard): four verified audit fixes (banner persistence, a11y, tooltip, unread badge)

### DIFF
--- a/packages/client/src/components/dashboard/WidgetCard.tsx
+++ b/packages/client/src/components/dashboard/WidgetCard.tsx
@@ -171,6 +171,9 @@ export default function WidgetCard({
       {/* View Details link — refreshes token then launches with SSO */}
       {moduleUrl && (
         <button
+          // Opens the module in a new tab (SSO) — announce that to screen
+          // readers (WCAG 3.2.5); the icon is decorative.
+          aria-label={`${t('dashboard.viewDetails')} — ${title} (${t('dashboard.opensInNewTab')})`}
           onClick={async () => {
             let token = useAuthStore.getState().accessToken || "";
             const refreshToken = useAuthStore.getState().refreshToken;
@@ -195,7 +198,7 @@ export default function WidgetCard({
           }}
           className={`mt-4 flex items-center gap-1.5 text-xs font-medium ${c.icon} hover:underline`}
         >
-          {t('dashboard.viewDetails')} <ExternalLink className="h-3 w-3" />
+          {t('dashboard.viewDetails')} <ExternalLink className="h-3 w-3" aria-hidden="true" />
         </button>
       )}
     </div>

--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -71,6 +71,18 @@ export default function DashboardLayout() {
   });
   const chatEnabled = chatStatus?.enabled !== false;
 
+  // Live unread-message count for the Messages nav badge. Polls on a modest
+  // interval (the socket also nudges chat caches on new messages). Only runs
+  // when chat is enabled for this org.
+  const { data: chatUnread } = useQuery({
+    queryKey: ["chat-unread-count"],
+    queryFn: () => api.get("/chat/unread-count").then((r) => r.data.data?.unread_count ?? 0),
+    enabled: !!user && chatEnabled,
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+  });
+  const unreadByPath: Record<string, number> = { "/messages": chatUnread ?? 0 };
+
   const hasBiometrics = (subscriptions || []).some(
     (s: any) => s.module_slug === "emp-biometrics" && (s.status === "active" || s.status === "trial")
   );
@@ -174,7 +186,7 @@ export default function DashboardLayout() {
 
       <nav ref={sidebarNavRef} className="flex-1 p-4 space-y-1 overflow-y-auto">
         {user?.role !== "super_admin" && <>
-          <NavSection label="" items={sidebarItems} location={location} t={t} />
+          <NavSection label="" items={sidebarItems} location={location} t={t} unreadByPath={unreadByPath} />
           {isHR && (
             // Positions is now a single collapsible parent (label rendered
             // by the NavItem itself), so the section label here would be a

--- a/packages/client/src/components/layout/NavSection.tsx
+++ b/packages/client/src/components/layout/NavSection.tsx
@@ -10,6 +10,18 @@ interface NavSectionProps {
   location: { pathname: string };
   t: (key: string) => string;
   activeClass?: string;
+  /** Live unread counts keyed by nav path (e.g. { "/messages": 3 }). */
+  unreadByPath?: Record<string, number>;
+}
+
+/** Small red count badge for a nav item (e.g. unread messages). */
+function CountBadge({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span className="ml-auto inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-red-500 px-1.5 text-[11px] font-semibold text-white">
+      {count > 99 ? "99+" : count}
+    </span>
+  );
 }
 
 function isItemActive(item: NavItem, pathname: string, allItems: NavItem[]): boolean {
@@ -23,7 +35,7 @@ function isItemActive(item: NavItem, pathname: string, allItems: NavItem[]): boo
     : isExact || (isPrefix && !hasMoreSpecificMatch);
 }
 
-export function NavSection({ label, items, location, t, activeClass = "bg-brand-50 text-brand-700" }: NavSectionProps) {
+export function NavSection({ label, items, location, t, activeClass = "bg-brand-50 text-brand-700", unreadByPath }: NavSectionProps) {
   return (
     <>
       {label && (
@@ -47,6 +59,7 @@ export function NavSection({ label, items, location, t, activeClass = "bg-brand-
             t={t}
             activeClass={activeClass}
             allItems={items}
+            unread={unreadByPath?.[item.path] ?? 0}
           />
         )
       )}
@@ -61,6 +74,7 @@ function NavLink({
   activeClass,
   allItems = [],
   indent = false,
+  unread = 0,
 }: {
   item: NavItem;
   location: { pathname: string };
@@ -68,6 +82,7 @@ function NavLink({
   activeClass: string;
   allItems?: NavItem[];
   indent?: boolean;
+  unread?: number;
 }) {
   const Icon = item.icon;
   const isActive = isItemActive(item, location.pathname, allItems);
@@ -89,6 +104,7 @@ function NavLink({
       <Icon className={`${indent ? "h-4 w-4" : "h-5 w-5"} flex-shrink-0`} />
       <span className="flex-1">{label}</span>
       {item.badge && <AiBadge label={item.badge} />}
+      <CountBadge count={unread} />
     </Link>
   );
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -458,7 +458,8 @@
       "documents": "المستندات",
       "announcements": "الإعلانات",
       "policies": "السياسات"
-    }
+    },
+    "opensInNewTab": "يفتح في علامة تبويب جديدة"
   },
   "plans": {
     "basic": "أساسي",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -458,7 +458,8 @@
       "documents": "Dokumente",
       "announcements": "Ankündigungen",
       "policies": "Richtlinien"
-    }
+    },
+    "opensInNewTab": "wird in neuem Tab geöffnet"
   },
   "plans": {
     "basic": "Basis",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -452,6 +452,7 @@
     "readMore": "Read more",
     "overdue": "overdue",
     "viewDetails": "View Details",
+    "opensInNewTab": "opens in new tab",
     "quickLinks": {
       "employees": "Employee Directory",
       "attendance": "Attendance",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -458,7 +458,8 @@
       "documents": "Documentos",
       "announcements": "Anuncios",
       "policies": "Políticas"
-    }
+    },
+    "opensInNewTab": "se abre en una pestaña nueva"
   },
   "plans": {
     "basic": "Básico",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -458,7 +458,8 @@
       "documents": "Documents",
       "announcements": "Annonces",
       "policies": "Politiques"
-    }
+    },
+    "opensInNewTab": "s'ouvre dans un nouvel onglet"
   },
   "plans": {
     "basic": "Basique",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -458,7 +458,8 @@
       "documents": "दस्तावेज़",
       "announcements": "घोषणाएँ",
       "policies": "नीतियाँ"
-    }
+    },
+    "opensInNewTab": "नए टैब में खुलता है"
   },
   "plans": {
     "basic": "बेसिक",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -458,7 +458,8 @@
       "documents": "ドキュメント",
       "announcements": "お知らせ",
       "policies": "ポリシー"
-    }
+    },
+    "opensInNewTab": "新しいタブで開く"
   },
   "plans": {
     "basic": "ベーシック",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -458,7 +458,8 @@
       "documents": "Documentos",
       "announcements": "Avisos",
       "policies": "Políticas"
-    }
+    },
+    "opensInNewTab": "abre em uma nova aba"
   },
   "plans": {
     "basic": "Básico",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -458,7 +458,8 @@
       "documents": "文档",
       "announcements": "公告",
       "policies": "政策"
-    }
+    },
+    "opensInNewTab": "在新标签页中打开"
   },
   "plans": {
     "basic": "基础版",

--- a/packages/client/src/pages/messages/EnableNotificationsBanner.tsx
+++ b/packages/client/src/pages/messages/EnableNotificationsBanner.tsx
@@ -19,7 +19,9 @@ export function EnableNotificationsBanner() {
     SUPPORTED ? Notification.permission : "unsupported",
   );
   const [dismissed, setDismissed] = useState(
-    () => sessionStorage.getItem(DISMISS_KEY) === "1",
+    // localStorage (not sessionStorage) so a dismissal persists across reloads
+    // and browser restarts — the banner shouldn't keep coming back every visit.
+    () => localStorage.getItem(DISMISS_KEY) === "1",
   );
   const [asking, setAsking] = useState(false);
 
@@ -51,7 +53,7 @@ export function EnableNotificationsBanner() {
   };
 
   const dismiss = () => {
-    sessionStorage.setItem(DISMISS_KEY, "1");
+    localStorage.setItem(DISMISS_KEY, "1");
     setDismissed(true);
   };
 

--- a/packages/client/src/pages/messages/MessagesPage.tsx
+++ b/packages/client/src/pages/messages/MessagesPage.tsx
@@ -108,7 +108,10 @@ function ConversationRow({
             )}
           </span>
           {conv.last_message_at && (
-            <span className="text-[11px] text-gray-400 flex-shrink-0">
+            <span
+              className="text-[11px] text-gray-400 flex-shrink-0"
+              title={new Date(conv.last_message_at).toLocaleString()}
+            >
               {relativeTime(conv.last_message_at)}
             </span>
           )}
@@ -498,7 +501,10 @@ export default function MessagesPage() {
                         <span className="truncate text-sm font-medium text-gray-800">
                           {hit.conversation_title}
                         </span>
-                        <span className="flex-shrink-0 text-[10px] text-gray-400">
+                        <span
+                          className="flex-shrink-0 text-[10px] text-gray-400"
+                          title={new Date(hit.created_at).toLocaleString()}
+                        >
                           {relativeTime(hit.created_at)}
                         </span>
                       </span>


### PR DESCRIPTION
## Context
Implements the audit-report findings that **held up after verifying each against the actual code**. Most of the 13-item report was false positives or dev-only artifacts (StrictMode double-mounts misread as a polling bug, Vite dev-server per-icon ESM misread as a bundle problem, "no caching" despite the app using TanStack Query with `staleTime`, etc.). These 4 are the genuinely real, worthwhile fixes.

## Changes
1. **Banner dismissal persists** (`EnableNotificationsBanner.tsx`) — `sessionStorage` → `localStorage`, so dismissing the "Enable alerts" banner survives reloads and browser restarts instead of reappearing every session.
2. **New-tab a11y** (`WidgetCard.tsx`) — module "View Details" buttons open a new tab via SSO; now they carry an `aria-label` announcing "opens in new tab" (WCAG 3.2.5), and the `ExternalLink` icon is `aria-hidden`. Adds the `dashboard.opensInNewTab` i18n key to all 9 locales.
3. **Timestamp tooltip** (`MessagesPage.tsx`) — relative timestamps ("4h", "1d") in the conversation list and search results now show the full local date/time on hover (`title` attribute).
4. **Messages nav unread badge** (`NavSection.tsx`, `DashboardLayout.tsx`) — wires the **already-existing** `GET /api/v1/chat/unread-count` endpoint (comment in the route literally says "nav badge") to a red count badge on the Messages sidebar link. Polled every 30s, gated on chat being enabled for the org, shows "99+" past 99.

## Verification
- Unread badge renders **"99+"** live in headless Chrome ✅
- `/chat/unread-count` returns a valid count (200) ✅
- 0 TypeScript errors

## Explicitly NOT done (verified false positives)
Priya avatar "broken render", Active-Modules card missing number, deleted-message actions, lucide micro-bundles, modules empty-state CTA, and the two "High" severity items (duplicate API calls = StrictMode dev artifact; "no caching layer" = app already uses TanStack Query). See the verification for details.

Branched off `main`.