### PR TITLE
fix(i18n): translate 6 keys that were English-only across all non-EN locales

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "لا يوجد موظفون في هذه الفئة.",
       "lateBy": "التأخر",
       "minSuffix": "دقيقة",
-      "close": "إغلاق"
+      "close": "إغلاق",
+      "dateLabel": "التاريخ",
+      "noSearchResults": "لا يوجد موظف يطابق بحثك.",
+      "searchPlaceholder": "البحث بالاسم أو البريد الإلكتروني أو القسم"
     },
     "export": {
       "title": "تصدير تقرير الحضور",
@@ -1706,7 +1709,8 @@
       "previous": "السابق",
       "next": "التالي",
       "alertPlannedInvalid": "يجب أن يكون الملاك المخطط 0 أو أكثر.",
-      "alertCurrentInvalid": "يجب أن يكون الملاك الحالي 0 أو أكثر."
+      "alertCurrentInvalid": "يجب أن يكون الملاك الحالي 0 أو أكثر.",
+      "searchPlaceholder": "البحث بعنوان الخطة أو السنة المالية..."
     },
     "vacancies": {
       "title": "الشواغر المفتوحة",
@@ -1850,7 +1854,9 @@
       "announcement_created": "إنشاء إعلان",
       "policy_created": "إنشاء سياسة",
       "policy_acknowledged": "تأكيد السياسة"
-    }
+    },
+    "noActionMatches": "لا توجد إجراءات مطابقة",
+    "searchActions": "البحث عن نوع الإجراء..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "Keine Mitarbeiter in dieser Kategorie.",
       "lateBy": "Verspätet um",
       "minSuffix": "Min.",
-      "close": "Schließen"
+      "close": "Schließen",
+      "dateLabel": "Datum",
+      "noSearchResults": "Kein Mitarbeiter entspricht Ihrer Suche.",
+      "searchPlaceholder": "Name, E-Mail oder Abteilung suchen"
     },
     "export": {
       "title": "Anwesenheitsbericht exportieren",
@@ -1706,7 +1709,8 @@
       "previous": "Zurück",
       "next": "Weiter",
       "alertPlannedInvalid": "Geplanter Personalbestand muss 0 oder größer sein.",
-      "alertCurrentInvalid": "Aktueller Personalbestand muss 0 oder größer sein."
+      "alertCurrentInvalid": "Aktueller Personalbestand muss 0 oder größer sein.",
+      "searchPlaceholder": "Nach Plantitel oder Geschäftsjahr suchen..."
     },
     "vacancies": {
       "title": "Offene Stellen",
@@ -1850,7 +1854,9 @@
       "announcement_created": "Ankündigung erstellt",
       "policy_created": "Richtlinie erstellt",
       "policy_acknowledged": "Richtlinie bestätigt"
-    }
+    },
+    "noActionMatches": "Keine passende Aktion",
+    "searchActions": "Aktionstyp suchen..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "No hay empleados en esta categoría.",
       "lateBy": "Retraso",
       "minSuffix": "min",
-      "close": "Cerrar"
+      "close": "Cerrar",
+      "dateLabel": "Fecha",
+      "noSearchResults": "Ningún empleado coincide con tu búsqueda.",
+      "searchPlaceholder": "Buscar nombre, correo o departamento"
     },
     "export": {
       "title": "Exportar informe de asistencia",
@@ -1706,7 +1709,8 @@
       "previous": "Anterior",
       "next": "Siguiente",
       "alertPlannedInvalid": "La plantilla planificada debe ser 0 o mayor.",
-      "alertCurrentInvalid": "La plantilla actual debe ser 0 o mayor."
+      "alertCurrentInvalid": "La plantilla actual debe ser 0 o mayor.",
+      "searchPlaceholder": "Buscar por título del plan o año fiscal..."
     },
     "vacancies": {
       "title": "Vacantes Abiertas",
@@ -1850,7 +1854,9 @@
       "announcement_created": "Anuncio creado",
       "policy_created": "Política creada",
       "policy_acknowledged": "Política reconocida"
-    }
+    },
+    "noActionMatches": "Ninguna acción coincide",
+    "searchActions": "Buscar tipo de acción..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "Aucun employé dans cette catégorie.",
       "lateBy": "Retard",
       "minSuffix": "min",
-      "close": "Fermer"
+      "close": "Fermer",
+      "dateLabel": "Date",
+      "noSearchResults": "Aucun employé ne correspond à votre recherche.",
+      "searchPlaceholder": "Rechercher par nom, e-mail ou service"
     },
     "export": {
       "title": "Exporter le rapport de présence",
@@ -1706,7 +1709,8 @@
       "previous": "Précédent",
       "next": "Suivant",
       "alertPlannedInvalid": "L'effectif planifié doit être supérieur ou égal à 0.",
-      "alertCurrentInvalid": "L'effectif actuel doit être supérieur ou égal à 0."
+      "alertCurrentInvalid": "L'effectif actuel doit être supérieur ou égal à 0.",
+      "searchPlaceholder": "Rechercher par titre de plan ou exercice fiscal..."
     },
     "vacancies": {
       "title": "Postes vacants",
@@ -1850,7 +1854,9 @@
       "announcement_created": "Annonce créée",
       "policy_created": "Politique créée",
       "policy_acknowledged": "Politique reconnue"
-    }
+    },
+    "noActionMatches": "Aucune action correspondante",
+    "searchActions": "Rechercher un type d'action..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "इस श्रेणी में कोई कर्मचारी नहीं।",
       "lateBy": "देरी",
       "minSuffix": "मिनट",
-      "close": "बंद करें"
+      "close": "बंद करें",
+      "dateLabel": "तिथि",
+      "noSearchResults": "आपकी खोज से कोई कर्मचारी मेल नहीं खाता।",
+      "searchPlaceholder": "नाम, ईमेल या विभाग खोजें"
     },
     "export": {
       "title": "उपस्थिति रिपोर्ट निर्यात करें",
@@ -1706,7 +1709,8 @@
       "previous": "पिछला",
       "next": "अगला",
       "alertPlannedInvalid": "नियोजित हेडकाउंट 0 या उससे अधिक होना चाहिए।",
-      "alertCurrentInvalid": "वर्तमान हेडकाउंट 0 या उससे अधिक होना चाहिए।"
+      "alertCurrentInvalid": "वर्तमान हेडकाउंट 0 या उससे अधिक होना चाहिए।",
+      "searchPlaceholder": "योजना शीर्षक या वित्तीय वर्ष से खोजें..."
     },
     "vacancies": {
       "title": "खुली रिक्तियाँ",
@@ -1850,7 +1854,9 @@
       "announcement_created": "घोषणा बनाई",
       "policy_created": "नीति बनाई",
       "policy_acknowledged": "नीति स्वीकृत"
-    }
+    },
+    "noActionMatches": "कोई मिलती-जुलती क्रिया नहीं",
+    "searchActions": "क्रिया प्रकार खोजें..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "このカテゴリに従業員はいません。",
       "lateBy": "遅刻時間",
       "minSuffix": "分",
-      "close": "閉じる"
+      "close": "閉じる",
+      "dateLabel": "日付",
+      "noSearchResults": "検索に一致する従業員はいません。",
+      "searchPlaceholder": "名前、メール、部門で検索"
     },
     "export": {
       "title": "勤怠レポートのエクスポート",
@@ -1706,7 +1709,8 @@
       "previous": "前へ",
       "next": "次へ",
       "alertPlannedInvalid": "計画人員は 0 以上である必要があります。",
-      "alertCurrentInvalid": "現在の人員は 0 以上である必要があります。"
+      "alertCurrentInvalid": "現在の人員は 0 以上である必要があります。",
+      "searchPlaceholder": "プラン名または会計年度で検索..."
     },
     "vacancies": {
       "title": "公開中の欠員",
@@ -1850,7 +1854,9 @@
       "announcement_created": "お知らせ作成",
       "policy_created": "ポリシー作成",
       "policy_acknowledged": "ポリシー承認"
-    }
+    },
+    "noActionMatches": "一致するアクションがありません",
+    "searchActions": "アクションの種類を検索..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "Nenhum funcionário nesta categoria.",
       "lateBy": "Atraso",
       "minSuffix": "min",
-      "close": "Fechar"
+      "close": "Fechar",
+      "dateLabel": "Data",
+      "noSearchResults": "Nenhum funcionário corresponde à sua busca.",
+      "searchPlaceholder": "Pesquisar nome, e-mail ou departamento"
     },
     "export": {
       "title": "Exportar relatório de presença",
@@ -1706,7 +1709,8 @@
       "previous": "Anterior",
       "next": "Próximo",
       "alertPlannedInvalid": "O quadro planejado deve ser 0 ou maior.",
-      "alertCurrentInvalid": "O quadro atual deve ser 0 ou maior."
+      "alertCurrentInvalid": "O quadro atual deve ser 0 ou maior.",
+      "searchPlaceholder": "Pesquisar por título do plano ou ano fiscal..."
     },
     "vacancies": {
       "title": "Vagas Abertas",
@@ -1850,7 +1854,9 @@
       "announcement_created": "Comunicado Criado",
       "policy_created": "Política Criada",
       "policy_acknowledged": "Política Reconhecida"
-    }
+    },
+    "noActionMatches": "Nenhuma ação correspondente",
+    "searchActions": "Pesquisar tipo de ação..."
   },
   "employees": {
     "directory": {

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -962,7 +962,10 @@
       "noEmployeesInCategory": "此类别中没有员工。",
       "lateBy": "迟到时长",
       "minSuffix": "分钟",
-      "close": "关闭"
+      "close": "关闭",
+      "dateLabel": "日期",
+      "noSearchResults": "没有员工与您的搜索匹配。",
+      "searchPlaceholder": "搜索姓名、邮箱或部门"
     },
     "export": {
       "title": "导出考勤报表",
@@ -1706,7 +1709,8 @@
       "previous": "上一页",
       "next": "下一页",
       "alertPlannedInvalid": "计划人数必须为 0 或更大。",
-      "alertCurrentInvalid": "当前人数必须为 0 或更大。"
+      "alertCurrentInvalid": "当前人数必须为 0 或更大。",
+      "searchPlaceholder": "按计划名称或财年搜索..."
     },
     "vacancies": {
       "title": "公开空缺",
@@ -1850,7 +1854,9 @@
       "announcement_created": "创建公告",
       "policy_created": "创建政策",
       "policy_acknowledged": "确认政策"
-    }
+    },
+    "noActionMatches": "无匹配的操作",
+    "searchActions": "搜索操作类型..."
   },
   "employees": {
     "directory": {


### PR DESCRIPTION
## Summary
A cross-module locale audit found **6 keys present in `en.json` but missing from all 8 other locale files** — so they fell back to English in every non-English language, even though they are live `t()` calls.

| Key | Page | English |
|-----|------|---------|
| `attendance.breakdown.dateLabel` | Attendance Dashboard | Date |
| `attendance.breakdown.searchPlaceholder` | Attendance Dashboard | Search name, email, or department |
| `attendance.breakdown.noSearchResults` | Attendance Dashboard | No employees match your search. |
| `audit.searchActions` | Audit | Search action type... |
| `audit.noActionMatches` | Audit | No matching action |
| `positions.headcountPlans.searchPlaceholder` | Headcount Plans | Search by plan title or fiscal year... |

Added correct translations for all 6 in **pt / es / fr / de / hi / ja / zh / ar**.

## Verification
- **Perfect key parity** across all 9 locales restored (2230 keys, audited via flattened key-set diff)
- All interpolation placeholders consistent
- All 9 locale files valid JSON; 0 TypeScript errors

Branched off the latest `main`.