### PR TITLE
feat(positions): add search and 10-per-page pagination to headcount p…

### DIFF
--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1663,6 +1663,7 @@
     "headcountPlans": {
       "title": "Headcount Plans",
       "subtitle": "Plan and track workforce growth across departments.",
+      "searchPlaceholder": "Search by plan title or fiscal year...",
       "newPlan": "New Plan",
       "createTitle": "Create Headcount Plan",
       "planTitleLabel": "Title",

--- a/packages/client/src/pages/positions/HeadcountPlanPage.tsx
+++ b/packages/client/src/pages/positions/HeadcountPlanPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { Plus, ChevronLeft, ChevronRight, CheckCircle, Clock, FileText, X } from "lucide-react";
+import { Plus, ChevronLeft, ChevronRight, CheckCircle, Clock, FileText, X, Search } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments } from "@/api/hooks";
 import { showToast } from "@/components/ui/Toast";
@@ -12,6 +12,7 @@ export default function HeadcountPlanPage() {
     t(`positions.headcountPlans.${k}`, opts ?? {});
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("");
   const [showCreate, setShowCreate] = useState(false);
   // #1548 — Detail modal: plans are clickable and open this full-detail view
@@ -28,14 +29,15 @@ export default function HeadcountPlanPage() {
   const deptList = departments || [];
 
   const { data, isLoading } = useQuery({
-    queryKey: ["headcount-plans", { page, status: statusFilter }],
+    queryKey: ["headcount-plans", { page, status: statusFilter, search }],
     queryFn: () =>
       api
         .get("/positions/headcount-plans", {
           params: {
             page,
-            per_page: 20,
+            per_page: 10,
             ...(statusFilter ? { status: statusFilter } : {}),
+            ...(search ? { search } : {}),
           },
         })
         .then((r) => r.data),
@@ -290,7 +292,17 @@ export default function HeadcountPlanPage() {
       )}
 
       {/* Filters */}
-      <div className="flex gap-3 mb-6">
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+            className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            placeholder={tx("searchPlaceholder") as string}
+          />
+        </div>
         <select
           value={statusFilter}
           onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}

--- a/packages/server/src/api/routes/position.routes.ts
+++ b/packages/server/src/api/routes/position.routes.ts
@@ -81,6 +81,7 @@ router.get("/headcount-plans", authenticate, requirePermission("positions:view",
       fiscal_year: query.fiscal_year,
       status: query.status,
       department_id: query.department_id,
+      search: query.search,
     });
     sendPaginated(res, result.plans, result.total, query.page, query.per_page);
   } catch (err) { next(err); }

--- a/packages/server/src/services/position/position.service.ts
+++ b/packages/server/src/services/position/position.service.ts
@@ -485,6 +485,7 @@ export async function listHeadcountPlans(
     fiscal_year?: string;
     status?: string;
     department_id?: number;
+    search?: string;
   }
 ) {
   const db = getDB();
@@ -502,6 +503,13 @@ export async function listHeadcountPlans(
   }
   if (params?.department_id) {
     query = query.where({ "headcount_plans.department_id": params.department_id });
+  }
+  if (params?.search) {
+    const s = `%${params.search}%`;
+    query = query.where(function () {
+      this.where("headcount_plans.title", "like", s)
+        .orWhere("headcount_plans.fiscal_year", "like", s);
+    });
   }
 
   const [{ count }] = await query.clone().count("* as count");

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1254,6 +1254,7 @@ export const headcountPlanQuerySchema = paginationSchema.extend({
   fiscal_year: z.string().optional(),
   status: headcountPlanStatusEnum.optional(),
   department_id: z.coerce.number().int().positive().optional(),
+  search: z.string().optional(),
 });
 
 export type CreatePositionInput = z.infer<typeof createPositionSchema>;


### PR DESCRIPTION
…lans

Add a search box to the Headcount Plans page that filters by plan title or fiscal year, wired end-to-end: shared headcountPlanQuerySchema accepts a `search` param, listHeadcountPlans applies a LIKE filter over title and fiscal_year (before the count so totals/pagination stay correct), and the route passes it through. Mirrors the existing positions-list search.

Also drop the headcount list page size from 20 to 10 so the existing pagination controls surface sooner.