### PR TITLE
fix(i18n): translate the Helpdesk Dashboard page

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2538,5 +2538,66 @@
       "damaged": "تالف",
       "updated": "تم التحديث"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "جارٍ تحميل لوحة مكتب المساعدة...",
+    "title": "لوحة مكتب المساعدة",
+    "subtitle": "نظرة عامة على تذاكر مكتب الموارد البشرية وأداء اتفاقية مستوى الخدمة (SLA).",
+    "viewAllTickets": "عرض كل التذاكر",
+    "stat": {
+      "totalOpen": "إجمالي المفتوحة",
+      "inProgress": "قيد المعالجة",
+      "overdue": "متأخرة (خرق SLA)",
+      "resolvedToday": "تم حلها اليوم"
+    },
+    "slaCompliance": {
+      "heading": "الالتزام بـ SLA",
+      "caption": "التذاكر التي تم حلها ضمن SLA"
+    },
+    "avgResolution": {
+      "heading": "متوسط وقت الحل",
+      "unit": "ساعة"
+    },
+    "satisfaction": {
+      "heading": "تقييم الرضا",
+      "notAvailable": "غير متاح",
+      "ratingCount_zero": "{{count}} تقييم",
+      "ratingCount_one": "{{count}} تقييم",
+      "ratingCount_two": "{{count}} تقييمان",
+      "ratingCount_few": "{{count}} تقييمات",
+      "ratingCount_many": "{{count}} تقييمًا",
+      "ratingCount_other": "{{count}} تقييم"
+    },
+    "categoryBreakdown": {
+      "heading": "التذاكر حسب الفئة"
+    },
+    "recentTickets": {
+      "heading": "أحدث التذاكر"
+    },
+    "noTicketsYet": "لا توجد تذاكر بعد",
+    "category": {
+      "leave": "إجازة",
+      "payroll": "كشوف الرواتب",
+      "benefits": "المزايا",
+      "it": "IT",
+      "facilities": "المرافق",
+      "onboarding": "الإعداد والتعيين",
+      "policy": "السياسات",
+      "general": "عام"
+    },
+    "priority": {
+      "low": "منخفضة",
+      "medium": "متوسطة",
+      "high": "عالية",
+      "urgent": "عاجلة"
+    },
+    "status": {
+      "open": "مفتوحة",
+      "in_progress": "قيد المعالجة",
+      "awaiting_response": "بانتظار الرد",
+      "resolved": "تم الحل",
+      "closed": "مغلقة",
+      "reopened": "أُعيد فتحها"
+    }
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2538,5 +2538,62 @@
       "damaged": "Beschädigt",
       "updated": "Aktualisiert"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "Helpdesk-Dashboard wird geladen ...",
+    "title": "Helpdesk-Dashboard",
+    "subtitle": "Überblick über HR-Helpdesk-Tickets und SLA-Leistung.",
+    "viewAllTickets": "Alle Tickets anzeigen",
+    "stat": {
+      "totalOpen": "Offen gesamt",
+      "inProgress": "In Bearbeitung",
+      "overdue": "Überfällig (SLA verletzt)",
+      "resolvedToday": "Heute gelöst"
+    },
+    "slaCompliance": {
+      "heading": "SLA-Einhaltung",
+      "caption": "Innerhalb des SLA gelöste Tickets"
+    },
+    "avgResolution": {
+      "heading": "Durchschnittliche Lösungszeit",
+      "unit": "Stunden"
+    },
+    "satisfaction": {
+      "heading": "Zufriedenheitsbewertung",
+      "notAvailable": "k. A.",
+      "ratingCount_one": "{{count}} Bewertung",
+      "ratingCount_other": "{{count}} Bewertungen"
+    },
+    "categoryBreakdown": {
+      "heading": "Tickets nach Kategorie"
+    },
+    "recentTickets": {
+      "heading": "Aktuelle Tickets"
+    },
+    "noTicketsYet": "Noch keine Tickets",
+    "category": {
+      "leave": "Urlaub",
+      "payroll": "Lohnabrechnung",
+      "benefits": "Leistungen",
+      "it": "IT",
+      "facilities": "Gebäudemanagement",
+      "onboarding": "Onboarding",
+      "policy": "Richtlinie",
+      "general": "Allgemein"
+    },
+    "priority": {
+      "low": "Niedrig",
+      "medium": "Mittel",
+      "high": "Hoch",
+      "urgent": "Dringend"
+    },
+    "status": {
+      "open": "Offen",
+      "in_progress": "In Bearbeitung",
+      "awaiting_response": "Wartet auf Antwort",
+      "resolved": "Gelöst",
+      "closed": "Geschlossen",
+      "reopened": "Wieder geöffnet"
+    }
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2544,5 +2544,62 @@
       "damaged": "Damaged",
       "updated": "Updated"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "Loading helpdesk dashboard...",
+    "title": "Helpdesk Dashboard",
+    "subtitle": "Overview of HR helpdesk tickets and SLA performance.",
+    "viewAllTickets": "View All Tickets",
+    "stat": {
+      "totalOpen": "Total Open",
+      "inProgress": "In Progress",
+      "overdue": "Overdue (SLA Breached)",
+      "resolvedToday": "Resolved Today"
+    },
+    "slaCompliance": {
+      "heading": "SLA Compliance",
+      "caption": "Tickets resolved within SLA"
+    },
+    "avgResolution": {
+      "heading": "Average Resolution Time",
+      "unit": "hours"
+    },
+    "satisfaction": {
+      "heading": "Satisfaction Rating",
+      "notAvailable": "N/A",
+      "ratingCount_one": "{{count}} rating",
+      "ratingCount_other": "{{count}} ratings"
+    },
+    "categoryBreakdown": {
+      "heading": "Tickets by Category"
+    },
+    "recentTickets": {
+      "heading": "Recent Tickets"
+    },
+    "noTicketsYet": "No tickets yet",
+    "category": {
+      "leave": "Leave",
+      "payroll": "Payroll",
+      "benefits": "Benefits",
+      "it": "IT",
+      "facilities": "Facilities",
+      "onboarding": "Onboarding",
+      "policy": "Policy",
+      "general": "General"
+    },
+    "priority": {
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "urgent": "Urgent"
+    },
+    "status": {
+      "open": "Open",
+      "in_progress": "In Progress",
+      "awaiting_response": "Awaiting Response",
+      "resolved": "Resolved",
+      "closed": "Closed",
+      "reopened": "Reopened"
+    }
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2538,5 +2538,62 @@
       "damaged": "Dañado",
       "updated": "Actualizado"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "Cargando el panel de soporte...",
+    "title": "Panel de soporte",
+    "subtitle": "Resumen de los tickets de soporte de RR. HH. y el cumplimiento de SLA.",
+    "viewAllTickets": "Ver todos los tickets",
+    "stat": {
+      "totalOpen": "Total abiertos",
+      "inProgress": "En curso",
+      "overdue": "Vencidos (SLA incumplido)",
+      "resolvedToday": "Resueltos hoy"
+    },
+    "slaCompliance": {
+      "heading": "Cumplimiento de SLA",
+      "caption": "Tickets resueltos dentro del SLA"
+    },
+    "avgResolution": {
+      "heading": "Tiempo medio de resolución",
+      "unit": "horas"
+    },
+    "satisfaction": {
+      "heading": "Valoración de satisfacción",
+      "notAvailable": "N/D",
+      "ratingCount_one": "{{count}} valoración",
+      "ratingCount_other": "{{count}} valoraciones"
+    },
+    "categoryBreakdown": {
+      "heading": "Tickets por categoría"
+    },
+    "recentTickets": {
+      "heading": "Tickets recientes"
+    },
+    "noTicketsYet": "Aún no hay tickets",
+    "category": {
+      "leave": "Ausencias",
+      "payroll": "Nómina",
+      "benefits": "Beneficios",
+      "it": "TI",
+      "facilities": "Instalaciones",
+      "onboarding": "Incorporación",
+      "policy": "Políticas",
+      "general": "General"
+    },
+    "priority": {
+      "low": "Baja",
+      "medium": "Media",
+      "high": "Alta",
+      "urgent": "Urgente"
+    },
+    "status": {
+      "open": "Abierto",
+      "in_progress": "En curso",
+      "awaiting_response": "Esperando respuesta",
+      "resolved": "Resuelto",
+      "closed": "Cerrado",
+      "reopened": "Reabierto"
+    }
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2538,5 +2538,62 @@
       "damaged": "Endommagé",
       "updated": "Mis à jour"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "Chargement du tableau de bord du service d'assistance...",
+    "title": "Tableau de bord du service d'assistance",
+    "subtitle": "Aperçu des tickets du service d'assistance RH et des performances SLA.",
+    "viewAllTickets": "Voir tous les tickets",
+    "stat": {
+      "totalOpen": "Tickets ouverts",
+      "inProgress": "En cours",
+      "overdue": "En retard (SLA dépassé)",
+      "resolvedToday": "Résolus aujourd'hui"
+    },
+    "slaCompliance": {
+      "heading": "Respect des SLA",
+      "caption": "Tickets résolus dans les délais SLA"
+    },
+    "avgResolution": {
+      "heading": "Temps de résolution moyen",
+      "unit": "heures"
+    },
+    "satisfaction": {
+      "heading": "Niveau de satisfaction",
+      "notAvailable": "N/D",
+      "ratingCount_one": "{{count}} évaluation",
+      "ratingCount_other": "{{count}} évaluations"
+    },
+    "categoryBreakdown": {
+      "heading": "Tickets par catégorie"
+    },
+    "recentTickets": {
+      "heading": "Tickets récents"
+    },
+    "noTicketsYet": "Aucun ticket pour le moment",
+    "category": {
+      "leave": "Congés",
+      "payroll": "Paie",
+      "benefits": "Avantages sociaux",
+      "it": "Informatique",
+      "facilities": "Locaux",
+      "onboarding": "Intégration",
+      "policy": "Règlement",
+      "general": "Général"
+    },
+    "priority": {
+      "low": "Faible",
+      "medium": "Moyenne",
+      "high": "Élevée",
+      "urgent": "Urgente"
+    },
+    "status": {
+      "open": "Ouvert",
+      "in_progress": "En cours",
+      "awaiting_response": "En attente de réponse",
+      "resolved": "Résolu",
+      "closed": "Fermé",
+      "reopened": "Rouvert"
+    }
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2538,5 +2538,62 @@
       "damaged": "क्षतिग्रस्त",
       "updated": "अपडेट किया गया"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "हेल्पडेस्क डैशबोर्ड लोड हो रहा है...",
+    "title": "हेल्पडेस्क डैशबोर्ड",
+    "subtitle": "HR हेल्पडेस्क टिकट और SLA प्रदर्शन का अवलोकन।",
+    "viewAllTickets": "सभी टिकट देखें",
+    "stat": {
+      "totalOpen": "कुल खुले",
+      "inProgress": "प्रगति पर",
+      "overdue": "अतिदेय (SLA उल्लंघित)",
+      "resolvedToday": "आज हल किए गए"
+    },
+    "slaCompliance": {
+      "heading": "SLA अनुपालन",
+      "caption": "SLA के भीतर हल किए गए टिकट"
+    },
+    "avgResolution": {
+      "heading": "औसत समाधान समय",
+      "unit": "घंटे"
+    },
+    "satisfaction": {
+      "heading": "संतुष्टि रेटिंग",
+      "notAvailable": "लागू नहीं",
+      "ratingCount_one": "{{count}} रेटिंग",
+      "ratingCount_other": "{{count}} रेटिंग"
+    },
+    "categoryBreakdown": {
+      "heading": "श्रेणी अनुसार टिकट"
+    },
+    "recentTickets": {
+      "heading": "हाल के टिकट"
+    },
+    "noTicketsYet": "अभी तक कोई टिकट नहीं",
+    "category": {
+      "leave": "अवकाश",
+      "payroll": "पेरोल",
+      "benefits": "लाभ",
+      "it": "IT",
+      "facilities": "सुविधाएँ",
+      "onboarding": "ऑनबोर्डिंग",
+      "policy": "नीति",
+      "general": "सामान्य"
+    },
+    "priority": {
+      "low": "निम्न",
+      "medium": "मध्यम",
+      "high": "उच्च",
+      "urgent": "अत्यावश्यक"
+    },
+    "status": {
+      "open": "खुला",
+      "in_progress": "प्रगति पर",
+      "awaiting_response": "प्रतिक्रिया की प्रतीक्षा में",
+      "resolved": "हल किया गया",
+      "closed": "बंद",
+      "reopened": "पुनः खोला गया"
+    }
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2538,5 +2538,62 @@
       "damaged": "破損",
       "updated": "更新"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "ヘルプデスクダッシュボードを読み込み中...",
+    "title": "ヘルプデスクダッシュボード",
+    "subtitle": "人事ヘルプデスクのチケットとSLA達成状況の概要。",
+    "viewAllTickets": "すべてのチケットを表示",
+    "stat": {
+      "totalOpen": "オープン合計",
+      "inProgress": "対応中",
+      "overdue": "期限超過（SLA違反）",
+      "resolvedToday": "本日解決済み"
+    },
+    "slaCompliance": {
+      "heading": "SLA遵守率",
+      "caption": "SLA内に解決したチケット"
+    },
+    "avgResolution": {
+      "heading": "平均解決時間",
+      "unit": "時間"
+    },
+    "satisfaction": {
+      "heading": "満足度評価",
+      "notAvailable": "なし",
+      "ratingCount_one": "{{count}}件の評価",
+      "ratingCount_other": "{{count}}件の評価"
+    },
+    "categoryBreakdown": {
+      "heading": "カテゴリ別チケット"
+    },
+    "recentTickets": {
+      "heading": "最近のチケット"
+    },
+    "noTicketsYet": "チケットはまだありません",
+    "category": {
+      "leave": "休暇",
+      "payroll": "給与",
+      "benefits": "福利厚生",
+      "it": "IT",
+      "facilities": "施設",
+      "onboarding": "オンボーディング",
+      "policy": "ポリシー",
+      "general": "一般"
+    },
+    "priority": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "urgent": "緊急"
+    },
+    "status": {
+      "open": "オープン",
+      "in_progress": "対応中",
+      "awaiting_response": "返信待ち",
+      "resolved": "解決済み",
+      "closed": "クローズ",
+      "reopened": "再オープン"
+    }
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2538,5 +2538,62 @@
       "damaged": "Danificado",
       "updated": "Atualizado"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "A carregar painel do suporte...",
+    "title": "Painel do Suporte",
+    "subtitle": "Visão geral dos tickets de suporte de RH e do desempenho de SLA.",
+    "viewAllTickets": "Ver todos os tickets",
+    "stat": {
+      "totalOpen": "Total em aberto",
+      "inProgress": "Em andamento",
+      "overdue": "Atrasados (SLA incumprido)",
+      "resolvedToday": "Resolvidos hoje"
+    },
+    "slaCompliance": {
+      "heading": "Conformidade com SLA",
+      "caption": "Tickets resolvidos dentro do SLA"
+    },
+    "avgResolution": {
+      "heading": "Tempo médio de resolução",
+      "unit": "horas"
+    },
+    "satisfaction": {
+      "heading": "Índice de satisfação",
+      "notAvailable": "N/D",
+      "ratingCount_one": "{{count}} avaliação",
+      "ratingCount_other": "{{count}} avaliações"
+    },
+    "categoryBreakdown": {
+      "heading": "Tickets por categoria"
+    },
+    "recentTickets": {
+      "heading": "Tickets recentes"
+    },
+    "noTicketsYet": "Ainda sem tickets",
+    "category": {
+      "leave": "Ausências",
+      "payroll": "Folha de pagamento",
+      "benefits": "Benefícios",
+      "it": "TI",
+      "facilities": "Instalações",
+      "onboarding": "Integração",
+      "policy": "Políticas",
+      "general": "Geral"
+    },
+    "priority": {
+      "low": "Baixa",
+      "medium": "Média",
+      "high": "Alta",
+      "urgent": "Urgente"
+    },
+    "status": {
+      "open": "Aberto",
+      "in_progress": "Em andamento",
+      "awaiting_response": "A aguardar resposta",
+      "resolved": "Resolvido",
+      "closed": "Fechado",
+      "reopened": "Reaberto"
+    }
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2538,5 +2538,62 @@
       "damaged": "已损坏",
       "updated": "已更新"
     }
+  },
+  "helpdeskDashboard": {
+    "loading": "正在加载服务台仪表板……",
+    "title": "服务台仪表板",
+    "subtitle": "HR 服务台工单与 SLA 表现概览。",
+    "viewAllTickets": "查看全部工单",
+    "stat": {
+      "totalOpen": "待处理总数",
+      "inProgress": "处理中",
+      "overdue": "已逾期（违反 SLA）",
+      "resolvedToday": "今日已解决"
+    },
+    "slaCompliance": {
+      "heading": "SLA 达标率",
+      "caption": "在 SLA 内解决的工单"
+    },
+    "avgResolution": {
+      "heading": "平均解决时长",
+      "unit": "小时"
+    },
+    "satisfaction": {
+      "heading": "满意度评分",
+      "notAvailable": "暂无",
+      "ratingCount_one": "{{count}} 条评分",
+      "ratingCount_other": "{{count}} 条评分"
+    },
+    "categoryBreakdown": {
+      "heading": "按类别统计工单"
+    },
+    "recentTickets": {
+      "heading": "近期工单"
+    },
+    "noTicketsYet": "暂无工单",
+    "category": {
+      "leave": "请假",
+      "payroll": "薪资",
+      "benefits": "福利",
+      "it": "IT",
+      "facilities": "后勤设施",
+      "onboarding": "入职",
+      "policy": "政策制度",
+      "general": "综合"
+    },
+    "priority": {
+      "low": "低",
+      "medium": "中",
+      "high": "高",
+      "urgent": "紧急"
+    },
+    "status": {
+      "open": "待处理",
+      "in_progress": "处理中",
+      "awaiting_response": "等待回复",
+      "resolved": "已解决",
+      "closed": "已关闭",
+      "reopened": "已重新打开"
+    }
   }
 }

--- a/packages/client/src/pages/helpdesk/HelpdeskDashboardPage.tsx
+++ b/packages/client/src/pages/helpdesk/HelpdeskDashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import api from "@/api/client";
 import {
@@ -46,12 +47,13 @@ function useDashboard() {
 }
 
 export default function HelpdeskDashboardPage() {
+  const { t } = useTranslation();
   const { data: stats, isLoading } = useDashboard();
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="text-gray-400">Loading helpdesk dashboard...</div>
+        <div className="text-gray-400">{t("helpdeskDashboard.loading")}</div>
       </div>
     );
   }
@@ -62,28 +64,28 @@ export default function HelpdeskDashboardPage() {
   // counts are clickable — fixes issue #1398.
   const statCards = [
     {
-      label: "Total Open",
+      label: t("helpdeskDashboard.stat.totalOpen"),
       value: stats.total_open,
       icon: Clock,
       color: "text-blue-600 bg-blue-50",
       href: "/helpdesk/tickets?status=open",
     },
     {
-      label: "In Progress",
+      label: t("helpdeskDashboard.stat.inProgress"),
       value: stats.in_progress + stats.awaiting_response,
       icon: Headphones,
       color: "text-yellow-600 bg-yellow-50",
       href: "/helpdesk/tickets?status=in_progress",
     },
     {
-      label: "Overdue (SLA Breached)",
+      label: t("helpdeskDashboard.stat.overdue"),
       value: stats.overdue,
       icon: AlertTriangle,
       color: "text-red-600 bg-red-50",
       href: "/helpdesk/tickets?sla=breached",
     },
     {
-      label: "Resolved Today",
+      label: t("helpdeskDashboard.stat.resolvedToday"),
       value: stats.resolved_today,
       icon: CheckCircle2,
       color: "text-green-600 bg-green-50",
@@ -100,16 +102,16 @@ export default function HelpdeskDashboardPage() {
     <div>
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Helpdesk Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900">{t("helpdeskDashboard.title")}</h1>
           <p className="text-gray-500 mt-1">
-            Overview of HR helpdesk tickets and SLA performance.
+            {t("helpdeskDashboard.subtitle")}
           </p>
         </div>
         <Link
           to="/helpdesk/tickets"
           className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
         >
-          View All Tickets <ArrowRight className="h-4 w-4" />
+          {t("helpdeskDashboard.viewAllTickets")} <ArrowRight className="h-4 w-4" />
         </Link>
       </div>
 
@@ -142,7 +144,7 @@ export default function HelpdeskDashboardPage() {
         {/* SLA Compliance */}
         <div className="bg-white rounded-xl border border-gray-200 p-6">
           <h3 className="text-sm font-semibold text-gray-700 mb-4 flex items-center gap-2">
-            <BarChart3 className="h-4 w-4" /> SLA Compliance
+            <BarChart3 className="h-4 w-4" /> {t("helpdeskDashboard.slaCompliance.heading")}
           </h3>
           <div className="flex items-center justify-center">
             <div className="relative w-32 h-32">
@@ -174,21 +176,21 @@ export default function HelpdeskDashboardPage() {
             </div>
           </div>
           <p className="text-center text-xs text-gray-500 mt-3">
-            Tickets resolved within SLA
+            {t("helpdeskDashboard.slaCompliance.caption")}
           </p>
         </div>
 
         {/* Avg Resolution Time */}
         <div className="bg-white rounded-xl border border-gray-200 p-6">
           <h3 className="text-sm font-semibold text-gray-700 mb-4 flex items-center gap-2">
-            <Clock className="h-4 w-4" /> Average Resolution Time
+            <Clock className="h-4 w-4" /> {t("helpdeskDashboard.avgResolution.heading")}
           </h3>
           <div className="flex items-center justify-center mt-4">
             <div className="text-center">
               <p className="text-4xl font-bold text-gray-900">
                 {stats.avg_resolution_hours}
               </p>
-              <p className="text-sm text-gray-500 mt-1">hours</p>
+              <p className="text-sm text-gray-500 mt-1">{t("helpdeskDashboard.avgResolution.unit")}</p>
             </div>
           </div>
         </div>
@@ -196,7 +198,7 @@ export default function HelpdeskDashboardPage() {
         {/* Satisfaction */}
         <div className="bg-white rounded-xl border border-gray-200 p-6">
           <h3 className="text-sm font-semibold text-gray-700 mb-4 flex items-center gap-2">
-            <Star className="h-4 w-4" /> Satisfaction Rating
+            <Star className="h-4 w-4" /> {t("helpdeskDashboard.satisfaction.heading")}
           </h3>
           <div className="flex items-center justify-center mt-4">
             <div className="text-center">
@@ -213,10 +215,10 @@ export default function HelpdeskDashboardPage() {
                 ))}
               </div>
               <p className="text-2xl font-bold text-gray-900">
-                {stats.avg_satisfaction ?? "N/A"}
+                {stats.avg_satisfaction ?? t("helpdeskDashboard.satisfaction.notAvailable")}
               </p>
               <p className="text-xs text-gray-500 mt-1">
-                {stats.rated_count} rating{stats.rated_count !== 1 ? "s" : ""}
+                {t("helpdeskDashboard.satisfaction.ratingCount", { count: stats.rated_count })}
               </p>
             </div>
           </div>
@@ -227,17 +229,17 @@ export default function HelpdeskDashboardPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
         <div className="bg-white rounded-xl border border-gray-200 p-6">
           <h3 className="text-sm font-semibold text-gray-700 mb-4">
-            Tickets by Category
+            {t("helpdeskDashboard.categoryBreakdown.heading")}
           </h3>
           <div className="space-y-3">
             {stats.category_breakdown.map((cat: any) => (
               <div key={cat.category} className="flex items-center gap-3">
                 <span
-                  className={`text-xs font-medium px-2 py-0.5 rounded capitalize ${
+                  className={`text-xs font-medium px-2 py-0.5 rounded ${
                     CATEGORY_COLORS[cat.category] || "bg-gray-100 text-gray-600"
                   }`}
                 >
-                  {cat.category}
+                  {t(`helpdeskDashboard.category.${cat.category}`, { defaultValue: cat.category })}
                 </span>
                 <div className="flex-1 bg-gray-100 rounded-full h-2">
                   <div
@@ -254,7 +256,7 @@ export default function HelpdeskDashboardPage() {
             ))}
             {stats.category_breakdown.length === 0 && (
               <p className="text-sm text-gray-400 text-center py-4">
-                No tickets yet
+                {t("helpdeskDashboard.noTicketsYet")}
               </p>
             )}
           </div>
@@ -263,45 +265,45 @@ export default function HelpdeskDashboardPage() {
         {/* Recent Tickets */}
         <div className="bg-white rounded-xl border border-gray-200 p-6">
           <h3 className="text-sm font-semibold text-gray-700 mb-4">
-            Recent Tickets
+            {t("helpdeskDashboard.recentTickets.heading")}
           </h3>
           <div className="space-y-3">
-            {stats.recent_tickets.slice(0, 8).map((t: any) => (
+            {stats.recent_tickets.slice(0, 8).map((ticket: any) => (
               <Link
-                key={t.id}
-                to={`/helpdesk/tickets/${t.id}`}
+                key={ticket.id}
+                to={`/helpdesk/tickets/${ticket.id}`}
                 className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-gray-50 transition-colors"
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-gray-900 truncate">
-                    #{t.id} {t.subject}
+                    #{ticket.id} {ticket.subject}
                   </p>
                   <p className="text-xs text-gray-500">
-                    {t.raised_by_name} &middot;{" "}
-                    {new Date(t.created_at).toLocaleDateString()}
+                    {ticket.raised_by_name} &middot;{" "}
+                    {new Date(ticket.created_at).toLocaleDateString()}
                   </p>
                 </div>
                 <div className="flex items-center gap-2 ml-3">
                   <span
                     className={`text-xs px-2 py-0.5 rounded font-medium ${
-                      PRIORITY_COLORS[t.priority] || ""
+                      PRIORITY_COLORS[ticket.priority] || ""
                     }`}
                   >
-                    {t.priority}
+                    {t(`helpdeskDashboard.priority.${ticket.priority}`, { defaultValue: ticket.priority })}
                   </span>
                   <span
                     className={`text-xs px-2 py-0.5 rounded font-medium ${
-                      STATUS_COLORS[t.status] || ""
+                      STATUS_COLORS[ticket.status] || ""
                     }`}
                   >
-                    {t.status.replace("_", " ")}
+                    {t(`helpdeskDashboard.status.${ticket.status}`, { defaultValue: ticket.status.replace("_", " ") })}
                   </span>
                 </div>
               </Link>
             ))}
             {stats.recent_tickets.length === 0 && (
               <p className="text-sm text-gray-400 text-center py-4">
-                No tickets yet
+                {t("helpdeskDashboard.noTicketsYet")}
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
Fully localizes the **Helpdesk Dashboard** page (`/helpdesk/dashboard`, "Assistance"), which was hardcoded in English and rendered untranslated under every locale (flagged under the French UI).

## What's translated (37 keys, all 9 locales)
- Header (title + subtitle) + **View All Tickets** + loading
- The four **stat cards** (Total Open / In Progress / Overdue (SLA Breached) / Resolved Today)
- **SLA Compliance** (heading + "Tickets resolved within SLA"), **Average Resolution Time** (heading + "hours"), **Satisfaction Rating** (heading + "N/A" + the pluralized "{{count}} rating(s)")
- **Tickets by Category** + **Recent Tickets** headings + the shared "No tickets yet" empty state
- The **category** (leave/payroll/benefits/IT/facilities/onboarding/policy/general), **priority** (low/medium/high/urgent), and **status** (open/in_progress/awaiting_response/resolved/closed/reopened) badge labels — resolved via `t()` with the raw value as `defaultValue`. "it" now renders "IT" and status no longer relies on `replace("_"," ")`. Renamed the recent-tickets loop var `t → ticket` so it doesn't shadow the i18n `t`.

## How it was built (multi-agent)
Translations were produced and **adversarially verified** by a multi-agent workflow: one agent extracted the full string inventory, eight translator agents (one per locale) ran in parallel, and an independent skeptical QA reviewer per locale hunted for mistranslations / awkward phrasing / broken `{{count}}` placeholders. **13 issues were caught and auto-corrected** (pt 4, fr 2, hi 4, zh 3).

A static post-check then found a real defect the verifier missed: Arabic's `_one` form had dropped `{{count}}`. A focused follow-up agent produced the **full Arabic CLDR plural set** (`_zero/_one/_two/_few/_many/_other`) for the ratings count, each retaining `{{count}}` — so Arabic pluralization is grammatically correct, not just `_one/_other`.

## Verification
- Renders fully in **all 8 non-English languages** — 9/9 strings matched per language via headless Chrome against the exact locale-file values
- French (the flagged locale) and Arabic (RTL, `dir=rtl`) confirmed
- **Zero** "returned an object" console errors
- 0 TypeScript errors; full key parity + `{{count}}` integrity across all 9 locales (Arabic intentionally carries the 4 extra CLDR plural forms)

Branched off the latest `main`.