### PR TITLE
fix(i18n): translate the Custom Fields page

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2575,6 +2575,23 @@
     "saving": "جارٍ الحفظ...",
     "updateFieldBtn": "تحديث الحقل",
     "createField": "إنشاء حقل",
-    "cancel": "إلغاء"
+    "cancel": "إلغاء",
+    "loading": "جارٍ تحميل الحقول...",
+    "empty": "لا توجد حقول مخصصة مُعرّفة لـ {{entity}}.",
+    "emptyHint": "انقر على \"إضافة حقل\" لإنشاء أول حقل مخصص لك.",
+    "colFieldName": "اسم الحقل",
+    "colKey": "المفتاح",
+    "colType": "النوع",
+    "colActions": "الإجراءات",
+    "optionsCount_one": "({{count}} خيار)",
+    "optionsCount_other": "({{count}} خيارات)",
+    "yes": "نعم",
+    "no": "لا",
+    "editFieldAria": "تعديل الحقل",
+    "deleteFieldAria": "حذف الحقل",
+    "deactivateNamed": "إلغاء تفعيل الحقل \"{{name}}\"؟",
+    "deactivate": "إلغاء تفعيل الحقل؟",
+    "deactivateDesc": "سيتم الاحتفاظ بالقيم الموجودة.",
+    "deactivateBtn": "إلغاء التفعيل"
   }
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "إلغاء تفعيل الحقل \"{{name}}\"؟",
     "deactivate": "إلغاء تفعيل الحقل؟",
     "deactivateDesc": "سيتم الاحتفاظ بالقيم الموجودة.",
-    "deactivateBtn": "إلغاء التفعيل"
+    "deactivateBtn": "إلغاء التفعيل",
+    "previewFieldName": "اسم الحقل",
+    "previewEnter": "أدخل {{name}}",
+    "previewValue": "قيمة",
+    "previewSelect": "اختر {{name}}...",
+    "previewOption": "خيار",
+    "noOptionsDefined": "لا توجد خيارات مُعرّفة",
+    "previewCheckbox": "مربع اختيار"
   }
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2550,20 +2550,12 @@
       "project": "المشروع",
       "document": "المستند"
     },
-    "fieldType": {
-      "text": "نص",
-      "textarea": "منطقة نص",
-      "number": "رقم",
-      "decimal": "عدد عشري",
-      "date": "تاريخ",
-      "datetime": "التاريخ والوقت",
-      "dropdown": "قائمة منسدلة",
-      "multi_select": "اختيار متعدد",
-      "checkbox": "مربع اختيار",
-      "email": "البريد الإلكتروني",
-      "phone": "الهاتف",
-      "url": "رابط",
-      "file": "ملف"
-    }
+    "fieldType": "نوع الحقل *",
+    "editField": "تعديل الحقل",
+    "newField": "حقل جديد",
+    "preview": "معاينة",
+    "hidePreview": "إخفاء المعاينة",
+    "fieldName": "اسم الحقل *",
+    "fieldNamePlaceholder": "مثل: مقاس التيشيرت"
   }
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2556,6 +2556,12 @@
     "preview": "معاينة",
     "hidePreview": "إخفاء المعاينة",
     "fieldName": "اسم الحقل *",
-    "fieldNamePlaceholder": "مثل: مقاس التيشيرت"
+    "fieldNamePlaceholder": "مثل: مقاس التيشيرت",
+    "section": "القسم",
+    "placeholder": "نص توضيحي",
+    "defaultValue": "القيمة الافتراضية",
+    "validationRegex": "تعبير نمطي للتحقق",
+    "minValue": "الحد الأدنى",
+    "maxValue": "الحد الأقصى"
   }
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2538,5 +2538,32 @@
       "damaged": "تالف",
       "updated": "تم التحديث"
     }
+  },
+  "customFields": {
+    "title": "الحقول المخصصة",
+    "subtitle": "حدّد حقول بيانات مخصصة للموظفين والأقسام والكيانات الأخرى",
+    "addField": "إضافة حقل",
+    "entity": {
+      "employee": "الموظف",
+      "department": "القسم",
+      "location": "الموقع",
+      "project": "المشروع",
+      "document": "المستند"
+    },
+    "fieldType": {
+      "text": "نص",
+      "textarea": "منطقة نص",
+      "number": "رقم",
+      "decimal": "عدد عشري",
+      "date": "تاريخ",
+      "datetime": "التاريخ والوقت",
+      "dropdown": "قائمة منسدلة",
+      "multi_select": "اختيار متعدد",
+      "checkbox": "مربع اختيار",
+      "email": "البريد الإلكتروني",
+      "phone": "الهاتف",
+      "url": "رابط",
+      "file": "ملف"
+    }
   }
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2550,7 +2550,21 @@
       "project": "المشروع",
       "document": "المستند"
     },
-    "fieldType": "نوع الحقل *",
+    "fieldType": {
+      "text": "نص",
+      "textarea": "منطقة نص",
+      "number": "رقم",
+      "decimal": "عدد عشري",
+      "date": "تاريخ",
+      "datetime": "التاريخ والوقت",
+      "dropdown": "قائمة منسدلة",
+      "multi_select": "اختيار متعدد",
+      "checkbox": "مربع اختيار",
+      "email": "البريد الإلكتروني",
+      "phone": "الهاتف",
+      "url": "رابط",
+      "file": "ملف"
+    },
     "editField": "تعديل الحقل",
     "newField": "حقل جديد",
     "preview": "معاينة",
@@ -2599,6 +2613,7 @@
     "previewSelect": "اختر {{name}}...",
     "previewOption": "خيار",
     "noOptionsDefined": "لا توجد خيارات مُعرّفة",
-    "previewCheckbox": "مربع اختيار"
+    "previewCheckbox": "مربع اختيار",
+    "fieldTypeField": "نوع الحقل *"
   }
 }

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "القيمة الافتراضية",
     "validationRegex": "تعبير نمطي للتحقق",
     "minValue": "الحد الأدنى",
-    "maxValue": "الحد الأقصى"
+    "maxValue": "الحد الأقصى",
+    "helpText": "نص المساعدة",
+    "helpTextPlaceholder": "تلميح أو وصف يظهر للمستخدمين",
+    "options": "الخيارات",
+    "optionPlaceholder": "اكتب الخيار واضغط Enter",
+    "add": "إضافة",
+    "required": "مطلوب",
+    "searchable": "قابل للبحث",
+    "fieldPreview": "معاينة الحقل",
+    "saveError": "فشل حفظ الحقل. يرجى المحاولة مرة أخرى.",
+    "saving": "جارٍ الحفظ...",
+    "updateFieldBtn": "تحديث الحقل",
+    "createField": "إنشاء حقل",
+    "cancel": "إلغاء"
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "Standardwert",
     "validationRegex": "Validierungs-Regex",
     "minValue": "Min.-Wert",
-    "maxValue": "Max.-Wert"
+    "maxValue": "Max.-Wert",
+    "helpText": "Hilfetext",
+    "helpTextPlaceholder": "Tooltip oder Beschreibung für Benutzer",
+    "options": "Optionen",
+    "optionPlaceholder": "Option eingeben und Enter drücken",
+    "add": "Hinzufügen",
+    "required": "Pflicht",
+    "searchable": "Durchsuchbar",
+    "fieldPreview": "Feldvorschau",
+    "saveError": "Feld konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "saving": "Wird gespeichert...",
+    "updateFieldBtn": "Feld aktualisieren",
+    "createField": "Feld erstellen",
+    "cancel": "Abbrechen"
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2538,5 +2538,32 @@
       "damaged": "Beschädigt",
       "updated": "Aktualisiert"
     }
+  },
+  "customFields": {
+    "title": "Benutzerdefinierte Felder",
+    "subtitle": "Definieren Sie benutzerdefinierte Datenfelder für Mitarbeiter, Abteilungen und andere Entitäten",
+    "addField": "Feld hinzufügen",
+    "entity": {
+      "employee": "Mitarbeiter",
+      "department": "Abteilung",
+      "location": "Standort",
+      "project": "Projekt",
+      "document": "Dokument"
+    },
+    "fieldType": {
+      "text": "Text",
+      "textarea": "Textbereich",
+      "number": "Zahl",
+      "decimal": "Dezimalzahl",
+      "date": "Datum",
+      "datetime": "Datum und Uhrzeit",
+      "dropdown": "Dropdown",
+      "multi_select": "Mehrfachauswahl",
+      "checkbox": "Kontrollkästchen",
+      "email": "E-Mail",
+      "phone": "Telefon",
+      "url": "URL",
+      "file": "Datei"
+    }
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2556,6 +2556,12 @@
     "preview": "Vorschau",
     "hidePreview": "Vorschau ausblenden",
     "fieldName": "Feldname *",
-    "fieldNamePlaceholder": "z. B. T-Shirt-Größe"
+    "fieldNamePlaceholder": "z. B. T-Shirt-Größe",
+    "section": "Abschnitt",
+    "placeholder": "Platzhalter",
+    "defaultValue": "Standardwert",
+    "validationRegex": "Validierungs-Regex",
+    "minValue": "Min.-Wert",
+    "maxValue": "Max.-Wert"
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "Feld \"{{name}}\" deaktivieren?",
     "deactivate": "Feld deaktivieren?",
     "deactivateDesc": "Vorhandene Werte bleiben erhalten.",
-    "deactivateBtn": "Deaktivieren"
+    "deactivateBtn": "Deaktivieren",
+    "previewFieldName": "Feldname",
+    "previewEnter": "{{name}} eingeben",
+    "previewValue": "Wert",
+    "previewSelect": "{{name}} auswählen...",
+    "previewOption": "Option",
+    "noOptionsDefined": "Keine Optionen definiert",
+    "previewCheckbox": "Kontrollkästchen"
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2550,7 +2550,21 @@
       "project": "Projekt",
       "document": "Dokument"
     },
-    "fieldType": "Feldtyp *",
+    "fieldType": {
+      "text": "Text",
+      "textarea": "Textbereich",
+      "number": "Zahl",
+      "decimal": "Dezimalzahl",
+      "date": "Datum",
+      "datetime": "Datum und Uhrzeit",
+      "dropdown": "Dropdown",
+      "multi_select": "Mehrfachauswahl",
+      "checkbox": "Kontrollkästchen",
+      "email": "E-Mail",
+      "phone": "Telefon",
+      "url": "URL",
+      "file": "Datei"
+    },
     "editField": "Feld bearbeiten",
     "newField": "Neues Feld",
     "preview": "Vorschau",
@@ -2599,6 +2613,7 @@
     "previewSelect": "{{name}} auswählen...",
     "previewOption": "Option",
     "noOptionsDefined": "Keine Optionen definiert",
-    "previewCheckbox": "Kontrollkästchen"
+    "previewCheckbox": "Kontrollkästchen",
+    "fieldTypeField": "Feldtyp *"
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2575,6 +2575,23 @@
     "saving": "Wird gespeichert...",
     "updateFieldBtn": "Feld aktualisieren",
     "createField": "Feld erstellen",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "loading": "Felder werden geladen...",
+    "empty": "Keine benutzerdefinierten Felder für {{entity}} definiert.",
+    "emptyHint": "Klicken Sie auf \"Feld hinzufügen\", um Ihr erstes benutzerdefiniertes Feld zu erstellen.",
+    "colFieldName": "Feldname",
+    "colKey": "Schlüssel",
+    "colType": "Typ",
+    "colActions": "Aktionen",
+    "optionsCount_one": "({{count}} Option)",
+    "optionsCount_other": "({{count}} Optionen)",
+    "yes": "Ja",
+    "no": "Nein",
+    "editFieldAria": "Feld bearbeiten",
+    "deleteFieldAria": "Feld löschen",
+    "deactivateNamed": "Feld \"{{name}}\" deaktivieren?",
+    "deactivate": "Feld deaktivieren?",
+    "deactivateDesc": "Vorhandene Werte bleiben erhalten.",
+    "deactivateBtn": "Deaktivieren"
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2550,20 +2550,12 @@
       "project": "Projekt",
       "document": "Dokument"
     },
-    "fieldType": {
-      "text": "Text",
-      "textarea": "Textbereich",
-      "number": "Zahl",
-      "decimal": "Dezimalzahl",
-      "date": "Datum",
-      "datetime": "Datum und Uhrzeit",
-      "dropdown": "Dropdown",
-      "multi_select": "Mehrfachauswahl",
-      "checkbox": "Kontrollkästchen",
-      "email": "E-Mail",
-      "phone": "Telefon",
-      "url": "URL",
-      "file": "Datei"
-    }
+    "fieldType": "Feldtyp *",
+    "editField": "Feld bearbeiten",
+    "newField": "Neues Feld",
+    "preview": "Vorschau",
+    "hidePreview": "Vorschau ausblenden",
+    "fieldName": "Feldname *",
+    "fieldNamePlaceholder": "z. B. T-Shirt-Größe"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2562,6 +2562,12 @@
     "preview": "Preview",
     "hidePreview": "Hide Preview",
     "fieldName": "Field Name *",
-    "fieldNamePlaceholder": "e.g. T-Shirt Size"
+    "fieldNamePlaceholder": "e.g. T-Shirt Size",
+    "section": "Section",
+    "placeholder": "Placeholder",
+    "defaultValue": "Default Value",
+    "validationRegex": "Validation Regex",
+    "minValue": "Min Value",
+    "maxValue": "Max Value"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2556,20 +2556,12 @@
       "project": "Project",
       "document": "Document"
     },
-    "fieldType": {
-      "text": "Text",
-      "textarea": "Text Area",
-      "number": "Number",
-      "decimal": "Decimal",
-      "date": "Date",
-      "datetime": "Date & Time",
-      "dropdown": "Dropdown",
-      "multi_select": "Multi Select",
-      "checkbox": "Checkbox",
-      "email": "Email",
-      "phone": "Phone",
-      "url": "URL",
-      "file": "File"
-    }
+    "fieldType": "Field Type *",
+    "editField": "Edit Field",
+    "newField": "New Field",
+    "preview": "Preview",
+    "hidePreview": "Hide Preview",
+    "fieldName": "Field Name *",
+    "fieldNamePlaceholder": "e.g. T-Shirt Size"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2598,6 +2598,13 @@
     "deactivateNamed": "Deactivate field \"{{name}}\"?",
     "deactivate": "Deactivate field?",
     "deactivateDesc": "Existing values will be preserved.",
-    "deactivateBtn": "Deactivate"
+    "deactivateBtn": "Deactivate",
+    "previewFieldName": "Field Name",
+    "previewEnter": "Enter {{name}}",
+    "previewValue": "value",
+    "previewSelect": "Select {{name}}...",
+    "previewOption": "option",
+    "noOptionsDefined": "No options defined",
+    "previewCheckbox": "Checkbox"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2556,7 +2556,21 @@
       "project": "Project",
       "document": "Document"
     },
-    "fieldType": "Field Type *",
+    "fieldType": {
+      "text": "Text",
+      "textarea": "Text Area",
+      "number": "Number",
+      "decimal": "Decimal",
+      "date": "Date",
+      "datetime": "Date & Time",
+      "dropdown": "Dropdown",
+      "multi_select": "Multi Select",
+      "checkbox": "Checkbox",
+      "email": "Email",
+      "phone": "Phone",
+      "url": "URL",
+      "file": "File"
+    },
     "editField": "Edit Field",
     "newField": "New Field",
     "preview": "Preview",
@@ -2605,6 +2619,7 @@
     "previewSelect": "Select {{name}}...",
     "previewOption": "option",
     "noOptionsDefined": "No options defined",
-    "previewCheckbox": "Checkbox"
+    "previewCheckbox": "Checkbox",
+    "fieldTypeField": "Field Type *"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2581,6 +2581,23 @@
     "saving": "Saving...",
     "updateFieldBtn": "Update Field",
     "createField": "Create Field",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "loading": "Loading fields...",
+    "empty": "No custom fields defined for {{entity}}.",
+    "emptyHint": "Click \"Add Field\" to create your first custom field.",
+    "colFieldName": "Field Name",
+    "colKey": "Key",
+    "colType": "Type",
+    "colActions": "Actions",
+    "optionsCount_one": "({{count}} option)",
+    "optionsCount_other": "({{count}} options)",
+    "yes": "Yes",
+    "no": "No",
+    "editFieldAria": "Edit field",
+    "deleteFieldAria": "Delete field",
+    "deactivateNamed": "Deactivate field \"{{name}}\"?",
+    "deactivate": "Deactivate field?",
+    "deactivateDesc": "Existing values will be preserved.",
+    "deactivateBtn": "Deactivate"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2568,6 +2568,19 @@
     "defaultValue": "Default Value",
     "validationRegex": "Validation Regex",
     "minValue": "Min Value",
-    "maxValue": "Max Value"
+    "maxValue": "Max Value",
+    "helpText": "Help Text",
+    "helpTextPlaceholder": "Tooltip or description shown to users",
+    "options": "Options",
+    "optionPlaceholder": "Type option and press Enter",
+    "add": "Add",
+    "required": "Required",
+    "searchable": "Searchable",
+    "fieldPreview": "Field Preview",
+    "saveError": "Failed to save field. Please try again.",
+    "saving": "Saving...",
+    "updateFieldBtn": "Update Field",
+    "createField": "Create Field",
+    "cancel": "Cancel"
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2544,5 +2544,32 @@
       "damaged": "Damaged",
       "updated": "Updated"
     }
+  },
+  "customFields": {
+    "title": "Custom Fields",
+    "subtitle": "Define custom data fields for employees, departments, and other entities",
+    "addField": "Add Field",
+    "entity": {
+      "employee": "Employee",
+      "department": "Department",
+      "location": "Location",
+      "project": "Project",
+      "document": "Document"
+    },
+    "fieldType": {
+      "text": "Text",
+      "textarea": "Text Area",
+      "number": "Number",
+      "decimal": "Decimal",
+      "date": "Date",
+      "datetime": "Date & Time",
+      "dropdown": "Dropdown",
+      "multi_select": "Multi Select",
+      "checkbox": "Checkbox",
+      "email": "Email",
+      "phone": "Phone",
+      "url": "URL",
+      "file": "File"
+    }
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2575,6 +2575,23 @@
     "saving": "Guardando...",
     "updateFieldBtn": "Actualizar Campo",
     "createField": "Crear Campo",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "loading": "Cargando campos...",
+    "empty": "No hay campos personalizados definidos para {{entity}}.",
+    "emptyHint": "Haz clic en \"Agregar Campo\" para crear tu primer campo personalizado.",
+    "colFieldName": "Nombre del Campo",
+    "colKey": "Clave",
+    "colType": "Tipo",
+    "colActions": "Acciones",
+    "optionsCount_one": "({{count}} opción)",
+    "optionsCount_other": "({{count}} opciones)",
+    "yes": "Sí",
+    "no": "No",
+    "editFieldAria": "Editar campo",
+    "deleteFieldAria": "Eliminar campo",
+    "deactivateNamed": "¿Desactivar el campo \"{{name}}\"?",
+    "deactivate": "¿Desactivar campo?",
+    "deactivateDesc": "Los valores existentes se conservarán.",
+    "deactivateBtn": "Desactivar"
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "¿Desactivar el campo \"{{name}}\"?",
     "deactivate": "¿Desactivar campo?",
     "deactivateDesc": "Los valores existentes se conservarán.",
-    "deactivateBtn": "Desactivar"
+    "deactivateBtn": "Desactivar",
+    "previewFieldName": "Nombre del Campo",
+    "previewEnter": "Ingresa {{name}}",
+    "previewValue": "valor",
+    "previewSelect": "Seleccionar {{name}}...",
+    "previewOption": "opción",
+    "noOptionsDefined": "No hay opciones definidas",
+    "previewCheckbox": "Casilla de Verificación"
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "Valor Predeterminado",
     "validationRegex": "Regex de Validación",
     "minValue": "Valor Mínimo",
-    "maxValue": "Valor Máximo"
+    "maxValue": "Valor Máximo",
+    "helpText": "Texto de Ayuda",
+    "helpTextPlaceholder": "Información o descripción mostrada a los usuarios",
+    "options": "Opciones",
+    "optionPlaceholder": "Escribe la opción y presiona Enter",
+    "add": "Agregar",
+    "required": "Obligatorio",
+    "searchable": "Buscable",
+    "fieldPreview": "Vista previa del Campo",
+    "saveError": "No se pudo guardar el campo. Inténtalo de nuevo.",
+    "saving": "Guardando...",
+    "updateFieldBtn": "Actualizar Campo",
+    "createField": "Crear Campo",
+    "cancel": "Cancelar"
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2538,5 +2538,32 @@
       "damaged": "Dañado",
       "updated": "Actualizado"
     }
+  },
+  "customFields": {
+    "title": "Campos Personalizados",
+    "subtitle": "Define campos de datos personalizados para empleados, departamentos y otras entidades",
+    "addField": "Agregar Campo",
+    "entity": {
+      "employee": "Empleado",
+      "department": "Departamento",
+      "location": "Ubicación",
+      "project": "Proyecto",
+      "document": "Documento"
+    },
+    "fieldType": {
+      "text": "Texto",
+      "textarea": "Área de Texto",
+      "number": "Número",
+      "decimal": "Decimal",
+      "date": "Fecha",
+      "datetime": "Fecha y Hora",
+      "dropdown": "Lista Desplegable",
+      "multi_select": "Selección Múltiple",
+      "checkbox": "Casilla de Verificación",
+      "email": "Correo electrónico",
+      "phone": "Teléfono",
+      "url": "URL",
+      "file": "Archivo"
+    }
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2550,20 +2550,12 @@
       "project": "Proyecto",
       "document": "Documento"
     },
-    "fieldType": {
-      "text": "Texto",
-      "textarea": "Área de Texto",
-      "number": "Número",
-      "decimal": "Decimal",
-      "date": "Fecha",
-      "datetime": "Fecha y Hora",
-      "dropdown": "Lista Desplegable",
-      "multi_select": "Selección Múltiple",
-      "checkbox": "Casilla de Verificación",
-      "email": "Correo electrónico",
-      "phone": "Teléfono",
-      "url": "URL",
-      "file": "Archivo"
-    }
+    "fieldType": "Tipo de Campo *",
+    "editField": "Editar Campo",
+    "newField": "Nuevo Campo",
+    "preview": "Vista previa",
+    "hidePreview": "Ocultar Vista previa",
+    "fieldName": "Nombre del Campo *",
+    "fieldNamePlaceholder": "p. ej. Talla de Camiseta"
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2556,6 +2556,12 @@
     "preview": "Vista previa",
     "hidePreview": "Ocultar Vista previa",
     "fieldName": "Nombre del Campo *",
-    "fieldNamePlaceholder": "p. ej. Talla de Camiseta"
+    "fieldNamePlaceholder": "p. ej. Talla de Camiseta",
+    "section": "Sección",
+    "placeholder": "Marcador de Posición",
+    "defaultValue": "Valor Predeterminado",
+    "validationRegex": "Regex de Validación",
+    "minValue": "Valor Mínimo",
+    "maxValue": "Valor Máximo"
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2550,7 +2550,21 @@
       "project": "Proyecto",
       "document": "Documento"
     },
-    "fieldType": "Tipo de Campo *",
+    "fieldType": {
+      "text": "Texto",
+      "textarea": "Área de Texto",
+      "number": "Número",
+      "decimal": "Decimal",
+      "date": "Fecha",
+      "datetime": "Fecha y Hora",
+      "dropdown": "Lista Desplegable",
+      "multi_select": "Selección Múltiple",
+      "checkbox": "Casilla de Verificación",
+      "email": "Correo electrónico",
+      "phone": "Teléfono",
+      "url": "URL",
+      "file": "Archivo"
+    },
     "editField": "Editar Campo",
     "newField": "Nuevo Campo",
     "preview": "Vista previa",
@@ -2599,6 +2613,7 @@
     "previewSelect": "Seleccionar {{name}}...",
     "previewOption": "opción",
     "noOptionsDefined": "No hay opciones definidas",
-    "previewCheckbox": "Casilla de Verificación"
+    "previewCheckbox": "Casilla de Verificación",
+    "fieldTypeField": "Tipo de Campo *"
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "Désactiver le champ « {{name}} » ?",
     "deactivate": "Désactiver le champ ?",
     "deactivateDesc": "Les valeurs existantes seront conservées.",
-    "deactivateBtn": "Désactiver"
+    "deactivateBtn": "Désactiver",
+    "previewFieldName": "Nom du champ",
+    "previewEnter": "Saisir {{name}}",
+    "previewValue": "une valeur",
+    "previewSelect": "Sélectionner {{name}}...",
+    "previewOption": "une option",
+    "noOptionsDefined": "Aucune option définie",
+    "previewCheckbox": "Case à cocher"
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "Valeur par défaut",
     "validationRegex": "Regex de validation",
     "minValue": "Valeur min.",
-    "maxValue": "Valeur max."
+    "maxValue": "Valeur max.",
+    "helpText": "Texte d'aide",
+    "helpTextPlaceholder": "Infobulle ou description affichée aux utilisateurs",
+    "options": "Options",
+    "optionPlaceholder": "Saisissez une option et appuyez sur Entrée",
+    "add": "Ajouter",
+    "required": "Obligatoire",
+    "searchable": "Recherchable",
+    "fieldPreview": "Aperçu du champ",
+    "saveError": "Échec de l'enregistrement du champ. Veuillez réessayer.",
+    "saving": "Enregistrement...",
+    "updateFieldBtn": "Mettre à jour le champ",
+    "createField": "Créer le champ",
+    "cancel": "Annuler"
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2538,5 +2538,32 @@
       "damaged": "Endommagé",
       "updated": "Mis à jour"
     }
+  },
+  "customFields": {
+    "title": "Champs personnalisés",
+    "subtitle": "Définissez des champs de données personnalisés pour les employés, les services et d'autres entités",
+    "addField": "Ajouter un champ",
+    "entity": {
+      "employee": "Employé",
+      "department": "Service",
+      "location": "Lieu",
+      "project": "Projet",
+      "document": "Document"
+    },
+    "fieldType": {
+      "text": "Texte",
+      "textarea": "Zone de texte",
+      "number": "Nombre",
+      "decimal": "Décimal",
+      "date": "Date",
+      "datetime": "Date et heure",
+      "dropdown": "Liste déroulante",
+      "multi_select": "Sélection multiple",
+      "checkbox": "Case à cocher",
+      "email": "E-mail",
+      "phone": "Téléphone",
+      "url": "URL",
+      "file": "Fichier"
+    }
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2556,6 +2556,12 @@
     "preview": "Aperçu",
     "hidePreview": "Masquer l'aperçu",
     "fieldName": "Nom du champ *",
-    "fieldNamePlaceholder": "ex. Taille de t-shirt"
+    "fieldNamePlaceholder": "ex. Taille de t-shirt",
+    "section": "Section",
+    "placeholder": "Texte indicatif",
+    "defaultValue": "Valeur par défaut",
+    "validationRegex": "Regex de validation",
+    "minValue": "Valeur min.",
+    "maxValue": "Valeur max."
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2550,7 +2550,21 @@
       "project": "Projet",
       "document": "Document"
     },
-    "fieldType": "Type de champ *",
+    "fieldType": {
+      "text": "Texte",
+      "textarea": "Zone de texte",
+      "number": "Nombre",
+      "decimal": "Décimal",
+      "date": "Date",
+      "datetime": "Date et heure",
+      "dropdown": "Liste déroulante",
+      "multi_select": "Sélection multiple",
+      "checkbox": "Case à cocher",
+      "email": "E-mail",
+      "phone": "Téléphone",
+      "url": "URL",
+      "file": "Fichier"
+    },
     "editField": "Modifier le champ",
     "newField": "Nouveau champ",
     "preview": "Aperçu",
@@ -2599,6 +2613,7 @@
     "previewSelect": "Sélectionner {{name}}...",
     "previewOption": "une option",
     "noOptionsDefined": "Aucune option définie",
-    "previewCheckbox": "Case à cocher"
+    "previewCheckbox": "Case à cocher",
+    "fieldTypeField": "Type de champ *"
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2550,20 +2550,12 @@
       "project": "Projet",
       "document": "Document"
     },
-    "fieldType": {
-      "text": "Texte",
-      "textarea": "Zone de texte",
-      "number": "Nombre",
-      "decimal": "Décimal",
-      "date": "Date",
-      "datetime": "Date et heure",
-      "dropdown": "Liste déroulante",
-      "multi_select": "Sélection multiple",
-      "checkbox": "Case à cocher",
-      "email": "E-mail",
-      "phone": "Téléphone",
-      "url": "URL",
-      "file": "Fichier"
-    }
+    "fieldType": "Type de champ *",
+    "editField": "Modifier le champ",
+    "newField": "Nouveau champ",
+    "preview": "Aperçu",
+    "hidePreview": "Masquer l'aperçu",
+    "fieldName": "Nom du champ *",
+    "fieldNamePlaceholder": "ex. Taille de t-shirt"
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2575,6 +2575,23 @@
     "saving": "Enregistrement...",
     "updateFieldBtn": "Mettre à jour le champ",
     "createField": "Créer le champ",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "loading": "Chargement des champs...",
+    "empty": "Aucun champ personnalisé défini pour {{entity}}.",
+    "emptyHint": "Cliquez sur « Ajouter un champ » pour créer votre premier champ personnalisé.",
+    "colFieldName": "Nom du champ",
+    "colKey": "Clé",
+    "colType": "Type",
+    "colActions": "Actions",
+    "optionsCount_one": "({{count}} option)",
+    "optionsCount_other": "({{count}} options)",
+    "yes": "Oui",
+    "no": "Non",
+    "editFieldAria": "Modifier le champ",
+    "deleteFieldAria": "Supprimer le champ",
+    "deactivateNamed": "Désactiver le champ « {{name}} » ?",
+    "deactivate": "Désactiver le champ ?",
+    "deactivateDesc": "Les valeurs existantes seront conservées.",
+    "deactivateBtn": "Désactiver"
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2538,5 +2538,32 @@
       "damaged": "क्षतिग्रस्त",
       "updated": "अपडेट किया गया"
     }
+  },
+  "customFields": {
+    "title": "कस्टम फ़ील्ड",
+    "subtitle": "कर्मचारियों, विभागों और अन्य इकाइयों के लिए कस्टम डेटा फ़ील्ड परिभाषित करें",
+    "addField": "फ़ील्ड जोड़ें",
+    "entity": {
+      "employee": "कर्मचारी",
+      "department": "विभाग",
+      "location": "स्थान",
+      "project": "परियोजना",
+      "document": "दस्तावेज़"
+    },
+    "fieldType": {
+      "text": "टेक्स्ट",
+      "textarea": "टेक्स्ट क्षेत्र",
+      "number": "संख्या",
+      "decimal": "दशमलव",
+      "date": "तिथि",
+      "datetime": "तिथि और समय",
+      "dropdown": "ड्रॉपडाउन",
+      "multi_select": "बहु चयन",
+      "checkbox": "चेकबॉक्स",
+      "email": "ईमेल",
+      "phone": "फ़ोन",
+      "url": "URL",
+      "file": "फ़ाइल"
+    }
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2575,6 +2575,23 @@
     "saving": "सहेजा जा रहा है...",
     "updateFieldBtn": "फ़ील्ड अपडेट करें",
     "createField": "फ़ील्ड बनाएं",
-    "cancel": "रद्द करें"
+    "cancel": "रद्द करें",
+    "loading": "फ़ील्ड लोड हो रहे हैं...",
+    "empty": "{{entity}} के लिए कोई कस्टम फ़ील्ड परिभाषित नहीं है।",
+    "emptyHint": "अपना पहला कस्टम फ़ील्ड बनाने के लिए \"फ़ील्ड जोड़ें\" पर क्लिक करें।",
+    "colFieldName": "फ़ील्ड नाम",
+    "colKey": "कुंजी",
+    "colType": "प्रकार",
+    "colActions": "क्रियाएं",
+    "optionsCount_one": "({{count}} विकल्प)",
+    "optionsCount_other": "({{count}} विकल्प)",
+    "yes": "हां",
+    "no": "नहीं",
+    "editFieldAria": "फ़ील्ड संपादित करें",
+    "deleteFieldAria": "फ़ील्ड हटाएं",
+    "deactivateNamed": "फ़ील्ड \"{{name}}\" निष्क्रिय करें?",
+    "deactivate": "फ़ील्ड निष्क्रिय करें?",
+    "deactivateDesc": "मौजूदा मान सुरक्षित रहेंगे।",
+    "deactivateBtn": "निष्क्रिय करें"
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "डिफ़ॉल्ट मान",
     "validationRegex": "वैलिडेशन रेगेक्स",
     "minValue": "न्यूनतम मान",
-    "maxValue": "अधिकतम मान"
+    "maxValue": "अधिकतम मान",
+    "helpText": "सहायता पाठ",
+    "helpTextPlaceholder": "उपयोगकर्ताओं को दिखाया जाने वाला टूलटिप या विवरण",
+    "options": "विकल्प",
+    "optionPlaceholder": "विकल्प टाइप करें और Enter दबाएं",
+    "add": "जोड़ें",
+    "required": "आवश्यक",
+    "searchable": "खोजने योग्य",
+    "fieldPreview": "फ़ील्ड पूर्वावलोकन",
+    "saveError": "फ़ील्ड सहेजने में विफल। कृपया पुनः प्रयास करें।",
+    "saving": "सहेजा जा रहा है...",
+    "updateFieldBtn": "फ़ील्ड अपडेट करें",
+    "createField": "फ़ील्ड बनाएं",
+    "cancel": "रद्द करें"
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "फ़ील्ड \"{{name}}\" निष्क्रिय करें?",
     "deactivate": "फ़ील्ड निष्क्रिय करें?",
     "deactivateDesc": "मौजूदा मान सुरक्षित रहेंगे।",
-    "deactivateBtn": "निष्क्रिय करें"
+    "deactivateBtn": "निष्क्रिय करें",
+    "previewFieldName": "फ़ील्ड नाम",
+    "previewEnter": "{{name}} दर्ज करें",
+    "previewValue": "मान",
+    "previewSelect": "{{name}} चुनें...",
+    "previewOption": "विकल्प",
+    "noOptionsDefined": "कोई विकल्प परिभाषित नहीं",
+    "previewCheckbox": "चेकबॉक्स"
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2550,20 +2550,12 @@
       "project": "परियोजना",
       "document": "दस्तावेज़"
     },
-    "fieldType": {
-      "text": "टेक्स्ट",
-      "textarea": "टेक्स्ट क्षेत्र",
-      "number": "संख्या",
-      "decimal": "दशमलव",
-      "date": "तिथि",
-      "datetime": "तिथि और समय",
-      "dropdown": "ड्रॉपडाउन",
-      "multi_select": "बहु चयन",
-      "checkbox": "चेकबॉक्स",
-      "email": "ईमेल",
-      "phone": "फ़ोन",
-      "url": "URL",
-      "file": "फ़ाइल"
-    }
+    "fieldType": "फ़ील्ड प्रकार *",
+    "editField": "फ़ील्ड संपादित करें",
+    "newField": "नया फ़ील्ड",
+    "preview": "पूर्वावलोकन",
+    "hidePreview": "पूर्वावलोकन छिपाएं",
+    "fieldName": "फ़ील्ड नाम *",
+    "fieldNamePlaceholder": "जैसे टी-शर्ट साइज़"
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2556,6 +2556,12 @@
     "preview": "पूर्वावलोकन",
     "hidePreview": "पूर्वावलोकन छिपाएं",
     "fieldName": "फ़ील्ड नाम *",
-    "fieldNamePlaceholder": "जैसे टी-शर्ट साइज़"
+    "fieldNamePlaceholder": "जैसे टी-शर्ट साइज़",
+    "section": "अनुभाग",
+    "placeholder": "प्लेसहोल्डर",
+    "defaultValue": "डिफ़ॉल्ट मान",
+    "validationRegex": "वैलिडेशन रेगेक्स",
+    "minValue": "न्यूनतम मान",
+    "maxValue": "अधिकतम मान"
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2550,7 +2550,21 @@
       "project": "परियोजना",
       "document": "दस्तावेज़"
     },
-    "fieldType": "फ़ील्ड प्रकार *",
+    "fieldType": {
+      "text": "टेक्स्ट",
+      "textarea": "टेक्स्ट क्षेत्र",
+      "number": "संख्या",
+      "decimal": "दशमलव",
+      "date": "तिथि",
+      "datetime": "तिथि और समय",
+      "dropdown": "ड्रॉपडाउन",
+      "multi_select": "बहु चयन",
+      "checkbox": "चेकबॉक्स",
+      "email": "ईमेल",
+      "phone": "फ़ोन",
+      "url": "URL",
+      "file": "फ़ाइल"
+    },
     "editField": "फ़ील्ड संपादित करें",
     "newField": "नया फ़ील्ड",
     "preview": "पूर्वावलोकन",
@@ -2599,6 +2613,7 @@
     "previewSelect": "{{name}} चुनें...",
     "previewOption": "विकल्प",
     "noOptionsDefined": "कोई विकल्प परिभाषित नहीं",
-    "previewCheckbox": "चेकबॉक्स"
+    "previewCheckbox": "चेकबॉक्स",
+    "fieldTypeField": "फ़ील्ड प्रकार *"
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2556,6 +2556,12 @@
     "preview": "プレビュー",
     "hidePreview": "プレビューを非表示",
     "fieldName": "フィールド名 *",
-    "fieldNamePlaceholder": "例: Tシャツのサイズ"
+    "fieldNamePlaceholder": "例: Tシャツのサイズ",
+    "section": "セクション",
+    "placeholder": "プレースホルダー",
+    "defaultValue": "既定値",
+    "validationRegex": "検証用正規表現",
+    "minValue": "最小値",
+    "maxValue": "最大値"
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2550,20 +2550,12 @@
       "project": "プロジェクト",
       "document": "ドキュメント"
     },
-    "fieldType": {
-      "text": "テキスト",
-      "textarea": "テキストエリア",
-      "number": "数値",
-      "decimal": "小数",
-      "date": "日付",
-      "datetime": "日時",
-      "dropdown": "ドロップダウン",
-      "multi_select": "複数選択",
-      "checkbox": "チェックボックス",
-      "email": "メール",
-      "phone": "電話",
-      "url": "URL",
-      "file": "ファイル"
-    }
+    "fieldType": "フィールドの種類 *",
+    "editField": "フィールドを編集",
+    "newField": "新規フィールド",
+    "preview": "プレビュー",
+    "hidePreview": "プレビューを非表示",
+    "fieldName": "フィールド名 *",
+    "fieldNamePlaceholder": "例: Tシャツのサイズ"
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2550,7 +2550,21 @@
       "project": "プロジェクト",
       "document": "ドキュメント"
     },
-    "fieldType": "フィールドの種類 *",
+    "fieldType": {
+      "text": "テキスト",
+      "textarea": "テキストエリア",
+      "number": "数値",
+      "decimal": "小数",
+      "date": "日付",
+      "datetime": "日時",
+      "dropdown": "ドロップダウン",
+      "multi_select": "複数選択",
+      "checkbox": "チェックボックス",
+      "email": "メール",
+      "phone": "電話",
+      "url": "URL",
+      "file": "ファイル"
+    },
     "editField": "フィールドを編集",
     "newField": "新規フィールド",
     "preview": "プレビュー",
@@ -2599,6 +2613,7 @@
     "previewSelect": "{{name}} を選択...",
     "previewOption": "選択肢",
     "noOptionsDefined": "選択肢が定義されていません",
-    "previewCheckbox": "チェックボックス"
+    "previewCheckbox": "チェックボックス",
+    "fieldTypeField": "フィールドの種類 *"
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "フィールド「{{name}}」を無効化しますか？",
     "deactivate": "フィールドを無効化しますか？",
     "deactivateDesc": "既存の値は保持されます。",
-    "deactivateBtn": "無効化"
+    "deactivateBtn": "無効化",
+    "previewFieldName": "フィールド名",
+    "previewEnter": "{{name}} を入力",
+    "previewValue": "値",
+    "previewSelect": "{{name}} を選択...",
+    "previewOption": "選択肢",
+    "noOptionsDefined": "選択肢が定義されていません",
+    "previewCheckbox": "チェックボックス"
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "既定値",
     "validationRegex": "検証用正規表現",
     "minValue": "最小値",
-    "maxValue": "最大値"
+    "maxValue": "最大値",
+    "helpText": "ヘルプテキスト",
+    "helpTextPlaceholder": "ユーザーに表示されるツールチップまたは説明",
+    "options": "選択肢",
+    "optionPlaceholder": "選択肢を入力して Enter キーを押してください",
+    "add": "追加",
+    "required": "必須",
+    "searchable": "検索可能",
+    "fieldPreview": "フィールドプレビュー",
+    "saveError": "フィールドの保存に失敗しました。もう一度お試しください。",
+    "saving": "保存中...",
+    "updateFieldBtn": "フィールドを更新",
+    "createField": "フィールドを作成",
+    "cancel": "キャンセル"
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2538,5 +2538,32 @@
       "damaged": "破損",
       "updated": "更新"
     }
+  },
+  "customFields": {
+    "title": "カスタムフィールド",
+    "subtitle": "従業員、部門、その他のエンティティ用のカスタムデータフィールドを定義します",
+    "addField": "フィールドを追加",
+    "entity": {
+      "employee": "従業員",
+      "department": "部門",
+      "location": "場所",
+      "project": "プロジェクト",
+      "document": "ドキュメント"
+    },
+    "fieldType": {
+      "text": "テキスト",
+      "textarea": "テキストエリア",
+      "number": "数値",
+      "decimal": "小数",
+      "date": "日付",
+      "datetime": "日時",
+      "dropdown": "ドロップダウン",
+      "multi_select": "複数選択",
+      "checkbox": "チェックボックス",
+      "email": "メール",
+      "phone": "電話",
+      "url": "URL",
+      "file": "ファイル"
+    }
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2575,6 +2575,23 @@
     "saving": "保存中...",
     "updateFieldBtn": "フィールドを更新",
     "createField": "フィールドを作成",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "loading": "フィールドを読み込み中...",
+    "empty": "{{entity}} のカスタムフィールドは定義されていません。",
+    "emptyHint": "「フィールドを追加」をクリックして最初のカスタムフィールドを作成してください。",
+    "colFieldName": "フィールド名",
+    "colKey": "キー",
+    "colType": "種類",
+    "colActions": "操作",
+    "optionsCount_one": "（選択肢 {{count}} 件）",
+    "optionsCount_other": "（選択肢 {{count}} 件）",
+    "yes": "はい",
+    "no": "いいえ",
+    "editFieldAria": "フィールドを編集",
+    "deleteFieldAria": "フィールドを削除",
+    "deactivateNamed": "フィールド「{{name}}」を無効化しますか？",
+    "deactivate": "フィールドを無効化しますか？",
+    "deactivateDesc": "既存の値は保持されます。",
+    "deactivateBtn": "無効化"
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2538,5 +2538,32 @@
       "damaged": "Danificado",
       "updated": "Atualizado"
     }
+  },
+  "customFields": {
+    "title": "Campos Personalizados",
+    "subtitle": "Defina campos de dados personalizados para funcionários, departamentos e outras entidades",
+    "addField": "Adicionar Campo",
+    "entity": {
+      "employee": "Funcionário",
+      "department": "Departamento",
+      "location": "Local",
+      "project": "Projeto",
+      "document": "Documento"
+    },
+    "fieldType": {
+      "text": "Texto",
+      "textarea": "Área de Texto",
+      "number": "Número",
+      "decimal": "Decimal",
+      "date": "Data",
+      "datetime": "Data e Hora",
+      "dropdown": "Lista Suspensa",
+      "multi_select": "Seleção Múltipla",
+      "checkbox": "Caixa de Seleção",
+      "email": "E-mail",
+      "phone": "Telefone",
+      "url": "URL",
+      "file": "Arquivo"
+    }
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2550,20 +2550,12 @@
       "project": "Projeto",
       "document": "Documento"
     },
-    "fieldType": {
-      "text": "Texto",
-      "textarea": "Área de Texto",
-      "number": "Número",
-      "decimal": "Decimal",
-      "date": "Data",
-      "datetime": "Data e Hora",
-      "dropdown": "Lista Suspensa",
-      "multi_select": "Seleção Múltipla",
-      "checkbox": "Caixa de Seleção",
-      "email": "E-mail",
-      "phone": "Telefone",
-      "url": "URL",
-      "file": "Arquivo"
-    }
+    "fieldType": "Tipo de Campo *",
+    "editField": "Editar Campo",
+    "newField": "Novo Campo",
+    "preview": "Pré-visualizar",
+    "hidePreview": "Ocultar Pré-visualização",
+    "fieldName": "Nome do Campo *",
+    "fieldNamePlaceholder": "ex.: Tamanho da Camiseta"
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "Valor Padrão",
     "validationRegex": "Regex de Validação",
     "minValue": "Valor Mínimo",
-    "maxValue": "Valor Máximo"
+    "maxValue": "Valor Máximo",
+    "helpText": "Texto de Ajuda",
+    "helpTextPlaceholder": "Dica ou descrição mostrada aos usuários",
+    "options": "Opções",
+    "optionPlaceholder": "Digite a opção e pressione Enter",
+    "add": "Adicionar",
+    "required": "Obrigatório",
+    "searchable": "Pesquisável",
+    "fieldPreview": "Pré-visualização do Campo",
+    "saveError": "Falha ao salvar o campo. Tente novamente.",
+    "saving": "Salvando...",
+    "updateFieldBtn": "Atualizar Campo",
+    "createField": "Criar Campo",
+    "cancel": "Cancelar"
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2556,6 +2556,12 @@
     "preview": "Pré-visualizar",
     "hidePreview": "Ocultar Pré-visualização",
     "fieldName": "Nome do Campo *",
-    "fieldNamePlaceholder": "ex.: Tamanho da Camiseta"
+    "fieldNamePlaceholder": "ex.: Tamanho da Camiseta",
+    "section": "Seção",
+    "placeholder": "Texto de Exemplo",
+    "defaultValue": "Valor Padrão",
+    "validationRegex": "Regex de Validação",
+    "minValue": "Valor Mínimo",
+    "maxValue": "Valor Máximo"
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "Desativar o campo \"{{name}}\"?",
     "deactivate": "Desativar campo?",
     "deactivateDesc": "Os valores existentes serão preservados.",
-    "deactivateBtn": "Desativar"
+    "deactivateBtn": "Desativar",
+    "previewFieldName": "Nome do Campo",
+    "previewEnter": "Insira {{name}}",
+    "previewValue": "valor",
+    "previewSelect": "Selecionar {{name}}...",
+    "previewOption": "opção",
+    "noOptionsDefined": "Nenhuma opção definida",
+    "previewCheckbox": "Caixa de Seleção"
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2575,6 +2575,23 @@
     "saving": "Salvando...",
     "updateFieldBtn": "Atualizar Campo",
     "createField": "Criar Campo",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "loading": "Carregando campos...",
+    "empty": "Nenhum campo personalizado definido para {{entity}}.",
+    "emptyHint": "Clique em \"Adicionar Campo\" para criar seu primeiro campo personalizado.",
+    "colFieldName": "Nome do Campo",
+    "colKey": "Chave",
+    "colType": "Tipo",
+    "colActions": "Ações",
+    "optionsCount_one": "({{count}} opção)",
+    "optionsCount_other": "({{count}} opções)",
+    "yes": "Sim",
+    "no": "Não",
+    "editFieldAria": "Editar campo",
+    "deleteFieldAria": "Excluir campo",
+    "deactivateNamed": "Desativar o campo \"{{name}}\"?",
+    "deactivate": "Desativar campo?",
+    "deactivateDesc": "Os valores existentes serão preservados.",
+    "deactivateBtn": "Desativar"
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2550,7 +2550,21 @@
       "project": "Projeto",
       "document": "Documento"
     },
-    "fieldType": "Tipo de Campo *",
+    "fieldType": {
+      "text": "Texto",
+      "textarea": "Área de Texto",
+      "number": "Número",
+      "decimal": "Decimal",
+      "date": "Data",
+      "datetime": "Data e Hora",
+      "dropdown": "Lista Suspensa",
+      "multi_select": "Seleção Múltipla",
+      "checkbox": "Caixa de Seleção",
+      "email": "E-mail",
+      "phone": "Telefone",
+      "url": "URL",
+      "file": "Arquivo"
+    },
     "editField": "Editar Campo",
     "newField": "Novo Campo",
     "preview": "Pré-visualizar",
@@ -2599,6 +2613,7 @@
     "previewSelect": "Selecionar {{name}}...",
     "previewOption": "opção",
     "noOptionsDefined": "Nenhuma opção definida",
-    "previewCheckbox": "Caixa de Seleção"
+    "previewCheckbox": "Caixa de Seleção",
+    "fieldTypeField": "Tipo de Campo *"
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2575,6 +2575,23 @@
     "saving": "正在保存...",
     "updateFieldBtn": "更新字段",
     "createField": "创建字段",
-    "cancel": "取消"
+    "cancel": "取消",
+    "loading": "正在加载字段...",
+    "empty": "未为 {{entity}} 定义自定义字段。",
+    "emptyHint": "点击“添加字段”创建您的第一个自定义字段。",
+    "colFieldName": "字段名称",
+    "colKey": "键",
+    "colType": "类型",
+    "colActions": "操作",
+    "optionsCount_one": "（{{count}} 个选项）",
+    "optionsCount_other": "（{{count}} 个选项）",
+    "yes": "是",
+    "no": "否",
+    "editFieldAria": "编辑字段",
+    "deleteFieldAria": "删除字段",
+    "deactivateNamed": "停用字段“{{name}}”？",
+    "deactivate": "停用字段？",
+    "deactivateDesc": "现有值将被保留。",
+    "deactivateBtn": "停用"
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2550,20 +2550,12 @@
       "project": "项目",
       "document": "文档"
     },
-    "fieldType": {
-      "text": "文本",
-      "textarea": "文本区域",
-      "number": "数字",
-      "decimal": "小数",
-      "date": "日期",
-      "datetime": "日期和时间",
-      "dropdown": "下拉菜单",
-      "multi_select": "多选",
-      "checkbox": "复选框",
-      "email": "邮箱",
-      "phone": "电话",
-      "url": "网址",
-      "file": "文件"
-    }
+    "fieldType": "字段类型 *",
+    "editField": "编辑字段",
+    "newField": "新建字段",
+    "preview": "预览",
+    "hidePreview": "隐藏预览",
+    "fieldName": "字段名称 *",
+    "fieldNamePlaceholder": "例如 T 恤尺码"
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2562,6 +2562,19 @@
     "defaultValue": "默认值",
     "validationRegex": "验证正则",
     "minValue": "最小值",
-    "maxValue": "最大值"
+    "maxValue": "最大值",
+    "helpText": "帮助文本",
+    "helpTextPlaceholder": "显示给用户的提示或说明",
+    "options": "选项",
+    "optionPlaceholder": "输入选项并按 Enter",
+    "add": "添加",
+    "required": "必填",
+    "searchable": "可搜索",
+    "fieldPreview": "字段预览",
+    "saveError": "保存字段失败。请重试。",
+    "saving": "正在保存...",
+    "updateFieldBtn": "更新字段",
+    "createField": "创建字段",
+    "cancel": "取消"
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2592,6 +2592,13 @@
     "deactivateNamed": "停用字段“{{name}}”？",
     "deactivate": "停用字段？",
     "deactivateDesc": "现有值将被保留。",
-    "deactivateBtn": "停用"
+    "deactivateBtn": "停用",
+    "previewFieldName": "字段名称",
+    "previewEnter": "输入{{name}}",
+    "previewValue": "值",
+    "previewSelect": "选择{{name}}...",
+    "previewOption": "选项",
+    "noOptionsDefined": "未定义选项",
+    "previewCheckbox": "复选框"
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2556,6 +2556,12 @@
     "preview": "预览",
     "hidePreview": "隐藏预览",
     "fieldName": "字段名称 *",
-    "fieldNamePlaceholder": "例如 T 恤尺码"
+    "fieldNamePlaceholder": "例如 T 恤尺码",
+    "section": "分区",
+    "placeholder": "占位符",
+    "defaultValue": "默认值",
+    "validationRegex": "验证正则",
+    "minValue": "最小值",
+    "maxValue": "最大值"
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2538,5 +2538,32 @@
       "damaged": "已损坏",
       "updated": "已更新"
     }
+  },
+  "customFields": {
+    "title": "自定义字段",
+    "subtitle": "为员工、部门和其他实体定义自定义数据字段",
+    "addField": "添加字段",
+    "entity": {
+      "employee": "员工",
+      "department": "部门",
+      "location": "地点",
+      "project": "项目",
+      "document": "文档"
+    },
+    "fieldType": {
+      "text": "文本",
+      "textarea": "文本区域",
+      "number": "数字",
+      "decimal": "小数",
+      "date": "日期",
+      "datetime": "日期和时间",
+      "dropdown": "下拉菜单",
+      "multi_select": "多选",
+      "checkbox": "复选框",
+      "email": "邮箱",
+      "phone": "电话",
+      "url": "网址",
+      "file": "文件"
+    }
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2550,7 +2550,21 @@
       "project": "项目",
       "document": "文档"
     },
-    "fieldType": "字段类型 *",
+    "fieldType": {
+      "text": "文本",
+      "textarea": "文本区域",
+      "number": "数字",
+      "decimal": "小数",
+      "date": "日期",
+      "datetime": "日期和时间",
+      "dropdown": "下拉菜单",
+      "multi_select": "多选",
+      "checkbox": "复选框",
+      "email": "邮箱",
+      "phone": "电话",
+      "url": "网址",
+      "file": "文件"
+    },
     "editField": "编辑字段",
     "newField": "新建字段",
     "preview": "预览",
@@ -2599,6 +2613,7 @@
     "previewSelect": "选择{{name}}...",
     "previewOption": "选项",
     "noOptionsDefined": "未定义选项",
-    "previewCheckbox": "复选框"
+    "previewCheckbox": "复选框",
+    "fieldTypeField": "字段类型 *"
   }
 }

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -473,7 +473,7 @@ export default function CustomFieldsSettingsPage() {
             {/* Help Text */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Help Text
+                {t("customFields.helpText")}
               </label>
               <textarea
                 value={form.help_text}
@@ -482,7 +482,7 @@ export default function CustomFieldsSettingsPage() {
                 }
                 rows={2}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
-                placeholder="Tooltip or description shown to users"
+                placeholder={t("customFields.helpTextPlaceholder")}
               />
             </div>
 
@@ -490,7 +490,7 @@ export default function CustomFieldsSettingsPage() {
             {needsOptions && (
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Options
+                  {t("customFields.options")}
                 </label>
                 <div className="flex gap-2 mb-2">
                   <input
@@ -503,7 +503,7 @@ export default function CustomFieldsSettingsPage() {
                         addOption();
                       }
                     }}
-                    placeholder="Type option and press Enter"
+                    placeholder={t("customFields.optionPlaceholder")}
                     className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                   <button
@@ -511,7 +511,7 @@ export default function CustomFieldsSettingsPage() {
                     onClick={addOption}
                     className="px-3 py-2 bg-gray-100 rounded-lg text-sm hover:bg-gray-200"
                   >
-                    Add
+                    {t("customFields.add")}
                   </button>
                 </div>
                 {form.options.length > 0 && (
@@ -547,7 +547,7 @@ export default function CustomFieldsSettingsPage() {
                   }
                   className="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
                 />
-                Required
+                {t("customFields.required")}
               </label>
               <label className="flex items-center gap-2 text-sm text-gray-700">
                 <input
@@ -558,7 +558,7 @@ export default function CustomFieldsSettingsPage() {
                   }
                   className="rounded border-gray-300 text-brand-600 focus:ring-brand-500"
                 />
-                Searchable
+                {t("customFields.searchable")}
               </label>
             </div>
 
@@ -566,7 +566,7 @@ export default function CustomFieldsSettingsPage() {
             {showPreview && (
               <div className="border border-dashed border-gray-300 rounded-lg p-4 bg-gray-50">
                 <p className="text-xs font-medium text-gray-400 mb-2 uppercase">
-                  Field Preview
+                  {t("customFields.fieldPreview")}
                 </p>
                 <FieldPreview form={form} />
               </div>
@@ -584,7 +584,7 @@ export default function CustomFieldsSettingsPage() {
                 resp?.message
                 || err?.response?.data?.message
                 || err?.message
-                || "Failed to save field. Please try again.";
+                || t("customFields.saveError");
               return (
                 <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
                   <div className="font-medium">{message}</div>
@@ -610,15 +610,15 @@ export default function CustomFieldsSettingsPage() {
                 className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 transition-colors disabled:opacity-50"
               >
                 {createMutation.isPending || updateMutation.isPending
-                  ? "Saving..."
-                  : editingId ? "Update Field" : "Create Field"}
+                  ? t("customFields.saving")
+                  : editingId ? t("customFields.updateFieldBtn") : t("customFields.createField")}
               </button>
               <button
                 type="button"
                 onClick={resetForm}
                 className="text-gray-500 hover:text-gray-700 px-4 py-2 text-sm"
               >
-                Cancel
+                {t("customFields.cancel")}
               </button>
             </div>
           </form>

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -378,7 +378,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Section */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Section
+                  {t("customFields.section")}
                 </label>
                 <input
                   type="text"
@@ -386,7 +386,7 @@ export default function CustomFieldsSettingsPage() {
                   onChange={(e) =>
                     setForm({ ...form, section: e.target.value })
                   }
-                  placeholder="Custom Fields"
+                  placeholder={t("customFields.title")}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
@@ -394,7 +394,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Placeholder */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Placeholder
+                  {t("customFields.placeholder")}
                 </label>
                 <input
                   type="text"
@@ -409,7 +409,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Default Value */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Default Value
+                  {t("customFields.defaultValue")}
                 </label>
                 <input
                   type="text"
@@ -424,7 +424,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Validation Regex */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Validation Regex
+                  {t("customFields.validationRegex")}
                 </label>
                 <input
                   type="text"
@@ -442,7 +442,7 @@ export default function CustomFieldsSettingsPage() {
                 <>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Min Value
+                      {t("customFields.minValue")}
                     </label>
                     <input
                       type="number"
@@ -455,7 +455,7 @@ export default function CustomFieldsSettingsPage() {
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Max Value
+                      {t("customFields.maxValue")}
                     </label>
                     <input
                       type="number"

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Plus,
@@ -13,6 +14,10 @@ import {
 import api from "@/api/client";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
 
+type TFn = (key: string, opts?: Record<string, unknown>) => string;
+
+// Labels resolved at render via t() under customFields.entity.* and
+// customFields.fieldType.*, with the English value as the defaultValue.
 const ENTITY_TYPES = [
   { key: "employee", label: "Employee" },
   { key: "department", label: "Department" },
@@ -20,6 +25,10 @@ const ENTITY_TYPES = [
   { key: "project", label: "Project" },
   { key: "document", label: "Document" },
 ] as const;
+function entityLabel(key: string, t: TFn): string {
+  const fallback = ENTITY_TYPES.find((e) => e.key === key)?.label ?? key;
+  return t(`customFields.entity.${key}`, { defaultValue: fallback });
+}
 
 const FIELD_TYPES = [
   { value: "text", label: "Text" },
@@ -36,6 +45,10 @@ const FIELD_TYPES = [
   { value: "url", label: "URL" },
   { value: "file", label: "File" },
 ] as const;
+function fieldTypeLabel(value: string, t: TFn): string {
+  const fallback = FIELD_TYPES.find((f) => f.value === value)?.label ?? value;
+  return t(`customFields.fieldType.${value}`, { defaultValue: fallback });
+}
 
 type FieldDefinition = {
   id: number;
@@ -73,6 +86,7 @@ const INITIAL_FORM = {
 };
 
 export default function CustomFieldsSettingsPage() {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState("employee");
   const [showForm, setShowForm] = useState(false);
@@ -254,9 +268,9 @@ export default function CustomFieldsSettingsPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Custom Fields</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{t("customFields.title")}</h1>
           <p className="text-sm text-gray-500 mt-1">
-            Define custom data fields for employees, departments, and other entities
+            {t("customFields.subtitle")}
           </p>
         </div>
         {!showForm && (
@@ -268,7 +282,7 @@ export default function CustomFieldsSettingsPage() {
             className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 transition-colors"
           >
             <Plus className="h-4 w-4" />
-            Add Field
+            {t("customFields.addField")}
           </button>
         )}
       </div>
@@ -276,7 +290,7 @@ export default function CustomFieldsSettingsPage() {
       {/* Entity Type Tabs */}
       <div className="border-b border-gray-200 mb-6">
         <nav className="flex gap-4">
-          {ENTITY_TYPES.map(({ key, label }) => (
+          {ENTITY_TYPES.map(({ key }) => (
             <button
               key={key}
               onClick={() => {
@@ -289,7 +303,7 @@ export default function CustomFieldsSettingsPage() {
                   : "border-transparent text-gray-500 hover:text-gray-700"
               }`}
             >
-              {label}
+              {entityLabel(key, t)}
             </button>
           ))}
         </nav>
@@ -353,9 +367,9 @@ export default function CustomFieldsSettingsPage() {
                   }
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
-                  {FIELD_TYPES.map(({ value, label }) => (
+                  {FIELD_TYPES.map(({ value }) => (
                     <option key={value} value={value}>
-                      {label}
+                      {fieldTypeLabel(value, t)}
                     </option>
                   ))}
                 </select>

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -627,15 +627,14 @@ export default function CustomFieldsSettingsPage() {
 
       {/* Field Definitions List */}
       {isLoading ? (
-        <div className="text-center py-10 text-gray-400">Loading fields...</div>
+        <div className="text-center py-10 text-gray-400">{t("customFields.loading")}</div>
       ) : fields.length === 0 ? (
         <div className="bg-white rounded-xl border border-gray-200 p-10 text-center">
           <p className="text-gray-400">
-            No custom fields defined for{" "}
-            {ENTITY_TYPES.find((t) => t.key === activeTab)?.label || activeTab}.
+            {t("customFields.empty", { entity: entityLabel(activeTab, t) })}
           </p>
           <p className="text-sm text-gray-400 mt-1">
-            Click "Add Field" to create your first custom field.
+            {t("customFields.emptyHint")}
           </p>
         </div>
       ) : (
@@ -655,22 +654,22 @@ export default function CustomFieldsSettingsPage() {
                   <tr>
                     <th className="w-10" />
                     <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">
-                      Field Name
+                      {t("customFields.colFieldName")}
                     </th>
                     <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">
-                      Key
+                      {t("customFields.colKey")}
                     </th>
                     <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">
-                      Type
+                      {t("customFields.colType")}
                     </th>
                     <th className="text-center text-xs font-medium text-gray-500 uppercase px-4 py-3">
-                      Required
+                      {t("customFields.required")}
                     </th>
                     <th className="text-center text-xs font-medium text-gray-500 uppercase px-4 py-3">
-                      Searchable
+                      {t("customFields.searchable")}
                     </th>
                     <th className="text-right text-xs font-medium text-gray-500 uppercase px-4 py-3">
-                      Actions
+                      {t("customFields.colActions")}
                     </th>
                   </tr>
                 </thead>
@@ -709,44 +708,44 @@ export default function CustomFieldsSettingsPage() {
                       </td>
                       <td className="px-4 py-3">
                         <span className="inline-block bg-gray-100 text-gray-700 px-2 py-0.5 rounded text-xs font-medium">
-                          {field.field_type}
+                          {fieldTypeLabel(field.field_type, t)}
                         </span>
                         {field.options && field.options.length > 0 && (
                           <span className="text-xs text-gray-400 ml-1">
-                            ({field.options.length} options)
+                            {t("customFields.optionsCount", { count: field.options.length })}
                           </span>
                         )}
                       </td>
                       <td className="px-4 py-3 text-center">
                         {field.is_required ? (
                           <span className="text-green-600 text-xs font-medium">
-                            Yes
+                            {t("customFields.yes")}
                           </span>
                         ) : (
-                          <span className="text-gray-300 text-xs">No</span>
+                          <span className="text-gray-300 text-xs">{t("customFields.no")}</span>
                         )}
                       </td>
                       <td className="px-4 py-3 text-center">
                         {field.is_searchable ? (
                           <span className="text-green-600 text-xs font-medium">
-                            Yes
+                            {t("customFields.yes")}
                           </span>
                         ) : (
-                          <span className="text-gray-300 text-xs">No</span>
+                          <span className="text-gray-300 text-xs">{t("customFields.no")}</span>
                         )}
                       </td>
                       <td className="px-4 py-3 text-right whitespace-nowrap">
                         <div className="flex items-center justify-end gap-1 flex-shrink-0">
                           <button
                             onClick={() => startEdit(field)}
-                            aria-label="Edit field"
+                            aria-label={t("customFields.editFieldAria")}
                             className="p-1.5 text-gray-400 hover:text-brand-600 rounded hover:bg-gray-100 flex-shrink-0"
                           >
                             <Pencil className="h-4 w-4" />
                           </button>
                           <button
                             onClick={() => setDeleteFieldTarget({ id: field.id, field_name: field.field_name })}
-                            aria-label="Delete field"
+                            aria-label={t("customFields.deleteFieldAria")}
                             className="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100 flex-shrink-0"
                           >
                             <Trash2 className="h-4 w-4" />
@@ -764,9 +763,9 @@ export default function CustomFieldsSettingsPage() {
 
       <ConfirmDialog
         open={deleteFieldTarget !== null}
-        title={deleteFieldTarget ? `Deactivate field "${deleteFieldTarget.field_name}"?` : "Deactivate field?"}
-        description="Existing values will be preserved."
-        confirmText="Deactivate"
+        title={deleteFieldTarget ? t("customFields.deactivateNamed", { name: deleteFieldTarget.field_name }) : t("customFields.deactivate")}
+        description={t("customFields.deactivateDesc")}
+        confirmText={t("customFields.deactivateBtn")}
         variant="danger"
         loading={deleteMutation.isPending}
         onConfirm={() => deleteFieldTarget && deleteMutation.mutate(deleteFieldTarget.id)}

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -780,13 +780,15 @@ export default function CustomFieldsSettingsPage() {
 // ---------------------------------------------------------------------------
 
 function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
+  const { t } = useTranslation();
   const commonClass =
     "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white";
+  const fieldName = form.field_name || t("customFields.previewFieldName");
 
   return (
     <div className="max-w-md">
       <label className="block text-sm font-medium text-gray-700 mb-1">
-        {form.field_name || "Field Name"}
+        {fieldName}
         {form.is_required && <span className="text-red-500 ml-1">*</span>}
       </label>
 
@@ -804,13 +806,13 @@ function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
               ? "url"
               : "text"
           }
-          placeholder={form.placeholder || `Enter ${form.field_name || "value"}`}
+          placeholder={form.placeholder || t("customFields.previewEnter", { name: form.field_name || t("customFields.previewValue") })}
           className={commonClass}
           disabled
         />
       ) : form.field_type === "textarea" ? (
         <textarea
-          placeholder={form.placeholder || `Enter ${form.field_name || "value"}`}
+          placeholder={form.placeholder || t("customFields.previewEnter", { name: form.field_name || t("customFields.previewValue") })}
           rows={3}
           className={commonClass}
           disabled
@@ -828,7 +830,7 @@ function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
         <input type="datetime-local" className={commonClass} disabled />
       ) : form.field_type === "dropdown" ? (
         <select className={commonClass} disabled>
-          <option>Select {form.field_name || "option"}...</option>
+          <option>{t("customFields.previewSelect", { name: form.field_name || t("customFields.previewOption") })}</option>
           {form.options.map((opt, i) => (
             <option key={i}>{opt}</option>
           ))}
@@ -845,7 +847,7 @@ function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
               </span>
             ))
           ) : (
-            <span className="text-sm text-gray-400">No options defined</span>
+            <span className="text-sm text-gray-400">{t("customFields.noOptionsDefined")}</span>
           )}
         </div>
       ) : form.field_type === "checkbox" ? (
@@ -855,7 +857,7 @@ function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
             className="rounded border-gray-300"
             disabled
           />
-          {form.field_name || "Checkbox"}
+          {form.field_name || t("customFields.previewCheckbox")}
         </label>
       ) : form.field_type === "file" ? (
         <input type="file" className={commonClass} disabled />

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -358,7 +358,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Field Type */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {t("customFields.fieldType")}
+                  {t("customFields.fieldTypeField")}
                 </label>
                 <select
                   value={form.field_type}

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -317,7 +317,7 @@ export default function CustomFieldsSettingsPage() {
         >
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-gray-900">
-              {editingId ? "Edit Field" : "New Field"}
+              {editingId ? t("customFields.editField") : t("customFields.newField")}
             </h2>
             <div className="flex items-center gap-2">
               <button
@@ -325,7 +325,7 @@ export default function CustomFieldsSettingsPage() {
                 className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
               >
                 <Eye className="h-4 w-4" />
-                {showPreview ? "Hide Preview" : "Preview"}
+                {showPreview ? t("customFields.hidePreview") : t("customFields.preview")}
               </button>
               <button
                 onClick={resetForm}
@@ -341,7 +341,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Field Name */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Field Name *
+                  {t("customFields.fieldName")}
                 </label>
                 <input
                   type="text"
@@ -349,7 +349,7 @@ export default function CustomFieldsSettingsPage() {
                   onChange={(e) =>
                     setForm({ ...form, field_name: e.target.value })
                   }
-                  placeholder="e.g. T-Shirt Size"
+                  placeholder={t("customFields.fieldNamePlaceholder")}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                   required
                 />
@@ -358,7 +358,7 @@ export default function CustomFieldsSettingsPage() {
               {/* Field Type */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Field Type *
+                  {t("customFields.fieldType")}
                 </label>
                 <select
                   value={form.field_type}


### PR DESCRIPTION
## Summary
Fully localizes the **Custom Fields** page (`/custom-fields`, "Champs personnalisés"), which was hardcoded in English and rendered untranslated under every locale (flagged under the French UI).

Wired in **6 incremental commits (~5 strings each)** so each batch is independently reviewable.

## What's translated (71 keys, all 9 locales)
- Header (title + subtitle) and **Add Field** button
- The five **entity tabs** (Employee / Department / Location / Project / Document) and the 13 **field-type labels** (Text / Text Area / Number / … / File), resolved via `entityLabel` / `fieldTypeLabel` helpers with the English value as `defaultValue`
- **Create / Edit form** — heading, Preview/Hide Preview, every field label + placeholder (Field Name, Field Type, Section, Placeholder, Default Value, Validation Regex, Min/Max Value, Help Text), Options input + Add, Required / Searchable toggles, the save-error message, and the Saving/Create/Update/Cancel actions
- **Field Preview** component — "Field Name" fallback, the "Enter {{name}}" / "Select {{name}}…" placeholders, "No options defined", checkbox fallback
- **Fields list** — loading, the parameterized empty state ("No custom fields defined for {{entity}}"), all six column headers, the field-type badge, pluralized "({{count}} options)", Yes/No required/searchable cells, edit/delete aria-labels
- **Deactivate dialog** (named + generic title, description, button)

## Note — fixed a key collision mid-PR
An intermediate commit gave the "Field Type *" form label the key `customFields.fieldType`, which collided with the `customFields.fieldType.*` type-label **object** map — JSON can't have the same key be both a string and an object, so one clobbered the other and the dropdown labels broke. The final commit renames the label to `fieldTypeField` and restores `fieldType` as the 13-key map. Full key parity (71 flattened keys) is confirmed across all 9 locales.

## Verification
- Renders fully in **all 8 non-English languages** — verified via headless Chrome against the exact strings in each locale file, **including opening the Add-Field form and checking a field-type dropdown option** (e.g. FR "Liste déroulante") to prove the collision fix
- French (the flagged locale) and Arabic (RTL, `dir=rtl`) both confirmed
- **Zero** "returned an object" console errors
- 0 TypeScript errors; full key parity across all 9 locales

Branched off the latest `main`.