### PR TITLE
fix(positions): forward is_critical filter to listPositions

### DIFF
--- a/packages/server/src/api/routes/position.routes.ts
+++ b/packages/server/src/api/routes/position.routes.ts
@@ -187,6 +187,7 @@ router.get("/", authenticate, requirePermission("positions:view", "positions:man
       status: query.status,
       employment_type: query.employment_type,
       search: query.search,
+      is_critical: query.is_critical,
     });
     sendPaginated(res, result.positions, result.total, query.page, query.per_page);
   } catch (err) { next(err); }


### PR DESCRIPTION
The positions list route parsed `is_critical` from the query (positionQuerySchema) and listPositions already supported filtering on it, but the route never passed the value through — so filtering by critical roles silently returned the full, unfiltered list. Forward query.is_critical to the service.