### PR TITLE
fix(i18n): translate the Employee Profile page

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -2538,5 +2538,264 @@
       "damaged": "تالف",
       "updated": "تم التحديث"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "البيانات الشخصية",
+      "education": "التعليم",
+      "experience": "الخبرة",
+      "dependents": "المُعالون",
+      "addresses": "العناوين",
+      "custom": "حقول مخصصة"
+    },
+    "invalidEmployee": {
+      "title": "موظف غير صالح",
+      "description": "معرّف الموظف في الرابط مفقود أو غير صالح.",
+      "backLink": "العودة إلى دليل الموظفين"
+    },
+    "accessDenied": {
+      "title": "تم رفض الوصول",
+      "description": "ليس لديك إذن لعرض هذا الملف الشخصي.",
+      "backLink": "العودة إلى لوحة التحكم"
+    },
+    "loadingProfile": "جارٍ تحميل الملف الشخصي...",
+    "employeeNotFound": "لم يتم العثور على الموظف",
+    "backToDirectory": "العودة إلى الدليل",
+    "noDesignation": "لا يوجد مسمى وظيفي",
+    "biometricPhotoTooltip": "تُدار الصورة عبر تسجيل كشك البصمة",
+    "biometricPhotoAlt": "صورة بصمة الوجه",
+    "profilePhotoAlt": "الملف الشخصي",
+    "biometricPhotoHint": "صورة من تسجيل البصمة — تُدار عبر الكشك.",
+    "removingPhoto": "جارٍ الإزالة...",
+    "removePhoto": "إزالة الصورة",
+    "empCodeLabel": "رمز الموظف: {{code}}",
+    "joinedLabel": "تاريخ الالتحاق: {{date}}",
+    "cancel": "إلغاء",
+    "editMyInfo": "تعديل بياناتي",
+    "editProfile": "تعديل الملف الشخصي",
+    "removePhotoDialog": {
+      "title": "إزالة صورة ملفك الشخصي؟",
+      "description": "ستظهر الأحرف الأولى من اسمك مرة أخرى.",
+      "confirm": "إزالة الصورة"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "يجب أن يتكون رقم PAN من 5 أحرف + 4 أرقام + حرف واحد (مثال: ABCDE1234F)",
+      "aadhaar": "يجب أن يتكون رقم Aadhaar من 12 رقمًا",
+      "uan": "يجب أن يتكون رقم UAN من 12 رقمًا",
+      "passport": "يجب أن يتكون رقم جواز السفر من حرف واحد + 7 أرقام (مثال: A1234567)"
+    },
+    "personal": {
+      "saveFailed": "فشل الحفظ",
+      "selfServiceNotice": "يمكنك تعديل بياناتك الشخصية وبيانات الاتصال في حالات الطوارئ. تواصل مع الموارد البشرية لتحديث الحقول الإدارية."
+    },
+    "field": {
+      "personalEmail": "البريد الإلكتروني الشخصي",
+      "contactNumber": "رقم الاتصال",
+      "gender": "الجنس",
+      "dateOfBirth": "تاريخ الميلاد",
+      "bloodGroup": "فصيلة الدم",
+      "maritalStatus": "الحالة الاجتماعية",
+      "nationality": "الجنسية",
+      "aadharNumber": "رقم Aadhar",
+      "panNumber": "رقم PAN",
+      "uanNumber": "رقم UAN",
+      "passportNumber": "رقم جواز السفر",
+      "passportExpiry": "انتهاء صلاحية جواز السفر",
+      "visaStatus": "حالة التأشيرة",
+      "visaExpiry": "انتهاء صلاحية التأشيرة",
+      "emergencyContact": "جهة الاتصال في حالات الطوارئ",
+      "emergencyPhone": "هاتف الطوارئ",
+      "emergencyRelation": "صلة القرابة لجهة الطوارئ",
+      "noticePeriodDays": "فترة الإشعار (بالأيام)",
+      "reportingManager": "المدير المباشر",
+      "department": "القسم",
+      "shift": "الوردية",
+      "designation": "المسمى الوظيفي",
+      "employeeCode": "رمز الموظف",
+      "probationStart": "بداية فترة التجربة",
+      "probationEnd": "نهاية فترة التجربة",
+      "confirmationDate": "تاريخ التثبيت",
+      "customRoles": "أدوار مخصصة",
+      "additionalManagers": "مديرون إضافيون"
+    },
+    "select": {
+      "placeholder": "اختر"
+    },
+    "gender": {
+      "male": "ذكر",
+      "female": "أنثى",
+      "other": "آخر"
+    },
+    "maritalStatus": {
+      "single": "أعزب",
+      "married": "متزوج",
+      "divorced": "مطلّق",
+      "widowed": "أرمل"
+    },
+    "placeholder": {
+      "aadhar": "12 رقمًا",
+      "pan": "ABCDE1234F",
+      "uan": "12 رقمًا",
+      "passport": "A1234567",
+      "designationSelfService": "تواصل مع الموارد البشرية للتغيير",
+      "designation": "مثال: مهندس أول",
+      "empCodeSelfService": "تواصل مع الموارد البشرية للتعيين",
+      "empCode": "مثال: EMP001"
+    },
+    "reportingManager": {
+      "none": "لا يوجد مدير"
+    },
+    "department": {
+      "none": "لا يوجد قسم"
+    },
+    "shift": {
+      "none": "لا توجد وردية"
+    },
+    "saving": "جارٍ الحفظ...",
+    "saveChanges": "حفظ التغييرات",
+    "additionalManagers": {
+      "loading": "جارٍ التحميل…",
+      "none": "لا يوجد مديرون إضافيون",
+      "userFallback": "المستخدم رقم {{id}}",
+      "selectedCount_one": "(تم تحديد {{count}})",
+      "selectedCount_other": "(تم تحديد {{count}})",
+      "helpText": "مديرون مشاركون يتمتعون بنفس صلاحية الوصول على مستوى الفريق مثل المدير المباشر الأساسي. تُحترم صلاحياتهم في كل إذن على مستوى الفريق.",
+      "removeAria": "إزالة {{name}}",
+      "removeAriaFallback": "مدير",
+      "searchPlaceholder": "ابحث بالاسم أو البريد الإلكتروني…",
+      "addPlaceholder": "إضافة آخر…",
+      "noMatches": "لا يوجد مستخدمون مطابقون",
+      "allSelected": "تم بالفعل تحديد جميع المستخدمين المؤهلين",
+      "savingButton": "جارٍ الحفظ…",
+      "saveButton": "حفظ المديرين الإضافيين",
+      "unsavedChanges": "تغييرات غير محفوظة",
+      "saved": "تم الحفظ"
+    },
+    "apiError": {
+      "requestFailed": "فشل الطلب"
+    },
+    "education": {
+      "add": "إضافة مؤهل تعليمي",
+      "edit": "تعديل المؤهل التعليمي",
+      "empty": "لم تتم إضافة أي سجلات تعليمية بعد.",
+      "deleteDialog": {
+        "title": "حذف هذا السجل التعليمي؟"
+      },
+      "field": {
+        "degree": "الدرجة العلمية",
+        "institution": "المؤسسة التعليمية",
+        "fieldOfStudy": "مجال الدراسة",
+        "grade": "التقدير",
+        "startYear": "سنة البداية",
+        "endYear": "سنة النهاية"
+      },
+      "placeholder": {
+        "degree": "مثال: بكالوريوس هندسة",
+        "institution": "مثال: جامعة الملك سعود"
+      },
+      "validation": {
+        "required": "الدرجة العلمية والمؤسسة التعليمية مطلوبتان",
+        "endYear": "يجب أن تكون سنة النهاية في سنة البداية أو بعدها"
+      },
+      "fromYear": "من {{year}}",
+      "gradeSuffix": "التقدير: {{grade}}"
+    },
+    "save": "حفظ",
+    "edit": "تعديل",
+    "delete": "حذف",
+    "experience": {
+      "add": "إضافة خبرة",
+      "edit": "تعديل الخبرة",
+      "empty": "لم تتم إضافة أي سجلات خبرة عملية بعد.",
+      "deleteDialog": {
+        "title": "حذف سجل الخبرة هذا؟"
+      },
+      "field": {
+        "company": "الشركة",
+        "designation": "المسمى الوظيفي",
+        "startDate": "تاريخ البداية",
+        "endDate": "تاريخ النهاية",
+        "description": "الوصف"
+      },
+      "currentlyWorking": "أعمل هنا حاليًا",
+      "current": "حالي",
+      "present": "حتى الآن",
+      "validation": {
+        "required": "الشركة والمسمى الوظيفي وتاريخ البداية مطلوبة"
+      }
+    },
+    "dependents": {
+      "add": "إضافة مُعال",
+      "edit": "تعديل المُعال",
+      "empty": "لم تتم إضافة أي مُعالين بعد.",
+      "deleteDialog": {
+        "title": "حذف هذا المُعال؟"
+      },
+      "field": {
+        "name": "الاسم",
+        "relationship": "صلة القرابة",
+        "dateOfBirth": "تاريخ الميلاد",
+        "gender": "الجنس",
+        "nomineePercent": "نسبة المستفيد %"
+      },
+      "isNominee": "مستفيد",
+      "placeholder": {
+        "relationship": "مثال: زوج/زوجة، ابن، أحد الوالدين"
+      },
+      "validation": {
+        "required": "الاسم وصلة القرابة مطلوبان"
+      },
+      "column": {
+        "name": "الاسم",
+        "relationship": "صلة القرابة",
+        "dob": "تاريخ الميلاد",
+        "gender": "الجنس",
+        "nominee": "المستفيد",
+        "actions": "الإجراءات"
+      },
+      "nomineeYes": "نعم",
+      "nomineeNo": "لا"
+    },
+    "addresses": {
+      "add": "إضافة عنوان",
+      "edit": "تعديل العنوان",
+      "empty": "لم تتم إضافة أي عناوين بعد.",
+      "deleteDialog": {
+        "title": "حذف هذا العنوان؟"
+      },
+      "field": {
+        "type": "النوع",
+        "country": "الدولة",
+        "line1": "العنوان السطر 1",
+        "line2": "العنوان السطر 2",
+        "city": "المدينة",
+        "state": "المحافظة",
+        "zipcode": "الرمز البريدي"
+      },
+      "type": {
+        "current": "الحالي",
+        "permanent": "الدائم"
+      },
+      "validation": {
+        "required": "العنوان السطر 1 والمدينة والمحافظة والرمز البريدي مطلوبة"
+      }
+    },
+    "customFields": {
+      "loading": "جارٍ تحميل الحقول المخصصة...",
+      "emptyTitle": "لم يتم تعريف أي حقول مخصصة للموظفين بعد.",
+      "emptyHint": "يمكن لمسؤولي الموارد البشرية إنشاء حقول مخصصة من صفحة إعدادات الحقول المخصصة.",
+      "heading": "حقول مخصصة",
+      "saveFailed": "فشل حفظ الحقول المخصصة",
+      "defaultSection": "حقول مخصصة",
+      "display": {
+        "yes": "نعم",
+        "no": "لا"
+      },
+      "selectPlaceholder": "اختر...",
+      "filePlaceholder": "مرجع الملف أو المسار"
+    }
   }
 }

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -2538,5 +2538,264 @@
       "damaged": "Beschädigt",
       "updated": "Aktualisiert"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "Persönlich",
+      "education": "Ausbildung",
+      "experience": "Berufserfahrung",
+      "dependents": "Angehörige",
+      "addresses": "Adressen",
+      "custom": "Benutzerdefinierte Felder"
+    },
+    "invalidEmployee": {
+      "title": "Ungültiger Mitarbeiter",
+      "description": "Die Mitarbeiter-ID in der URL fehlt oder ist ungültig.",
+      "backLink": "Zurück zum Mitarbeiterverzeichnis"
+    },
+    "accessDenied": {
+      "title": "Zugriff verweigert",
+      "description": "Sie haben keine Berechtigung, dieses Profil anzuzeigen.",
+      "backLink": "Zurück zum Dashboard"
+    },
+    "loadingProfile": "Profil wird geladen...",
+    "employeeNotFound": "Mitarbeiter nicht gefunden",
+    "backToDirectory": "Zurück zum Verzeichnis",
+    "noDesignation": "Keine Bezeichnung",
+    "biometricPhotoTooltip": "Das Foto wird über die biometrische Kiosk-Erfassung verwaltet",
+    "biometricPhotoAlt": "Biometrisches Gesicht",
+    "profilePhotoAlt": "Profil",
+    "biometricPhotoHint": "Foto aus der biometrischen Erfassung – wird über den Kiosk verwaltet.",
+    "removingPhoto": "Wird entfernt...",
+    "removePhoto": "Foto entfernen",
+    "empCodeLabel": "Mitarbeiter-Nr.: {{code}}",
+    "joinedLabel": "Eingetreten am: {{date}}",
+    "cancel": "Abbrechen",
+    "editMyInfo": "Meine Daten bearbeiten",
+    "editProfile": "Profil bearbeiten",
+    "removePhotoDialog": {
+      "title": "Ihr Profilfoto entfernen?",
+      "description": "Es werden wieder Ihre Initialen angezeigt.",
+      "confirm": "Foto entfernen"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "PAN muss aus 5 Buchstaben + 4 Ziffern + 1 Buchstaben bestehen (z. B. ABCDE1234F)",
+      "aadhaar": "Aadhaar muss aus 12 Ziffern bestehen",
+      "uan": "UAN muss aus 12 Ziffern bestehen",
+      "passport": "Reisepass muss aus 1 Buchstaben + 7 Ziffern bestehen (z. B. A1234567)"
+    },
+    "personal": {
+      "saveFailed": "Speichern fehlgeschlagen",
+      "selfServiceNotice": "Sie können Ihre persönlichen Daten und Notfallkontakte bearbeiten. Wenden Sie sich an die Personalabteilung, um administrative Felder zu aktualisieren."
+    },
+    "field": {
+      "personalEmail": "Private E-Mail",
+      "contactNumber": "Telefonnummer",
+      "gender": "Geschlecht",
+      "dateOfBirth": "Geburtsdatum",
+      "bloodGroup": "Blutgruppe",
+      "maritalStatus": "Familienstand",
+      "nationality": "Staatsangehörigkeit",
+      "aadharNumber": "Aadhaar-Nummer",
+      "panNumber": "PAN-Nummer",
+      "uanNumber": "UAN-Nummer",
+      "passportNumber": "Reisepassnummer",
+      "passportExpiry": "Ablaufdatum des Reisepasses",
+      "visaStatus": "Visumstatus",
+      "visaExpiry": "Ablaufdatum des Visums",
+      "emergencyContact": "Notfallkontakt",
+      "emergencyPhone": "Notfalltelefon",
+      "emergencyRelation": "Beziehung zum Notfallkontakt",
+      "noticePeriodDays": "Kündigungsfrist (Tage)",
+      "reportingManager": "Vorgesetzter",
+      "department": "Abteilung",
+      "shift": "Schicht",
+      "designation": "Bezeichnung",
+      "employeeCode": "Mitarbeiternummer",
+      "probationStart": "Beginn der Probezeit",
+      "probationEnd": "Ende der Probezeit",
+      "confirmationDate": "Übernahmedatum",
+      "customRoles": "Benutzerdefinierte Rollen",
+      "additionalManagers": "Zusätzliche Vorgesetzte"
+    },
+    "select": {
+      "placeholder": "Auswählen"
+    },
+    "gender": {
+      "male": "Männlich",
+      "female": "Weiblich",
+      "other": "Divers"
+    },
+    "maritalStatus": {
+      "single": "Ledig",
+      "married": "Verheiratet",
+      "divorced": "Geschieden",
+      "widowed": "Verwitwet"
+    },
+    "placeholder": {
+      "aadhar": "12 Ziffern",
+      "pan": "ABCDE1234F",
+      "uan": "12 Ziffern",
+      "passport": "A1234567",
+      "designationSelfService": "Zum Ändern an die Personalabteilung wenden",
+      "designation": "z. B. Senior Engineer",
+      "empCodeSelfService": "Zum Festlegen an die Personalabteilung wenden",
+      "empCode": "z. B. EMP001"
+    },
+    "reportingManager": {
+      "none": "Kein Vorgesetzter"
+    },
+    "department": {
+      "none": "Keine Abteilung"
+    },
+    "shift": {
+      "none": "Keine Schicht"
+    },
+    "saving": "Wird gespeichert...",
+    "saveChanges": "Änderungen speichern",
+    "additionalManagers": {
+      "loading": "Wird geladen…",
+      "none": "Keine zusätzlichen Vorgesetzten",
+      "userFallback": "Benutzer #{{id}}",
+      "selectedCount_one": "({{count}} ausgewählt)",
+      "selectedCount_other": "({{count}} ausgewählt)",
+      "helpText": "Mitverantwortliche mit demselben teambezogenen Zugriff wie der primäre Vorgesetzte. Wird von jeder teambezogenen Berechtigung berücksichtigt.",
+      "removeAria": "{{name}} entfernen",
+      "removeAriaFallback": "Vorgesetzten",
+      "searchPlaceholder": "Nach Name oder E-Mail suchen…",
+      "addPlaceholder": "Weitere hinzufügen…",
+      "noMatches": "Keine passenden Benutzer",
+      "allSelected": "Alle berechtigten Benutzer bereits ausgewählt",
+      "savingButton": "Wird gespeichert…",
+      "saveButton": "Zusätzliche Vorgesetzte speichern",
+      "unsavedChanges": "nicht gespeicherte Änderungen",
+      "saved": "Gespeichert"
+    },
+    "apiError": {
+      "requestFailed": "Anfrage fehlgeschlagen"
+    },
+    "education": {
+      "add": "Ausbildung hinzufügen",
+      "edit": "Ausbildung bearbeiten",
+      "empty": "Noch keine Ausbildungseinträge hinzugefügt.",
+      "deleteDialog": {
+        "title": "Diesen Ausbildungseintrag löschen?"
+      },
+      "field": {
+        "degree": "Abschluss",
+        "institution": "Bildungseinrichtung",
+        "fieldOfStudy": "Studienfach",
+        "grade": "Note",
+        "startYear": "Anfangsjahr",
+        "endYear": "Abschlussjahr"
+      },
+      "placeholder": {
+        "degree": "z. B. B.Tech",
+        "institution": "z. B. IIT Delhi"
+      },
+      "validation": {
+        "required": "Abschluss und Bildungseinrichtung sind erforderlich",
+        "endYear": "Das Abschlussjahr muss im oder nach dem Anfangsjahr liegen"
+      },
+      "fromYear": "Seit {{year}}",
+      "gradeSuffix": "Note: {{grade}}"
+    },
+    "save": "Speichern",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "experience": {
+      "add": "Berufserfahrung hinzufügen",
+      "edit": "Berufserfahrung bearbeiten",
+      "empty": "Noch keine Einträge zur Berufserfahrung hinzugefügt.",
+      "deleteDialog": {
+        "title": "Diesen Berufserfahrungseintrag löschen?"
+      },
+      "field": {
+        "company": "Unternehmen",
+        "designation": "Bezeichnung",
+        "startDate": "Startdatum",
+        "endDate": "Enddatum",
+        "description": "Beschreibung"
+      },
+      "currentlyWorking": "Derzeit hier tätig",
+      "current": "Aktuell",
+      "present": "Heute",
+      "validation": {
+        "required": "Unternehmen, Bezeichnung und Startdatum sind erforderlich"
+      }
+    },
+    "dependents": {
+      "add": "Angehörigen hinzufügen",
+      "edit": "Angehörigen bearbeiten",
+      "empty": "Noch keine Angehörigen hinzugefügt.",
+      "deleteDialog": {
+        "title": "Diesen Angehörigen löschen?"
+      },
+      "field": {
+        "name": "Name",
+        "relationship": "Beziehung",
+        "dateOfBirth": "Geburtsdatum",
+        "gender": "Geschlecht",
+        "nomineePercent": "Begünstigung %"
+      },
+      "isNominee": "Ist Begünstigter",
+      "placeholder": {
+        "relationship": "z. B. Ehepartner, Kind, Elternteil"
+      },
+      "validation": {
+        "required": "Name und Beziehung sind erforderlich"
+      },
+      "column": {
+        "name": "Name",
+        "relationship": "Beziehung",
+        "dob": "Geb.-Datum",
+        "gender": "Geschlecht",
+        "nominee": "Begünstigter",
+        "actions": "Aktionen"
+      },
+      "nomineeYes": "Ja",
+      "nomineeNo": "Nein"
+    },
+    "addresses": {
+      "add": "Adresse hinzufügen",
+      "edit": "Adresse bearbeiten",
+      "empty": "Noch keine Adressen hinzugefügt.",
+      "deleteDialog": {
+        "title": "Diese Adresse löschen?"
+      },
+      "field": {
+        "type": "Typ",
+        "country": "Land",
+        "line1": "Adresszeile 1",
+        "line2": "Adresszeile 2",
+        "city": "Stadt",
+        "state": "Bundesland",
+        "zipcode": "Postleitzahl"
+      },
+      "type": {
+        "current": "Aktuell",
+        "permanent": "Dauerhaft"
+      },
+      "validation": {
+        "required": "Adresszeile 1, Stadt, Bundesland und Postleitzahl sind erforderlich"
+      }
+    },
+    "customFields": {
+      "loading": "Benutzerdefinierte Felder werden geladen...",
+      "emptyTitle": "Es wurden noch keine benutzerdefinierten Felder für Mitarbeiter definiert.",
+      "emptyHint": "HR-Administratoren können benutzerdefinierte Felder auf der Einstellungsseite für benutzerdefinierte Felder erstellen.",
+      "heading": "Benutzerdefinierte Felder",
+      "saveFailed": "Speichern der benutzerdefinierten Felder fehlgeschlagen",
+      "defaultSection": "Benutzerdefinierte Felder",
+      "display": {
+        "yes": "Ja",
+        "no": "Nein"
+      },
+      "selectPlaceholder": "Auswählen...",
+      "filePlaceholder": "Dateireferenz oder Pfad"
+    }
   }
 }

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -2544,5 +2544,264 @@
       "damaged": "Damaged",
       "updated": "Updated"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "Personal",
+      "education": "Education",
+      "experience": "Experience",
+      "dependents": "Dependents",
+      "addresses": "Addresses",
+      "custom": "Custom Fields"
+    },
+    "invalidEmployee": {
+      "title": "Invalid Employee",
+      "description": "The employee ID in the URL is missing or invalid.",
+      "backLink": "Back to Employee Directory"
+    },
+    "accessDenied": {
+      "title": "Access denied",
+      "description": "You don't have permission to view this profile.",
+      "backLink": "Back to Dashboard"
+    },
+    "loadingProfile": "Loading profile...",
+    "employeeNotFound": "Employee not found",
+    "backToDirectory": "Back to Directory",
+    "noDesignation": "No designation",
+    "biometricPhotoTooltip": "Photo is managed via biometric kiosk enrollment",
+    "biometricPhotoAlt": "Biometric face",
+    "profilePhotoAlt": "Profile",
+    "biometricPhotoHint": "Photo from biometric enrollment — managed via the kiosk.",
+    "removingPhoto": "Removing...",
+    "removePhoto": "Remove photo",
+    "empCodeLabel": "Emp Code: {{code}}",
+    "joinedLabel": "Joined: {{date}}",
+    "cancel": "Cancel",
+    "editMyInfo": "Edit My Info",
+    "editProfile": "Edit Profile",
+    "removePhotoDialog": {
+      "title": "Remove your profile photo?",
+      "description": "You'll show initials again.",
+      "confirm": "Remove photo"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "PAN must be 5 letters + 4 digits + 1 letter (e.g. ABCDE1234F)",
+      "aadhaar": "Aadhaar must be 12 digits",
+      "uan": "UAN must be 12 digits",
+      "passport": "Passport must be 1 letter + 7 digits (e.g. A1234567)"
+    },
+    "personal": {
+      "saveFailed": "Failed to save",
+      "selfServiceNotice": "You can edit your personal and emergency contact information. Contact HR to update administrative fields."
+    },
+    "field": {
+      "personalEmail": "Personal Email",
+      "contactNumber": "Contact Number",
+      "gender": "Gender",
+      "dateOfBirth": "Date of Birth",
+      "bloodGroup": "Blood Group",
+      "maritalStatus": "Marital Status",
+      "nationality": "Nationality",
+      "aadharNumber": "Aadhar Number",
+      "panNumber": "PAN Number",
+      "uanNumber": "UAN Number",
+      "passportNumber": "Passport Number",
+      "passportExpiry": "Passport Expiry",
+      "visaStatus": "Visa Status",
+      "visaExpiry": "Visa Expiry",
+      "emergencyContact": "Emergency Contact",
+      "emergencyPhone": "Emergency Phone",
+      "emergencyRelation": "Emergency Relation",
+      "noticePeriodDays": "Notice Period (days)",
+      "reportingManager": "Reporting Manager",
+      "department": "Department",
+      "shift": "Shift",
+      "designation": "Designation",
+      "employeeCode": "Employee Code",
+      "probationStart": "Probation Start",
+      "probationEnd": "Probation End",
+      "confirmationDate": "Confirmation Date",
+      "customRoles": "Custom Roles",
+      "additionalManagers": "Additional Managers"
+    },
+    "select": {
+      "placeholder": "Select"
+    },
+    "gender": {
+      "male": "Male",
+      "female": "Female",
+      "other": "Other"
+    },
+    "maritalStatus": {
+      "single": "Single",
+      "married": "Married",
+      "divorced": "Divorced",
+      "widowed": "Widowed"
+    },
+    "placeholder": {
+      "aadhar": "12 digits",
+      "pan": "ABCDE1234F",
+      "uan": "12 digits",
+      "passport": "A1234567",
+      "designationSelfService": "Contact HR to change",
+      "designation": "e.g. Senior Engineer",
+      "empCodeSelfService": "Contact HR to set",
+      "empCode": "e.g. EMP001"
+    },
+    "reportingManager": {
+      "none": "No Manager"
+    },
+    "department": {
+      "none": "No department"
+    },
+    "shift": {
+      "none": "No shift"
+    },
+    "saving": "Saving...",
+    "saveChanges": "Save Changes",
+    "additionalManagers": {
+      "loading": "Loading…",
+      "none": "No additional managers",
+      "userFallback": "User #{{id}}",
+      "selectedCount_one": "({{count}} selected)",
+      "selectedCount_other": "({{count}} selected)",
+      "helpText": "Co-managers with the same team-scope access as the primary Reporting Manager. Honoured by every team-scoped permission.",
+      "removeAria": "Remove {{name}}",
+      "removeAriaFallback": "manager",
+      "searchPlaceholder": "Search by name or email…",
+      "addPlaceholder": "Add another…",
+      "noMatches": "No matching users",
+      "allSelected": "All eligible users already selected",
+      "savingButton": "Saving…",
+      "saveButton": "Save additional managers",
+      "unsavedChanges": "unsaved changes",
+      "saved": "Saved"
+    },
+    "apiError": {
+      "requestFailed": "Request failed"
+    },
+    "education": {
+      "add": "Add Education",
+      "edit": "Edit Education",
+      "empty": "No education records added yet.",
+      "deleteDialog": {
+        "title": "Delete this education record?"
+      },
+      "field": {
+        "degree": "Degree",
+        "institution": "Institution",
+        "fieldOfStudy": "Field of Study",
+        "grade": "Grade",
+        "startYear": "Start Year",
+        "endYear": "End Year"
+      },
+      "placeholder": {
+        "degree": "e.g. B.Tech",
+        "institution": "e.g. IIT Delhi"
+      },
+      "validation": {
+        "required": "Degree and Institution are required",
+        "endYear": "End year must be on or after start year"
+      },
+      "fromYear": "From {{year}}",
+      "gradeSuffix": "Grade: {{grade}}"
+    },
+    "save": "Save",
+    "edit": "Edit",
+    "delete": "Delete",
+    "experience": {
+      "add": "Add Experience",
+      "edit": "Edit Experience",
+      "empty": "No work experience records added yet.",
+      "deleteDialog": {
+        "title": "Delete this experience record?"
+      },
+      "field": {
+        "company": "Company",
+        "designation": "Designation",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "description": "Description"
+      },
+      "currentlyWorking": "Currently working here",
+      "current": "Current",
+      "present": "Present",
+      "validation": {
+        "required": "Company, Designation and Start Date are required"
+      }
+    },
+    "dependents": {
+      "add": "Add Dependent",
+      "edit": "Edit Dependent",
+      "empty": "No dependents added yet.",
+      "deleteDialog": {
+        "title": "Delete this dependent?"
+      },
+      "field": {
+        "name": "Name",
+        "relationship": "Relationship",
+        "dateOfBirth": "Date of Birth",
+        "gender": "Gender",
+        "nomineePercent": "Nominee %"
+      },
+      "isNominee": "Is Nominee",
+      "placeholder": {
+        "relationship": "e.g. Spouse, Child, Parent"
+      },
+      "validation": {
+        "required": "Name and Relationship are required"
+      },
+      "column": {
+        "name": "Name",
+        "relationship": "Relationship",
+        "dob": "DOB",
+        "gender": "Gender",
+        "nominee": "Nominee",
+        "actions": "Actions"
+      },
+      "nomineeYes": "Yes",
+      "nomineeNo": "No"
+    },
+    "addresses": {
+      "add": "Add Address",
+      "edit": "Edit Address",
+      "empty": "No addresses added yet.",
+      "deleteDialog": {
+        "title": "Delete this address?"
+      },
+      "field": {
+        "type": "Type",
+        "country": "Country",
+        "line1": "Address Line 1",
+        "line2": "Address Line 2",
+        "city": "City",
+        "state": "State",
+        "zipcode": "Zipcode"
+      },
+      "type": {
+        "current": "Current",
+        "permanent": "Permanent"
+      },
+      "validation": {
+        "required": "Address line 1, City, State and Zipcode are required"
+      }
+    },
+    "customFields": {
+      "loading": "Loading custom fields...",
+      "emptyTitle": "No custom fields have been defined for employees yet.",
+      "emptyHint": "HR administrators can create custom fields from the Custom Fields settings page.",
+      "heading": "Custom Fields",
+      "saveFailed": "Failed to save custom fields",
+      "defaultSection": "Custom Fields",
+      "display": {
+        "yes": "Yes",
+        "no": "No"
+      },
+      "selectPlaceholder": "Select...",
+      "filePlaceholder": "File reference or path"
+    }
   }
 }

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -2538,5 +2538,264 @@
       "damaged": "Dañado",
       "updated": "Actualizado"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "Personal",
+      "education": "Formación",
+      "experience": "Experiencia",
+      "dependents": "Dependientes",
+      "addresses": "Direcciones",
+      "custom": "Campos personalizados"
+    },
+    "invalidEmployee": {
+      "title": "Empleado no válido",
+      "description": "El ID de empleado de la URL falta o no es válido.",
+      "backLink": "Volver al directorio de empleados"
+    },
+    "accessDenied": {
+      "title": "Acceso denegado",
+      "description": "No tienes permiso para ver este perfil.",
+      "backLink": "Volver al panel"
+    },
+    "loadingProfile": "Cargando perfil...",
+    "employeeNotFound": "Empleado no encontrado",
+    "backToDirectory": "Volver al directorio",
+    "noDesignation": "Sin puesto",
+    "biometricPhotoTooltip": "La foto se gestiona mediante el registro en el quiosco biométrico",
+    "biometricPhotoAlt": "Rostro biométrico",
+    "profilePhotoAlt": "Perfil",
+    "biometricPhotoHint": "Foto del registro biométrico: se gestiona desde el quiosco.",
+    "removingPhoto": "Eliminando...",
+    "removePhoto": "Eliminar foto",
+    "empCodeLabel": "Código de empleado: {{code}}",
+    "joinedLabel": "Incorporación: {{date}}",
+    "cancel": "Cancelar",
+    "editMyInfo": "Editar mi información",
+    "editProfile": "Editar perfil",
+    "removePhotoDialog": {
+      "title": "¿Eliminar tu foto de perfil?",
+      "description": "Se mostrarán de nuevo tus iniciales.",
+      "confirm": "Eliminar foto"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "El PAN debe tener 5 letras + 4 dígitos + 1 letra (p. ej. ABCDE1234F)",
+      "aadhaar": "El Aadhaar debe tener 12 dígitos",
+      "uan": "El UAN debe tener 12 dígitos",
+      "passport": "El pasaporte debe tener 1 letra + 7 dígitos (p. ej. A1234567)"
+    },
+    "personal": {
+      "saveFailed": "No se pudo guardar",
+      "selfServiceNotice": "Puedes editar tu información personal y de contacto de emergencia. Contacta con RR. HH. para actualizar los campos administrativos."
+    },
+    "field": {
+      "personalEmail": "Correo personal",
+      "contactNumber": "Número de contacto",
+      "gender": "Género",
+      "dateOfBirth": "Fecha de nacimiento",
+      "bloodGroup": "Grupo sanguíneo",
+      "maritalStatus": "Estado civil",
+      "nationality": "Nacionalidad",
+      "aadharNumber": "Número de Aadhar",
+      "panNumber": "Número de PAN",
+      "uanNumber": "Número de UAN",
+      "passportNumber": "Número de pasaporte",
+      "passportExpiry": "Vencimiento del pasaporte",
+      "visaStatus": "Estado del visado",
+      "visaExpiry": "Vencimiento del visado",
+      "emergencyContact": "Contacto de emergencia",
+      "emergencyPhone": "Teléfono de emergencia",
+      "emergencyRelation": "Parentesco de emergencia",
+      "noticePeriodDays": "Periodo de preaviso (días)",
+      "reportingManager": "Responsable directo",
+      "department": "Departamento",
+      "shift": "Turno",
+      "designation": "Puesto",
+      "employeeCode": "Código de empleado",
+      "probationStart": "Inicio del periodo de prueba",
+      "probationEnd": "Fin del periodo de prueba",
+      "confirmationDate": "Fecha de confirmación",
+      "customRoles": "Roles personalizados",
+      "additionalManagers": "Responsables adicionales"
+    },
+    "select": {
+      "placeholder": "Seleccionar"
+    },
+    "gender": {
+      "male": "Masculino",
+      "female": "Femenino",
+      "other": "Otro"
+    },
+    "maritalStatus": {
+      "single": "Soltero/a",
+      "married": "Casado/a",
+      "divorced": "Divorciado/a",
+      "widowed": "Viudo/a"
+    },
+    "placeholder": {
+      "aadhar": "12 dígitos",
+      "pan": "ABCDE1234F",
+      "uan": "12 dígitos",
+      "passport": "A1234567",
+      "designationSelfService": "Contacta con RR. HH. para cambiarlo",
+      "designation": "p. ej. Ingeniero sénior",
+      "empCodeSelfService": "Contacta con RR. HH. para establecerlo",
+      "empCode": "p. ej. EMP001"
+    },
+    "reportingManager": {
+      "none": "Sin responsable"
+    },
+    "department": {
+      "none": "Sin departamento"
+    },
+    "shift": {
+      "none": "Sin turno"
+    },
+    "saving": "Guardando...",
+    "saveChanges": "Guardar cambios",
+    "additionalManagers": {
+      "loading": "Cargando…",
+      "none": "Sin responsables adicionales",
+      "userFallback": "Usuario n.º {{id}}",
+      "selectedCount_one": "({{count}} seleccionado)",
+      "selectedCount_other": "({{count}} seleccionados)",
+      "helpText": "Corresponsables con el mismo acceso al ámbito de equipo que el responsable directo principal. Se respetan en todos los permisos de ámbito de equipo.",
+      "removeAria": "Eliminar a {{name}}",
+      "removeAriaFallback": "responsable",
+      "searchPlaceholder": "Buscar por nombre o correo…",
+      "addPlaceholder": "Añadir otro…",
+      "noMatches": "No hay usuarios coincidentes",
+      "allSelected": "Ya se han seleccionado todos los usuarios elegibles",
+      "savingButton": "Guardando…",
+      "saveButton": "Guardar responsables adicionales",
+      "unsavedChanges": "cambios sin guardar",
+      "saved": "Guardado"
+    },
+    "apiError": {
+      "requestFailed": "La solicitud falló"
+    },
+    "education": {
+      "add": "Añadir formación",
+      "edit": "Editar formación",
+      "empty": "Aún no se han añadido registros de formación.",
+      "deleteDialog": {
+        "title": "¿Eliminar este registro de formación?"
+      },
+      "field": {
+        "degree": "Título",
+        "institution": "Institución",
+        "fieldOfStudy": "Campo de estudio",
+        "grade": "Calificación",
+        "startYear": "Año de inicio",
+        "endYear": "Año de finalización"
+      },
+      "placeholder": {
+        "degree": "p. ej. Grado en Ingeniería",
+        "institution": "p. ej. IIT Delhi"
+      },
+      "validation": {
+        "required": "El título y la institución son obligatorios",
+        "endYear": "El año de finalización debe ser igual o posterior al año de inicio"
+      },
+      "fromYear": "Desde {{year}}",
+      "gradeSuffix": "Calificación: {{grade}}"
+    },
+    "save": "Guardar",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "experience": {
+      "add": "Añadir experiencia",
+      "edit": "Editar experiencia",
+      "empty": "Aún no se han añadido registros de experiencia laboral.",
+      "deleteDialog": {
+        "title": "¿Eliminar este registro de experiencia?"
+      },
+      "field": {
+        "company": "Empresa",
+        "designation": "Puesto",
+        "startDate": "Fecha de inicio",
+        "endDate": "Fecha de finalización",
+        "description": "Descripción"
+      },
+      "currentlyWorking": "Trabajo aquí actualmente",
+      "current": "Actual",
+      "present": "Actualidad",
+      "validation": {
+        "required": "La empresa, el puesto y la fecha de inicio son obligatorios"
+      }
+    },
+    "dependents": {
+      "add": "Añadir dependiente",
+      "edit": "Editar dependiente",
+      "empty": "Aún no se han añadido dependientes.",
+      "deleteDialog": {
+        "title": "¿Eliminar este dependiente?"
+      },
+      "field": {
+        "name": "Nombre",
+        "relationship": "Parentesco",
+        "dateOfBirth": "Fecha de nacimiento",
+        "gender": "Género",
+        "nomineePercent": "% de beneficiario"
+      },
+      "isNominee": "Es beneficiario",
+      "placeholder": {
+        "relationship": "p. ej. Cónyuge, Hijo/a, Padre/Madre"
+      },
+      "validation": {
+        "required": "El nombre y el parentesco son obligatorios"
+      },
+      "column": {
+        "name": "Nombre",
+        "relationship": "Parentesco",
+        "dob": "F. nac.",
+        "gender": "Género",
+        "nominee": "Beneficiario",
+        "actions": "Acciones"
+      },
+      "nomineeYes": "Sí",
+      "nomineeNo": "No"
+    },
+    "addresses": {
+      "add": "Añadir dirección",
+      "edit": "Editar dirección",
+      "empty": "Aún no se han añadido direcciones.",
+      "deleteDialog": {
+        "title": "¿Eliminar esta dirección?"
+      },
+      "field": {
+        "type": "Tipo",
+        "country": "País",
+        "line1": "Línea de dirección 1",
+        "line2": "Línea de dirección 2",
+        "city": "Ciudad",
+        "state": "Provincia",
+        "zipcode": "Código postal"
+      },
+      "type": {
+        "current": "Actual",
+        "permanent": "Permanente"
+      },
+      "validation": {
+        "required": "La línea de dirección 1, la ciudad, la provincia y el código postal son obligatorios"
+      }
+    },
+    "customFields": {
+      "loading": "Cargando campos personalizados...",
+      "emptyTitle": "Aún no se han definido campos personalizados para los empleados.",
+      "emptyHint": "Los administradores de RR. HH. pueden crear campos personalizados desde la página de configuración de campos personalizados.",
+      "heading": "Campos personalizados",
+      "saveFailed": "No se pudieron guardar los campos personalizados",
+      "defaultSection": "Campos personalizados",
+      "display": {
+        "yes": "Sí",
+        "no": "No"
+      },
+      "selectPlaceholder": "Seleccionar...",
+      "filePlaceholder": "Referencia o ruta del archivo"
+    }
   }
 }

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -2538,5 +2538,264 @@
       "damaged": "Endommagé",
       "updated": "Mis à jour"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "Personnel",
+      "education": "Formation",
+      "experience": "Expérience",
+      "dependents": "Personnes à charge",
+      "addresses": "Adresses",
+      "custom": "Champs personnalisés"
+    },
+    "invalidEmployee": {
+      "title": "Employé invalide",
+      "description": "L'identifiant de l'employé dans l'URL est manquant ou invalide.",
+      "backLink": "Retour à l'annuaire des employés"
+    },
+    "accessDenied": {
+      "title": "Accès refusé",
+      "description": "Vous n'avez pas l'autorisation de consulter ce profil.",
+      "backLink": "Retour au tableau de bord"
+    },
+    "loadingProfile": "Chargement du profil...",
+    "employeeNotFound": "Employé introuvable",
+    "backToDirectory": "Retour à l'annuaire",
+    "noDesignation": "Aucune fonction",
+    "biometricPhotoTooltip": "La photo est gérée via l'inscription à la borne biométrique",
+    "biometricPhotoAlt": "Visage biométrique",
+    "profilePhotoAlt": "Profil",
+    "biometricPhotoHint": "Photo issue de l'inscription biométrique — gérée via la borne.",
+    "removingPhoto": "Suppression...",
+    "removePhoto": "Supprimer la photo",
+    "empCodeLabel": "Code employé : {{code}}",
+    "joinedLabel": "Date d'entrée : {{date}}",
+    "cancel": "Annuler",
+    "editMyInfo": "Modifier mes informations",
+    "editProfile": "Modifier le profil",
+    "removePhotoDialog": {
+      "title": "Supprimer votre photo de profil ?",
+      "description": "Vos initiales seront de nouveau affichées.",
+      "confirm": "Supprimer la photo"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "Le PAN doit comporter 5 lettres + 4 chiffres + 1 lettre (ex. ABCDE1234F)",
+      "aadhaar": "L'Aadhaar doit comporter 12 chiffres",
+      "uan": "L'UAN doit comporter 12 chiffres",
+      "passport": "Le passeport doit comporter 1 lettre + 7 chiffres (ex. A1234567)"
+    },
+    "personal": {
+      "saveFailed": "Échec de l'enregistrement",
+      "selfServiceNotice": "Vous pouvez modifier vos informations personnelles et votre contact d'urgence. Contactez les RH pour mettre à jour les champs administratifs."
+    },
+    "field": {
+      "personalEmail": "E-mail personnel",
+      "contactNumber": "Numéro de téléphone",
+      "gender": "Genre",
+      "dateOfBirth": "Date de naissance",
+      "bloodGroup": "Groupe sanguin",
+      "maritalStatus": "Situation de famille",
+      "nationality": "Nationalité",
+      "aadharNumber": "Numéro Aadhaar",
+      "panNumber": "Numéro PAN",
+      "uanNumber": "Numéro UAN",
+      "passportNumber": "Numéro de passeport",
+      "passportExpiry": "Expiration du passeport",
+      "visaStatus": "Statut du visa",
+      "visaExpiry": "Expiration du visa",
+      "emergencyContact": "Contact d'urgence",
+      "emergencyPhone": "Téléphone d'urgence",
+      "emergencyRelation": "Lien de parenté (urgence)",
+      "noticePeriodDays": "Préavis (jours)",
+      "reportingManager": "Responsable hiérarchique",
+      "department": "Service",
+      "shift": "Équipe",
+      "designation": "Fonction",
+      "employeeCode": "Code employé",
+      "probationStart": "Début de la période d'essai",
+      "probationEnd": "Fin de la période d'essai",
+      "confirmationDate": "Date de confirmation",
+      "customRoles": "Rôles personnalisés",
+      "additionalManagers": "Responsables supplémentaires"
+    },
+    "select": {
+      "placeholder": "Sélectionner"
+    },
+    "gender": {
+      "male": "Homme",
+      "female": "Femme",
+      "other": "Autre"
+    },
+    "maritalStatus": {
+      "single": "Célibataire",
+      "married": "Marié(e)",
+      "divorced": "Divorcé(e)",
+      "widowed": "Veuf(ve)"
+    },
+    "placeholder": {
+      "aadhar": "12 chiffres",
+      "pan": "ABCDE1234F",
+      "uan": "12 chiffres",
+      "passport": "A1234567",
+      "designationSelfService": "Contactez les RH pour modifier",
+      "designation": "ex. Ingénieur senior",
+      "empCodeSelfService": "Contactez les RH pour définir",
+      "empCode": "ex. EMP001"
+    },
+    "reportingManager": {
+      "none": "Aucun responsable"
+    },
+    "department": {
+      "none": "Aucun service"
+    },
+    "shift": {
+      "none": "Aucune équipe"
+    },
+    "saving": "Enregistrement...",
+    "saveChanges": "Enregistrer les modifications",
+    "additionalManagers": {
+      "loading": "Chargement…",
+      "none": "Aucun responsable supplémentaire",
+      "userFallback": "Utilisateur n° {{id}}",
+      "selectedCount_one": "({{count}} sélectionné)",
+      "selectedCount_other": "({{count}} sélectionnés)",
+      "helpText": "Co-responsables disposant du même accès au périmètre d'équipe que le responsable hiérarchique principal. Pris en compte par toutes les autorisations liées au périmètre d'équipe.",
+      "removeAria": "Supprimer {{name}}",
+      "removeAriaFallback": "responsable",
+      "searchPlaceholder": "Rechercher par nom ou e-mail…",
+      "addPlaceholder": "Ajouter un autre…",
+      "noMatches": "Aucun utilisateur correspondant",
+      "allSelected": "Tous les utilisateurs éligibles sont déjà sélectionnés",
+      "savingButton": "Enregistrement…",
+      "saveButton": "Enregistrer les responsables supplémentaires",
+      "unsavedChanges": "modifications non enregistrées",
+      "saved": "Enregistré"
+    },
+    "apiError": {
+      "requestFailed": "Échec de la requête"
+    },
+    "education": {
+      "add": "Ajouter une formation",
+      "edit": "Modifier la formation",
+      "empty": "Aucune formation enregistrée pour le moment.",
+      "deleteDialog": {
+        "title": "Supprimer cette formation ?"
+      },
+      "field": {
+        "degree": "Diplôme",
+        "institution": "Établissement",
+        "fieldOfStudy": "Domaine d'études",
+        "grade": "Mention",
+        "startYear": "Année de début",
+        "endYear": "Année de fin"
+      },
+      "placeholder": {
+        "degree": "ex. Licence",
+        "institution": "ex. Université Paris-Saclay"
+      },
+      "validation": {
+        "required": "Le diplôme et l'établissement sont obligatoires",
+        "endYear": "L'année de fin doit être égale ou postérieure à l'année de début"
+      },
+      "fromYear": "Depuis {{year}}",
+      "gradeSuffix": "Mention : {{grade}}"
+    },
+    "save": "Enregistrer",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "experience": {
+      "add": "Ajouter une expérience",
+      "edit": "Modifier l'expérience",
+      "empty": "Aucune expérience professionnelle enregistrée pour le moment.",
+      "deleteDialog": {
+        "title": "Supprimer cette expérience ?"
+      },
+      "field": {
+        "company": "Entreprise",
+        "designation": "Fonction",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "description": "Description"
+      },
+      "currentlyWorking": "Poste actuel",
+      "current": "Actuel",
+      "present": "Présent",
+      "validation": {
+        "required": "L'entreprise, la fonction et la date de début sont obligatoires"
+      }
+    },
+    "dependents": {
+      "add": "Ajouter une personne à charge",
+      "edit": "Modifier la personne à charge",
+      "empty": "Aucune personne à charge ajoutée pour le moment.",
+      "deleteDialog": {
+        "title": "Supprimer cette personne à charge ?"
+      },
+      "field": {
+        "name": "Nom",
+        "relationship": "Lien de parenté",
+        "dateOfBirth": "Date de naissance",
+        "gender": "Genre",
+        "nomineePercent": "% bénéficiaire"
+      },
+      "isNominee": "Bénéficiaire",
+      "placeholder": {
+        "relationship": "ex. Conjoint, Enfant, Parent"
+      },
+      "validation": {
+        "required": "Le nom et le lien de parenté sont obligatoires"
+      },
+      "column": {
+        "name": "Nom",
+        "relationship": "Lien de parenté",
+        "dob": "Naissance",
+        "gender": "Genre",
+        "nominee": "Bénéficiaire",
+        "actions": "Actions"
+      },
+      "nomineeYes": "Oui",
+      "nomineeNo": "Non"
+    },
+    "addresses": {
+      "add": "Ajouter une adresse",
+      "edit": "Modifier l'adresse",
+      "empty": "Aucune adresse ajoutée pour le moment.",
+      "deleteDialog": {
+        "title": "Supprimer cette adresse ?"
+      },
+      "field": {
+        "type": "Type",
+        "country": "Pays",
+        "line1": "Adresse ligne 1",
+        "line2": "Adresse ligne 2",
+        "city": "Ville",
+        "state": "État/Région",
+        "zipcode": "Code postal"
+      },
+      "type": {
+        "current": "Actuelle",
+        "permanent": "Permanente"
+      },
+      "validation": {
+        "required": "L'adresse ligne 1, la ville, l'État/région et le code postal sont obligatoires"
+      }
+    },
+    "customFields": {
+      "loading": "Chargement des champs personnalisés...",
+      "emptyTitle": "Aucun champ personnalisé n'a encore été défini pour les employés.",
+      "emptyHint": "Les administrateurs RH peuvent créer des champs personnalisés depuis la page des paramètres des champs personnalisés.",
+      "heading": "Champs personnalisés",
+      "saveFailed": "Échec de l'enregistrement des champs personnalisés",
+      "defaultSection": "Champs personnalisés",
+      "display": {
+        "yes": "Oui",
+        "no": "Non"
+      },
+      "selectPlaceholder": "Sélectionner...",
+      "filePlaceholder": "Référence ou chemin du fichier"
+    }
   }
 }

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -2538,5 +2538,264 @@
       "damaged": "क्षतिग्रस्त",
       "updated": "अपडेट किया गया"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "व्यक्तिगत",
+      "education": "शिक्षा",
+      "experience": "अनुभव",
+      "dependents": "आश्रित",
+      "addresses": "पते",
+      "custom": "कस्टम फ़ील्ड"
+    },
+    "invalidEmployee": {
+      "title": "अमान्य कर्मचारी",
+      "description": "URL में कर्मचारी ID अनुपस्थित या अमान्य है।",
+      "backLink": "कर्मचारी निर्देशिका पर वापस जाएँ"
+    },
+    "accessDenied": {
+      "title": "पहुँच अस्वीकृत",
+      "description": "आपके पास यह प्रोफ़ाइल देखने की अनुमति नहीं है।",
+      "backLink": "डैशबोर्ड पर वापस जाएँ"
+    },
+    "loadingProfile": "प्रोफ़ाइल लोड हो रही है...",
+    "employeeNotFound": "कर्मचारी नहीं मिला",
+    "backToDirectory": "निर्देशिका पर वापस जाएँ",
+    "noDesignation": "कोई पदनाम नहीं",
+    "biometricPhotoTooltip": "फ़ोटो बायोमेट्रिक कियोस्क नामांकन के माध्यम से प्रबंधित होती है",
+    "biometricPhotoAlt": "बायोमेट्रिक चेहरा",
+    "profilePhotoAlt": "प्रोफ़ाइल",
+    "biometricPhotoHint": "बायोमेट्रिक नामांकन से फ़ोटो — कियोस्क के माध्यम से प्रबंधित।",
+    "removingPhoto": "हटाई जा रही है...",
+    "removePhoto": "फ़ोटो हटाएँ",
+    "empCodeLabel": "कर्मचारी कोड: {{code}}",
+    "joinedLabel": "ज्वाइन किया: {{date}}",
+    "cancel": "रद्द करें",
+    "editMyInfo": "मेरी जानकारी संपादित करें",
+    "editProfile": "प्रोफ़ाइल संपादित करें",
+    "removePhotoDialog": {
+      "title": "अपनी प्रोफ़ाइल फ़ोटो हटाएँ?",
+      "description": "आपको फिर से आद्याक्षर दिखेंगे।",
+      "confirm": "फ़ोटो हटाएँ"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "PAN में 5 अक्षर + 4 अंक + 1 अक्षर होने चाहिए (उदा. ABCDE1234F)",
+      "aadhaar": "आधार 12 अंकों का होना चाहिए",
+      "uan": "UAN 12 अंकों का होना चाहिए",
+      "passport": "पासपोर्ट में 1 अक्षर + 7 अंक होने चाहिए (उदा. A1234567)"
+    },
+    "personal": {
+      "saveFailed": "सहेजने में विफल",
+      "selfServiceNotice": "आप अपनी व्यक्तिगत और आपातकालीन संपर्क जानकारी संपादित कर सकते हैं। प्रशासनिक फ़ील्ड अपडेट करने के लिए HR से संपर्क करें।"
+    },
+    "field": {
+      "personalEmail": "व्यक्तिगत ईमेल",
+      "contactNumber": "संपर्क नंबर",
+      "gender": "लिंग",
+      "dateOfBirth": "जन्म तिथि",
+      "bloodGroup": "रक्त समूह",
+      "maritalStatus": "वैवाहिक स्थिति",
+      "nationality": "राष्ट्रीयता",
+      "aadharNumber": "आधार नंबर",
+      "panNumber": "PAN नंबर",
+      "uanNumber": "UAN नंबर",
+      "passportNumber": "पासपोर्ट नंबर",
+      "passportExpiry": "पासपोर्ट समाप्ति",
+      "visaStatus": "वीज़ा स्थिति",
+      "visaExpiry": "वीज़ा समाप्ति",
+      "emergencyContact": "आपातकालीन संपर्क",
+      "emergencyPhone": "आपातकालीन फ़ोन",
+      "emergencyRelation": "आपातकालीन संबंध",
+      "noticePeriodDays": "नोटिस अवधि (दिन)",
+      "reportingManager": "रिपोर्टिंग मैनेजर",
+      "department": "विभाग",
+      "shift": "शिफ़्ट",
+      "designation": "पदनाम",
+      "employeeCode": "कर्मचारी कोड",
+      "probationStart": "परिवीक्षा प्रारंभ",
+      "probationEnd": "परिवीक्षा समाप्ति",
+      "confirmationDate": "पुष्टिकरण तिथि",
+      "customRoles": "कस्टम भूमिकाएँ",
+      "additionalManagers": "अतिरिक्त मैनेजर"
+    },
+    "select": {
+      "placeholder": "चुनें"
+    },
+    "gender": {
+      "male": "पुरुष",
+      "female": "महिला",
+      "other": "अन्य"
+    },
+    "maritalStatus": {
+      "single": "अविवाहित",
+      "married": "विवाहित",
+      "divorced": "तलाकशुदा",
+      "widowed": "विधवा/विधुर"
+    },
+    "placeholder": {
+      "aadhar": "12 अंक",
+      "pan": "ABCDE1234F",
+      "uan": "12 अंक",
+      "passport": "A1234567",
+      "designationSelfService": "बदलने के लिए HR से संपर्क करें",
+      "designation": "उदा. वरिष्ठ इंजीनियर",
+      "empCodeSelfService": "सेट करने के लिए HR से संपर्क करें",
+      "empCode": "उदा. EMP001"
+    },
+    "reportingManager": {
+      "none": "कोई मैनेजर नहीं"
+    },
+    "department": {
+      "none": "कोई विभाग नहीं"
+    },
+    "shift": {
+      "none": "कोई शिफ़्ट नहीं"
+    },
+    "saving": "सहेजा जा रहा है...",
+    "saveChanges": "परिवर्तन सहेजें",
+    "additionalManagers": {
+      "loading": "लोड हो रहा है…",
+      "none": "कोई अतिरिक्त मैनेजर नहीं",
+      "userFallback": "उपयोगकर्ता #{{id}}",
+      "selectedCount_one": "({{count}} चयनित)",
+      "selectedCount_other": "({{count}} चयनित)",
+      "helpText": "प्राथमिक रिपोर्टिंग मैनेजर के समान टीम-स्कोप पहुँच वाले सह-मैनेजर। हर टीम-स्कोप अनुमति में मान्य।",
+      "removeAria": "{{name}} को हटाएँ",
+      "removeAriaFallback": "मैनेजर",
+      "searchPlaceholder": "नाम या ईमेल से खोजें…",
+      "addPlaceholder": "एक और जोड़ें…",
+      "noMatches": "कोई मेल खाता उपयोगकर्ता नहीं",
+      "allSelected": "सभी पात्र उपयोगकर्ता पहले से चयनित हैं",
+      "savingButton": "सहेजा जा रहा है…",
+      "saveButton": "अतिरिक्त मैनेजर सहेजें",
+      "unsavedChanges": "असहेजे परिवर्तन",
+      "saved": "सहेजा गया"
+    },
+    "apiError": {
+      "requestFailed": "अनुरोध विफल"
+    },
+    "education": {
+      "add": "शिक्षा जोड़ें",
+      "edit": "शिक्षा संपादित करें",
+      "empty": "अभी तक कोई शिक्षा रिकॉर्ड नहीं जोड़ा गया।",
+      "deleteDialog": {
+        "title": "यह शिक्षा रिकॉर्ड हटाएँ?"
+      },
+      "field": {
+        "degree": "डिग्री",
+        "institution": "संस्थान",
+        "fieldOfStudy": "अध्ययन क्षेत्र",
+        "grade": "ग्रेड",
+        "startYear": "प्रारंभ वर्ष",
+        "endYear": "समाप्ति वर्ष"
+      },
+      "placeholder": {
+        "degree": "उदा. बी.टेक",
+        "institution": "उदा. IIT दिल्ली"
+      },
+      "validation": {
+        "required": "डिग्री और संस्थान आवश्यक हैं",
+        "endYear": "समाप्ति वर्ष प्रारंभ वर्ष को या उसके बाद होना चाहिए"
+      },
+      "fromYear": "{{year}} से",
+      "gradeSuffix": "ग्रेड: {{grade}}"
+    },
+    "save": "सहेजें",
+    "edit": "संपादित करें",
+    "delete": "हटाएँ",
+    "experience": {
+      "add": "अनुभव जोड़ें",
+      "edit": "अनुभव संपादित करें",
+      "empty": "अभी तक कोई कार्य अनुभव रिकॉर्ड नहीं जोड़ा गया।",
+      "deleteDialog": {
+        "title": "यह अनुभव रिकॉर्ड हटाएँ?"
+      },
+      "field": {
+        "company": "कंपनी",
+        "designation": "पदनाम",
+        "startDate": "प्रारंभ तिथि",
+        "endDate": "समाप्ति तिथि",
+        "description": "विवरण"
+      },
+      "currentlyWorking": "वर्तमान में यहाँ कार्यरत",
+      "current": "वर्तमान",
+      "present": "वर्तमान",
+      "validation": {
+        "required": "कंपनी, पदनाम और प्रारंभ तिथि आवश्यक हैं"
+      }
+    },
+    "dependents": {
+      "add": "आश्रित जोड़ें",
+      "edit": "आश्रित संपादित करें",
+      "empty": "अभी तक कोई आश्रित नहीं जोड़ा गया।",
+      "deleteDialog": {
+        "title": "यह आश्रित हटाएँ?"
+      },
+      "field": {
+        "name": "नाम",
+        "relationship": "संबंध",
+        "dateOfBirth": "जन्म तिथि",
+        "gender": "लिंग",
+        "nomineePercent": "नामिती %"
+      },
+      "isNominee": "नामिती है",
+      "placeholder": {
+        "relationship": "उदा. पति/पत्नी, संतान, माता-पिता"
+      },
+      "validation": {
+        "required": "नाम और संबंध आवश्यक हैं"
+      },
+      "column": {
+        "name": "नाम",
+        "relationship": "संबंध",
+        "dob": "जन्म तिथि",
+        "gender": "लिंग",
+        "nominee": "नामिती",
+        "actions": "क्रियाएँ"
+      },
+      "nomineeYes": "हाँ",
+      "nomineeNo": "नहीं"
+    },
+    "addresses": {
+      "add": "पता जोड़ें",
+      "edit": "पता संपादित करें",
+      "empty": "अभी तक कोई पता नहीं जोड़ा गया।",
+      "deleteDialog": {
+        "title": "यह पता हटाएँ?"
+      },
+      "field": {
+        "type": "प्रकार",
+        "country": "देश",
+        "line1": "पता पंक्ति 1",
+        "line2": "पता पंक्ति 2",
+        "city": "शहर",
+        "state": "राज्य",
+        "zipcode": "पिन कोड"
+      },
+      "type": {
+        "current": "वर्तमान",
+        "permanent": "स्थायी"
+      },
+      "validation": {
+        "required": "पता पंक्ति 1, शहर, राज्य और पिन कोड आवश्यक हैं"
+      }
+    },
+    "customFields": {
+      "loading": "कस्टम फ़ील्ड लोड हो रहे हैं...",
+      "emptyTitle": "अभी तक कर्मचारियों के लिए कोई कस्टम फ़ील्ड परिभाषित नहीं किए गए हैं।",
+      "emptyHint": "HR प्रशासक कस्टम फ़ील्ड सेटिंग्स पृष्ठ से कस्टम फ़ील्ड बना सकते हैं।",
+      "heading": "कस्टम फ़ील्ड",
+      "saveFailed": "कस्टम फ़ील्ड सहेजने में विफल",
+      "defaultSection": "कस्टम फ़ील्ड",
+      "display": {
+        "yes": "हाँ",
+        "no": "नहीं"
+      },
+      "selectPlaceholder": "चुनें...",
+      "filePlaceholder": "फ़ाइल संदर्भ या पथ"
+    }
   }
 }

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -2538,5 +2538,264 @@
       "damaged": "破損",
       "updated": "更新"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "個人情報",
+      "education": "学歴",
+      "experience": "職歴",
+      "dependents": "扶養家族",
+      "addresses": "住所",
+      "custom": "カスタム項目"
+    },
+    "invalidEmployee": {
+      "title": "無効な従業員",
+      "description": "URL内の従業員IDが見つからないか、無効です。",
+      "backLink": "従業員ディレクトリに戻る"
+    },
+    "accessDenied": {
+      "title": "アクセスが拒否されました",
+      "description": "このプロフィールを閲覧する権限がありません。",
+      "backLink": "ダッシュボードに戻る"
+    },
+    "loadingProfile": "プロフィールを読み込み中...",
+    "employeeNotFound": "従業員が見つかりません",
+    "backToDirectory": "ディレクトリに戻る",
+    "noDesignation": "役職なし",
+    "biometricPhotoTooltip": "写真は生体認証キオスクの登録で管理されます",
+    "biometricPhotoAlt": "生体認証の顔写真",
+    "profilePhotoAlt": "プロフィール",
+    "biometricPhotoHint": "生体認証登録の写真 — キオスクで管理されます。",
+    "removingPhoto": "削除中...",
+    "removePhoto": "写真を削除",
+    "empCodeLabel": "従業員コード: {{code}}",
+    "joinedLabel": "入社日: {{date}}",
+    "cancel": "キャンセル",
+    "editMyInfo": "自分の情報を編集",
+    "editProfile": "プロフィールを編集",
+    "removePhotoDialog": {
+      "title": "プロフィール写真を削除しますか？",
+      "description": "再びイニシャルが表示されます。",
+      "confirm": "写真を削除"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "PANは英字5文字＋数字4桁＋英字1文字で入力してください（例: ABCDE1234F）",
+      "aadhaar": "Aadhaarは12桁で入力してください",
+      "uan": "UANは12桁で入力してください",
+      "passport": "パスポート番号は英字1文字＋数字7桁で入力してください（例: A1234567）"
+    },
+    "personal": {
+      "saveFailed": "保存に失敗しました",
+      "selfServiceNotice": "個人情報および緊急連絡先情報を編集できます。管理項目の更新は人事担当者にお問い合わせください。"
+    },
+    "field": {
+      "personalEmail": "個人メールアドレス",
+      "contactNumber": "連絡先電話番号",
+      "gender": "性別",
+      "dateOfBirth": "生年月日",
+      "bloodGroup": "血液型",
+      "maritalStatus": "婚姻状況",
+      "nationality": "国籍",
+      "aadharNumber": "Aadhar番号",
+      "panNumber": "PAN番号",
+      "uanNumber": "UAN番号",
+      "passportNumber": "パスポート番号",
+      "passportExpiry": "パスポート有効期限",
+      "visaStatus": "ビザステータス",
+      "visaExpiry": "ビザ有効期限",
+      "emergencyContact": "緊急連絡先",
+      "emergencyPhone": "緊急連絡先電話番号",
+      "emergencyRelation": "緊急連絡先との続柄",
+      "noticePeriodDays": "退職予告期間（日）",
+      "reportingManager": "直属の上司",
+      "department": "部署",
+      "shift": "シフト",
+      "designation": "役職",
+      "employeeCode": "従業員コード",
+      "probationStart": "試用期間開始日",
+      "probationEnd": "試用期間終了日",
+      "confirmationDate": "本採用日",
+      "customRoles": "カスタムロール",
+      "additionalManagers": "追加マネージャー"
+    },
+    "select": {
+      "placeholder": "選択"
+    },
+    "gender": {
+      "male": "男性",
+      "female": "女性",
+      "other": "その他"
+    },
+    "maritalStatus": {
+      "single": "未婚",
+      "married": "既婚",
+      "divorced": "離婚",
+      "widowed": "死別"
+    },
+    "placeholder": {
+      "aadhar": "12桁",
+      "pan": "ABCDE1234F",
+      "uan": "12桁",
+      "passport": "A1234567",
+      "designationSelfService": "変更は人事にお問い合わせください",
+      "designation": "例: シニアエンジニア",
+      "empCodeSelfService": "設定は人事にお問い合わせください",
+      "empCode": "例: EMP001"
+    },
+    "reportingManager": {
+      "none": "上司なし"
+    },
+    "department": {
+      "none": "部署なし"
+    },
+    "shift": {
+      "none": "シフトなし"
+    },
+    "saving": "保存中...",
+    "saveChanges": "変更を保存",
+    "additionalManagers": {
+      "loading": "読み込み中…",
+      "none": "追加マネージャーなし",
+      "userFallback": "ユーザー #{{id}}",
+      "selectedCount_one": "（{{count}}件選択中）",
+      "selectedCount_other": "（{{count}}件選択中）",
+      "helpText": "直属の上司と同じチーム範囲のアクセス権を持つ共同マネージャー。チーム範囲のすべての権限で適用されます。",
+      "removeAria": "{{name}}を削除",
+      "removeAriaFallback": "マネージャー",
+      "searchPlaceholder": "名前またはメールアドレスで検索…",
+      "addPlaceholder": "別のマネージャーを追加…",
+      "noMatches": "一致するユーザーがいません",
+      "allSelected": "対象ユーザーはすべて選択済みです",
+      "savingButton": "保存中…",
+      "saveButton": "追加マネージャーを保存",
+      "unsavedChanges": "未保存の変更",
+      "saved": "保存しました"
+    },
+    "apiError": {
+      "requestFailed": "リクエストに失敗しました"
+    },
+    "education": {
+      "add": "学歴を追加",
+      "edit": "学歴を編集",
+      "empty": "まだ学歴が登録されていません。",
+      "deleteDialog": {
+        "title": "この学歴を削除しますか？"
+      },
+      "field": {
+        "degree": "学位",
+        "institution": "学校名",
+        "fieldOfStudy": "専攻分野",
+        "grade": "成績",
+        "startYear": "開始年",
+        "endYear": "終了年"
+      },
+      "placeholder": {
+        "degree": "例: 学士（工学）",
+        "institution": "例: デリー工科大学"
+      },
+      "validation": {
+        "required": "学位と学校名は必須です",
+        "endYear": "終了年は開始年以降にしてください"
+      },
+      "fromYear": "{{year}}年から",
+      "gradeSuffix": "成績：{{grade}}"
+    },
+    "save": "保存",
+    "edit": "編集",
+    "delete": "削除",
+    "experience": {
+      "add": "職歴を追加",
+      "edit": "職歴を編集",
+      "empty": "まだ職歴が登録されていません。",
+      "deleteDialog": {
+        "title": "この職歴を削除しますか？"
+      },
+      "field": {
+        "company": "会社名",
+        "designation": "役職",
+        "startDate": "開始日",
+        "endDate": "終了日",
+        "description": "職務内容"
+      },
+      "currentlyWorking": "現在在籍中",
+      "current": "現職",
+      "present": "現在",
+      "validation": {
+        "required": "会社名、役職、開始日は必須です"
+      }
+    },
+    "dependents": {
+      "add": "扶養家族を追加",
+      "edit": "扶養家族を編集",
+      "empty": "まだ扶養家族が登録されていません。",
+      "deleteDialog": {
+        "title": "この扶養家族を削除しますか？"
+      },
+      "field": {
+        "name": "氏名",
+        "relationship": "続柄",
+        "dateOfBirth": "生年月日",
+        "gender": "性別",
+        "nomineePercent": "受取人割合（%）"
+      },
+      "isNominee": "受取人",
+      "placeholder": {
+        "relationship": "例: 配偶者、子、親"
+      },
+      "validation": {
+        "required": "氏名と続柄は必須です"
+      },
+      "column": {
+        "name": "氏名",
+        "relationship": "続柄",
+        "dob": "生年月日",
+        "gender": "性別",
+        "nominee": "受取人",
+        "actions": "操作"
+      },
+      "nomineeYes": "はい",
+      "nomineeNo": "いいえ"
+    },
+    "addresses": {
+      "add": "住所を追加",
+      "edit": "住所を編集",
+      "empty": "まだ住所が登録されていません。",
+      "deleteDialog": {
+        "title": "この住所を削除しますか？"
+      },
+      "field": {
+        "type": "種類",
+        "country": "国",
+        "line1": "住所1",
+        "line2": "住所2",
+        "city": "市区町村",
+        "state": "都道府県・州",
+        "zipcode": "郵便番号"
+      },
+      "type": {
+        "current": "現住所",
+        "permanent": "恒久住所"
+      },
+      "validation": {
+        "required": "住所1、市区町村、都道府県・州、郵便番号は必須です"
+      }
+    },
+    "customFields": {
+      "loading": "カスタム項目を読み込み中...",
+      "emptyTitle": "従業員向けのカスタム項目はまだ定義されていません。",
+      "emptyHint": "人事管理者はカスタム項目設定ページからカスタム項目を作成できます。",
+      "heading": "カスタム項目",
+      "saveFailed": "カスタム項目の保存に失敗しました",
+      "defaultSection": "カスタム項目",
+      "display": {
+        "yes": "はい",
+        "no": "いいえ"
+      },
+      "selectPlaceholder": "選択...",
+      "filePlaceholder": "ファイル参照またはパス"
+    }
   }
 }

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -2538,5 +2538,264 @@
       "damaged": "Danificado",
       "updated": "Atualizado"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "Pessoal",
+      "education": "Formação",
+      "experience": "Experiência",
+      "dependents": "Dependentes",
+      "addresses": "Endereços",
+      "custom": "Campos personalizados"
+    },
+    "invalidEmployee": {
+      "title": "Funcionário inválido",
+      "description": "O ID do funcionário na URL está ausente ou é inválido.",
+      "backLink": "Voltar ao diretório de funcionários"
+    },
+    "accessDenied": {
+      "title": "Acesso negado",
+      "description": "Você não tem permissão para ver este perfil.",
+      "backLink": "Voltar ao painel"
+    },
+    "loadingProfile": "Carregando perfil...",
+    "employeeNotFound": "Funcionário não encontrado",
+    "backToDirectory": "Voltar ao diretório",
+    "noDesignation": "Sem cargo",
+    "biometricPhotoTooltip": "A foto é gerenciada pelo cadastro no quiosque biométrico",
+    "biometricPhotoAlt": "Rosto biométrico",
+    "profilePhotoAlt": "Perfil",
+    "biometricPhotoHint": "Foto do cadastro biométrico — gerenciada pelo quiosque.",
+    "removingPhoto": "Removendo...",
+    "removePhoto": "Remover foto",
+    "empCodeLabel": "Código do funcionário: {{code}}",
+    "joinedLabel": "Admissão: {{date}}",
+    "cancel": "Cancelar",
+    "editMyInfo": "Editar minhas informações",
+    "editProfile": "Editar perfil",
+    "removePhotoDialog": {
+      "title": "Remover sua foto de perfil?",
+      "description": "Suas iniciais serão exibidas novamente.",
+      "confirm": "Remover foto"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "O PAN deve ter 5 letras + 4 dígitos + 1 letra (ex.: ABCDE1234F)",
+      "aadhaar": "O Aadhaar deve ter 12 dígitos",
+      "uan": "O UAN deve ter 12 dígitos",
+      "passport": "O passaporte deve ter 1 letra + 7 dígitos (ex.: A1234567)"
+    },
+    "personal": {
+      "saveFailed": "Falha ao salvar",
+      "selfServiceNotice": "Você pode editar suas informações pessoais e de contato de emergência. Entre em contato com o RH para atualizar campos administrativos."
+    },
+    "field": {
+      "personalEmail": "E-mail pessoal",
+      "contactNumber": "Telefone de contato",
+      "gender": "Gênero",
+      "dateOfBirth": "Data de nascimento",
+      "bloodGroup": "Tipo sanguíneo",
+      "maritalStatus": "Estado civil",
+      "nationality": "Nacionalidade",
+      "aadharNumber": "Número Aadhar",
+      "panNumber": "Número PAN",
+      "uanNumber": "Número UAN",
+      "passportNumber": "Número do passaporte",
+      "passportExpiry": "Validade do passaporte",
+      "visaStatus": "Status do visto",
+      "visaExpiry": "Validade do visto",
+      "emergencyContact": "Contato de emergência",
+      "emergencyPhone": "Telefone de emergência",
+      "emergencyRelation": "Parentesco de emergência",
+      "noticePeriodDays": "Aviso prévio (dias)",
+      "reportingManager": "Gestor responsável",
+      "department": "Departamento",
+      "shift": "Turno",
+      "designation": "Cargo",
+      "employeeCode": "Código do funcionário",
+      "probationStart": "Início da experiência",
+      "probationEnd": "Fim da experiência",
+      "confirmationDate": "Data de efetivação",
+      "customRoles": "Funções personalizadas",
+      "additionalManagers": "Gestores adicionais"
+    },
+    "select": {
+      "placeholder": "Selecionar"
+    },
+    "gender": {
+      "male": "Masculino",
+      "female": "Feminino",
+      "other": "Outro"
+    },
+    "maritalStatus": {
+      "single": "Solteiro(a)",
+      "married": "Casado(a)",
+      "divorced": "Divorciado(a)",
+      "widowed": "Viúvo(a)"
+    },
+    "placeholder": {
+      "aadhar": "12 dígitos",
+      "pan": "ABCDE1234F",
+      "uan": "12 dígitos",
+      "passport": "A1234567",
+      "designationSelfService": "Entre em contato com o RH para alterar",
+      "designation": "ex.: Engenheiro Sênior",
+      "empCodeSelfService": "Entre em contato com o RH para definir",
+      "empCode": "ex.: EMP001"
+    },
+    "reportingManager": {
+      "none": "Sem gestor"
+    },
+    "department": {
+      "none": "Sem departamento"
+    },
+    "shift": {
+      "none": "Sem turno"
+    },
+    "saving": "Salvando...",
+    "saveChanges": "Salvar alterações",
+    "additionalManagers": {
+      "loading": "Carregando…",
+      "none": "Nenhum gestor adicional",
+      "userFallback": "Usuário nº {{id}}",
+      "selectedCount_one": "({{count}} selecionado)",
+      "selectedCount_other": "({{count}} selecionados)",
+      "helpText": "Cogestores com o mesmo acesso de escopo de equipe do gestor responsável principal. Respeitado por todas as permissões de escopo de equipe.",
+      "removeAria": "Remover {{name}}",
+      "removeAriaFallback": "gestor",
+      "searchPlaceholder": "Buscar por nome ou e-mail…",
+      "addPlaceholder": "Adicionar outro…",
+      "noMatches": "Nenhum usuário correspondente",
+      "allSelected": "Todos os usuários elegíveis já foram selecionados",
+      "savingButton": "Salvando…",
+      "saveButton": "Salvar gestores adicionais",
+      "unsavedChanges": "alterações não salvas",
+      "saved": "Salvo"
+    },
+    "apiError": {
+      "requestFailed": "Falha na solicitação"
+    },
+    "education": {
+      "add": "Adicionar formação",
+      "edit": "Editar formação",
+      "empty": "Nenhum registro de formação adicionado ainda.",
+      "deleteDialog": {
+        "title": "Excluir este registro de formação?"
+      },
+      "field": {
+        "degree": "Diploma",
+        "institution": "Instituição",
+        "fieldOfStudy": "Área de estudo",
+        "grade": "Nota",
+        "startYear": "Ano de início",
+        "endYear": "Ano de conclusão"
+      },
+      "placeholder": {
+        "degree": "ex.: B.Tech",
+        "institution": "ex.: IIT Delhi"
+      },
+      "validation": {
+        "required": "Diploma e Instituição são obrigatórios",
+        "endYear": "O ano de conclusão deve ser igual ou posterior ao ano de início"
+      },
+      "fromYear": "A partir de {{year}}",
+      "gradeSuffix": "Nota: {{grade}}"
+    },
+    "save": "Salvar",
+    "edit": "Editar",
+    "delete": "Excluir",
+    "experience": {
+      "add": "Adicionar experiência",
+      "edit": "Editar experiência",
+      "empty": "Nenhum registro de experiência profissional adicionado ainda.",
+      "deleteDialog": {
+        "title": "Excluir este registro de experiência?"
+      },
+      "field": {
+        "company": "Empresa",
+        "designation": "Cargo",
+        "startDate": "Data de início",
+        "endDate": "Data de término",
+        "description": "Descrição"
+      },
+      "currentlyWorking": "Trabalho aqui atualmente",
+      "current": "Atual",
+      "present": "Atual",
+      "validation": {
+        "required": "Empresa, Cargo e Data de início são obrigatórios"
+      }
+    },
+    "dependents": {
+      "add": "Adicionar dependente",
+      "edit": "Editar dependente",
+      "empty": "Nenhum dependente adicionado ainda.",
+      "deleteDialog": {
+        "title": "Excluir este dependente?"
+      },
+      "field": {
+        "name": "Nome",
+        "relationship": "Parentesco",
+        "dateOfBirth": "Data de nascimento",
+        "gender": "Gênero",
+        "nomineePercent": "% do beneficiário"
+      },
+      "isNominee": "É beneficiário",
+      "placeholder": {
+        "relationship": "ex.: Cônjuge, Filho(a), Pai/Mãe"
+      },
+      "validation": {
+        "required": "Nome e Parentesco são obrigatórios"
+      },
+      "column": {
+        "name": "Nome",
+        "relationship": "Parentesco",
+        "dob": "Nasc.",
+        "gender": "Gênero",
+        "nominee": "Beneficiário",
+        "actions": "Ações"
+      },
+      "nomineeYes": "Sim",
+      "nomineeNo": "Não"
+    },
+    "addresses": {
+      "add": "Adicionar endereço",
+      "edit": "Editar endereço",
+      "empty": "Nenhum endereço adicionado ainda.",
+      "deleteDialog": {
+        "title": "Excluir este endereço?"
+      },
+      "field": {
+        "type": "Tipo",
+        "country": "País",
+        "line1": "Endereço linha 1",
+        "line2": "Endereço linha 2",
+        "city": "Cidade",
+        "state": "Estado",
+        "zipcode": "CEP"
+      },
+      "type": {
+        "current": "Atual",
+        "permanent": "Permanente"
+      },
+      "validation": {
+        "required": "Endereço linha 1, Cidade, Estado e CEP são obrigatórios"
+      }
+    },
+    "customFields": {
+      "loading": "Carregando campos personalizados...",
+      "emptyTitle": "Nenhum campo personalizado foi definido para funcionários ainda.",
+      "emptyHint": "Os administradores de RH podem criar campos personalizados na página de configurações de Campos personalizados.",
+      "heading": "Campos personalizados",
+      "saveFailed": "Falha ao salvar campos personalizados",
+      "defaultSection": "Campos personalizados",
+      "display": {
+        "yes": "Sim",
+        "no": "Não"
+      },
+      "selectPlaceholder": "Selecionar...",
+      "filePlaceholder": "Referência ou caminho do arquivo"
+    }
   }
 }

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -2538,5 +2538,264 @@
       "damaged": "已损坏",
       "updated": "已更新"
     }
+  },
+  "employeeProfile": {
+    "tab": {
+      "personal": "个人信息",
+      "education": "教育经历",
+      "experience": "工作经历",
+      "dependents": "受抚养人",
+      "addresses": "地址",
+      "custom": "自定义字段"
+    },
+    "invalidEmployee": {
+      "title": "无效员工",
+      "description": "URL 中的员工 ID 缺失或无效。",
+      "backLink": "返回员工目录"
+    },
+    "accessDenied": {
+      "title": "访问被拒绝",
+      "description": "您无权查看此档案。",
+      "backLink": "返回仪表盘"
+    },
+    "loadingProfile": "正在加载档案……",
+    "employeeNotFound": "未找到员工",
+    "backToDirectory": "返回目录",
+    "noDesignation": "无职位",
+    "biometricPhotoTooltip": "照片通过生物识别终端录入管理",
+    "biometricPhotoAlt": "生物识别人脸",
+    "profilePhotoAlt": "档案",
+    "biometricPhotoHint": "照片来自生物识别录入——通过终端管理。",
+    "removingPhoto": "正在移除……",
+    "removePhoto": "移除照片",
+    "empCodeLabel": "员工编号：{{code}}",
+    "joinedLabel": "入职日期：{{date}}",
+    "cancel": "取消",
+    "editMyInfo": "编辑我的信息",
+    "editProfile": "编辑档案",
+    "removePhotoDialog": {
+      "title": "移除您的档案照片？",
+      "description": "将重新显示姓名首字母。",
+      "confirm": "移除照片"
+    },
+    "fieldRow": {
+      "empty": "-"
+    },
+    "validation": {
+      "pan": "PAN 必须为 5 个字母 + 4 个数字 + 1 个字母（例如 ABCDE1234F）",
+      "aadhaar": "Aadhaar 必须为 12 位数字",
+      "uan": "UAN 必须为 12 位数字",
+      "passport": "护照号必须为 1 个字母 + 7 个数字（例如 A1234567）"
+    },
+    "personal": {
+      "saveFailed": "保存失败",
+      "selfServiceNotice": "您可以编辑个人信息和紧急联系人信息。如需更新管理字段，请联系人力资源部。"
+    },
+    "field": {
+      "personalEmail": "个人邮箱",
+      "contactNumber": "联系电话",
+      "gender": "性别",
+      "dateOfBirth": "出生日期",
+      "bloodGroup": "血型",
+      "maritalStatus": "婚姻状况",
+      "nationality": "国籍",
+      "aadharNumber": "Aadhar 号码",
+      "panNumber": "PAN 号码",
+      "uanNumber": "UAN 号码",
+      "passportNumber": "护照号码",
+      "passportExpiry": "护照有效期",
+      "visaStatus": "签证状态",
+      "visaExpiry": "签证有效期",
+      "emergencyContact": "紧急联系人",
+      "emergencyPhone": "紧急联系电话",
+      "emergencyRelation": "紧急联系人关系",
+      "noticePeriodDays": "通知期（天）",
+      "reportingManager": "汇报经理",
+      "department": "部门",
+      "shift": "班次",
+      "designation": "职位",
+      "employeeCode": "员工编号",
+      "probationStart": "试用期开始",
+      "probationEnd": "试用期结束",
+      "confirmationDate": "转正日期",
+      "customRoles": "自定义角色",
+      "additionalManagers": "其他经理"
+    },
+    "select": {
+      "placeholder": "请选择"
+    },
+    "gender": {
+      "male": "男",
+      "female": "女",
+      "other": "其他"
+    },
+    "maritalStatus": {
+      "single": "未婚",
+      "married": "已婚",
+      "divorced": "离异",
+      "widowed": "丧偶"
+    },
+    "placeholder": {
+      "aadhar": "12 位数字",
+      "pan": "ABCDE1234F",
+      "uan": "12 位数字",
+      "passport": "A1234567",
+      "designationSelfService": "如需更改请联系人力资源部",
+      "designation": "例如：高级工程师",
+      "empCodeSelfService": "如需设置请联系人力资源部",
+      "empCode": "例如：EMP001"
+    },
+    "reportingManager": {
+      "none": "无经理"
+    },
+    "department": {
+      "none": "无部门"
+    },
+    "shift": {
+      "none": "无班次"
+    },
+    "saving": "正在保存……",
+    "saveChanges": "保存更改",
+    "additionalManagers": {
+      "loading": "正在加载……",
+      "none": "无其他经理",
+      "userFallback": "用户 #{{id}}",
+      "selectedCount_one": "（已选择 {{count}} 个）",
+      "selectedCount_other": "（已选择 {{count}} 个）",
+      "helpText": "与主汇报经理拥有相同团队范围访问权限的协同经理。每项团队范围的权限均予以认可。",
+      "removeAria": "移除 {{name}}",
+      "removeAriaFallback": "经理",
+      "searchPlaceholder": "按姓名或邮箱搜索……",
+      "addPlaceholder": "添加另一位……",
+      "noMatches": "无匹配用户",
+      "allSelected": "所有符合条件的用户均已选择",
+      "savingButton": "正在保存……",
+      "saveButton": "保存其他经理",
+      "unsavedChanges": "未保存的更改",
+      "saved": "已保存"
+    },
+    "apiError": {
+      "requestFailed": "请求失败"
+    },
+    "education": {
+      "add": "添加教育经历",
+      "edit": "编辑教育经历",
+      "empty": "尚未添加教育记录。",
+      "deleteDialog": {
+        "title": "删除此教育记录？"
+      },
+      "field": {
+        "degree": "学位",
+        "institution": "院校",
+        "fieldOfStudy": "专业",
+        "grade": "成绩",
+        "startYear": "起始年份",
+        "endYear": "结束年份"
+      },
+      "placeholder": {
+        "degree": "例如：工学学士",
+        "institution": "例如：印度理工学院德里分校"
+      },
+      "validation": {
+        "required": "学位和院校为必填项",
+        "endYear": "结束年份必须不早于起始年份"
+      },
+      "fromYear": "自 {{year}} 年起",
+      "gradeSuffix": "成绩：{{grade}}"
+    },
+    "save": "保存",
+    "edit": "编辑",
+    "delete": "删除",
+    "experience": {
+      "add": "添加工作经历",
+      "edit": "编辑工作经历",
+      "empty": "尚未添加工作经历记录。",
+      "deleteDialog": {
+        "title": "删除此工作经历记录？"
+      },
+      "field": {
+        "company": "公司",
+        "designation": "职位",
+        "startDate": "开始日期",
+        "endDate": "结束日期",
+        "description": "描述"
+      },
+      "currentlyWorking": "目前在职",
+      "current": "当前",
+      "present": "至今",
+      "validation": {
+        "required": "公司、职位和开始日期为必填项"
+      }
+    },
+    "dependents": {
+      "add": "添加受抚养人",
+      "edit": "编辑受抚养人",
+      "empty": "尚未添加受抚养人。",
+      "deleteDialog": {
+        "title": "删除此受抚养人？"
+      },
+      "field": {
+        "name": "姓名",
+        "relationship": "关系",
+        "dateOfBirth": "出生日期",
+        "gender": "性别",
+        "nomineePercent": "受益人比例 %"
+      },
+      "isNominee": "是否为受益人",
+      "placeholder": {
+        "relationship": "例如：配偶、子女、父母"
+      },
+      "validation": {
+        "required": "姓名和关系为必填项"
+      },
+      "column": {
+        "name": "姓名",
+        "relationship": "关系",
+        "dob": "出生日期",
+        "gender": "性别",
+        "nominee": "受益人",
+        "actions": "操作"
+      },
+      "nomineeYes": "是",
+      "nomineeNo": "否"
+    },
+    "addresses": {
+      "add": "添加地址",
+      "edit": "编辑地址",
+      "empty": "尚未添加地址。",
+      "deleteDialog": {
+        "title": "删除此地址？"
+      },
+      "field": {
+        "type": "类型",
+        "country": "国家/地区",
+        "line1": "地址行 1",
+        "line2": "地址行 2",
+        "city": "城市",
+        "state": "省/州",
+        "zipcode": "邮政编码"
+      },
+      "type": {
+        "current": "现居",
+        "permanent": "永久"
+      },
+      "validation": {
+        "required": "地址行 1、城市、省/州和邮政编码为必填项"
+      }
+    },
+    "customFields": {
+      "loading": "正在加载自定义字段……",
+      "emptyTitle": "尚未为员工定义任何自定义字段。",
+      "emptyHint": "人力资源管理员可在自定义字段设置页面创建自定义字段。",
+      "heading": "自定义字段",
+      "saveFailed": "保存自定义字段失败",
+      "defaultSection": "自定义字段",
+      "display": {
+        "yes": "是",
+        "no": "否"
+      },
+      "selectPlaceholder": "请选择……",
+      "filePlaceholder": "文件引用或路径"
+    }
   }
 }

--- a/packages/client/src/pages/employees/EmployeeProfilePage.tsx
+++ b/packages/client/src/pages/employees/EmployeeProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -38,6 +39,7 @@ const TABS: { key: Tab; label: string; icon: React.ElementType }[] = [
 ];
 
 export default function EmployeeProfilePage() {
+  const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const userId = Number(id);
   const queryClient = useQueryClient();
@@ -212,10 +214,10 @@ export default function EmployeeProfilePage() {
     return (
       <div className="flex flex-col items-center justify-center py-20">
         <User className="h-12 w-12 text-gray-300 mb-4" />
-        <h2 className="text-lg font-semibold text-gray-700 mb-1">Invalid Employee</h2>
-        <p className="text-sm text-gray-500 mb-4">The employee ID in the URL is missing or invalid.</p>
+        <h2 className="text-lg font-semibold text-gray-700 mb-1">{t("employeeProfile.invalidEmployee.title")}</h2>
+        <p className="text-sm text-gray-500 mb-4">{t("employeeProfile.invalidEmployee.description")}</p>
         <Link to="/employees" className="text-brand-600 text-sm font-medium hover:text-brand-700">
-          &larr; Back to Employee Directory
+          &larr; {t("employeeProfile.invalidEmployee.backLink")}
         </Link>
       </div>
     );
@@ -225,12 +227,12 @@ export default function EmployeeProfilePage() {
     return (
       <div className="flex flex-col items-center justify-center py-20">
         <User className="h-12 w-12 text-gray-300 mb-4" />
-        <h2 className="text-lg font-semibold text-gray-700 mb-1">Access denied</h2>
+        <h2 className="text-lg font-semibold text-gray-700 mb-1">{t("employeeProfile.accessDenied.title")}</h2>
         <p className="text-sm text-gray-500 mb-4">
-          You don't have permission to view this profile.
+          {t("employeeProfile.accessDenied.description")}
         </p>
         <Link to="/" className="text-brand-600 text-sm font-medium hover:text-brand-700">
-          &larr; Back to Dashboard
+          &larr; {t("employeeProfile.accessDenied.backLink")}
         </Link>
       </div>
     );
@@ -239,7 +241,7 @@ export default function EmployeeProfilePage() {
   if (profileLoading) {
     return (
       <div className="flex items-center justify-center py-20 text-gray-400">
-        Loading profile...
+        {t("employeeProfile.loadingProfile")}
       </div>
     );
   }
@@ -247,7 +249,7 @@ export default function EmployeeProfilePage() {
   if (!profile) {
     return (
       <div className="flex items-center justify-center py-20 text-gray-400">
-        Employee not found
+        {t("employeeProfile.employeeNotFound")}
       </div>
     );
   }
@@ -259,7 +261,7 @@ export default function EmployeeProfilePage() {
         to="/employees"
         className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-brand-600 mb-6"
       >
-        <ArrowLeft className="h-4 w-4" /> Back to Directory
+        <ArrowLeft className="h-4 w-4" /> {t("employeeProfile.backToDirectory")}
       </Link>
 
       {/* Header */}
@@ -282,20 +284,20 @@ export default function EmployeeProfilePage() {
                   onClick={() => photoEditable && photoInputRef.current?.click()}
                   title={
                     hasBiometric
-                      ? "Photo is managed via biometric kiosk enrollment"
+                      ? t("employeeProfile.biometricPhotoTooltip")
                       : undefined
                   }
                 >
                   {hasBiometric ? (
                     <img
                       src={`/api/v3/biometric/face/${userId}.jpg`}
-                      alt="Biometric face"
+                      alt={t("employeeProfile.biometricPhotoAlt")}
                       className="h-full w-full object-cover"
                     />
                   ) : photoUrl ? (
                     <img
                       src={photoUrl}
-                      alt="Profile"
+                      alt={t("employeeProfile.profilePhotoAlt")}
                       className="h-full w-full object-cover"
                       onError={() => setPhotoUrl(null)}
                     />
@@ -327,13 +329,13 @@ export default function EmployeeProfilePage() {
                   <h1 className="text-xl font-bold text-gray-900">
                     {profile.first_name} {profile.last_name}
                   </h1>
-                  <p className="text-sm text-gray-500">{profile.designation || "No designation"}</p>
+                  <p className="text-sm text-gray-500">{profile.designation || t("employeeProfile.noDesignation")}</p>
                   <p className="text-sm text-gray-400">{profile.email}</p>
                   {/* Hint when the photo comes from biometric enrollment —
                       explains why the upload affordance isn't there. */}
                   {hasBiometric && (
                     <p className="mt-1 text-xs text-gray-500">
-                      Photo from biometric enrollment — managed via the kiosk.
+                      {t("employeeProfile.biometricPhotoHint")}
                     </p>
                   )}
                   {/* #1650 — Remove photo only meaningful for the manual
@@ -348,10 +350,10 @@ export default function EmployeeProfilePage() {
                     >
                       {removingPhoto ? (
                         <>
-                          <Loader2 className="h-3 w-3 animate-spin" /> Removing...
+                          <Loader2 className="h-3 w-3 animate-spin" /> {t("employeeProfile.removingPhoto")}
                         </>
                       ) : (
-                        "Remove photo"
+                        t("employeeProfile.removePhoto")
                       )}
                     </button>
                   )}
@@ -361,9 +363,9 @@ export default function EmployeeProfilePage() {
           })()}
           <div className="ml-auto flex items-start gap-4">
             <div className="text-right text-sm text-gray-500">
-              {profile.emp_code && <p>Emp Code: {profile.emp_code}</p>}
+              {profile.emp_code && <p>{t("employeeProfile.empCodeLabel", { code: profile.emp_code })}</p>}
               {profile.date_of_joining && (
-                <p>Joined: {new Date(profile.date_of_joining).toLocaleDateString()}</p>
+                <p>{t("employeeProfile.joinedLabel", { date: new Date(profile.date_of_joining).toLocaleDateString() })}</p>
               )}
             </div>
             {activeTab === "personal" && canEdit && (
@@ -372,7 +374,7 @@ export default function EmployeeProfilePage() {
                 className="flex items-center gap-1.5 text-sm font-medium text-brand-600 hover:text-brand-700 border border-brand-200 px-3 py-1.5 rounded-lg hover:bg-brand-50"
               >
                 <Pencil className="h-3.5 w-3.5" />
-                {editing ? "Cancel" : isOwnProfile && !isHR ? "Edit My Info" : "Edit Profile"}
+                {editing ? t("employeeProfile.cancel") : isOwnProfile && !isHR ? t("employeeProfile.editMyInfo") : t("employeeProfile.editProfile")}
               </button>
             )}
           </div>
@@ -393,7 +395,7 @@ export default function EmployeeProfilePage() {
               }`}
             >
               <Icon className="h-4 w-4" />
-              {label}
+              {t(`employeeProfile.tab.${key}`, { defaultValue: label })}
             </button>
           ))}
         </nav>
@@ -407,7 +409,7 @@ export default function EmployeeProfilePage() {
             editing={editing}
             onSave={(data: Record<string, unknown>) => updateProfile.mutate(data)}
             saving={updateProfile.isPending}
-            error={updateProfile.isError ? ((updateProfile.error as any)?.response?.data?.error?.message || "Failed to save") : null}
+            error={updateProfile.isError ? ((updateProfile.error as any)?.response?.data?.error?.message || t("employeeProfile.personal.saveFailed")) : null}
             allUsers={allUsers || []}
             departments={departments || []}
             shifts={shifts || []}
@@ -424,9 +426,9 @@ export default function EmployeeProfilePage() {
 
       <ConfirmDialog
         open={showRemovePhoto}
-        title="Remove your profile photo?"
-        description="You'll show initials again."
-        confirmText="Remove photo"
+        title={t("employeeProfile.removePhotoDialog.title")}
+        description={t("employeeProfile.removePhotoDialog.description")}
+        confirmText={t("employeeProfile.removePhotoDialog.confirm")}
         variant="danger"
         loading={removingPhoto}
         onConfirm={handlePhotoRemove}
@@ -441,10 +443,11 @@ export default function EmployeeProfilePage() {
 // ---------------------------------------------------------------------------
 
 function FieldRow({ label, value }: { label: string; value?: string | number | null }) {
+  const { t } = useTranslation();
   return (
     <div className="grid grid-cols-3 py-3 border-b border-gray-100 last:border-0">
       <dt className="text-sm font-medium text-gray-500">{label}</dt>
-      <dd className="col-span-2 text-sm text-gray-900">{value || "-"}</dd>
+      <dd className="col-span-2 text-sm text-gray-900">{value || t("employeeProfile.fieldRow.empty")}</dd>
     </div>
   );
 }
@@ -455,31 +458,30 @@ const AADHAR_REGEX = /^[0-9]{12}$/;
 const UAN_REGEX = /^[0-9]{12}$/; // EPFO Universal Account Number — always 12 digits
 const PASSPORT_REGEX = /^[A-PR-WY][0-9]{7}$/; // Indian passport: 1 letter (excl. Q, X, Z), 7 digits
 
+// Returns an i18n KEY (not the message) so the calling component can render
+// it with t(). Keeps this helper hook-free / pure.
 function validateIdDoc(
   field: "pan_number" | "aadhar_number" | "uan_number" | "passport_number",
   value: string,
 ): string | null {
   if (!value) return null; // empty is allowed (optional field)
   if (field === "pan_number") {
-    return PAN_REGEX.test(value)
-      ? null
-      : "PAN must be 5 letters + 4 digits + 1 letter (e.g. ABCDE1234F)";
+    return PAN_REGEX.test(value) ? null : "employeeProfile.validation.pan";
   }
   if (field === "aadhar_number") {
-    return AADHAR_REGEX.test(value) ? null : "Aadhaar must be 12 digits";
+    return AADHAR_REGEX.test(value) ? null : "employeeProfile.validation.aadhaar";
   }
   if (field === "uan_number") {
-    return UAN_REGEX.test(value) ? null : "UAN must be 12 digits";
+    return UAN_REGEX.test(value) ? null : "employeeProfile.validation.uan";
   }
   if (field === "passport_number") {
-    return PASSPORT_REGEX.test(value)
-      ? null
-      : "Passport must be 1 letter + 7 digits (e.g. A1234567)";
+    return PASSPORT_REGEX.test(value) ? null : "employeeProfile.validation.passport";
   }
   return null;
 }
 
 function PersonalTab({ profile, editing, onSave, saving, error, allUsers, departments, shifts, userId, selfService }: { profile: any; editing?: boolean; onSave?: (data: Record<string, unknown>) => void; saving?: boolean; error?: string | null; allUsers?: any[]; departments?: any[]; shifts?: any[]; userId?: number; selfService?: boolean }) {
+  const { t } = useTranslation();
   const [form, setForm] = useState<Record<string, string>>({});
   const [idErrors, setIdErrors] = useState<{ pan_number?: string; aadhar_number?: string; uan_number?: string; passport_number?: string }>({});
   // Bug fix: previously this effect depended on [editing, profile], so any
@@ -549,52 +551,52 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
         {error && <div className="bg-red-50 text-red-700 text-sm p-3 rounded-lg mb-4">{error}</div>}
         {selfService && (
           <div className="bg-blue-50 border border-blue-200 text-blue-700 text-sm p-3 rounded-lg mb-4">
-            You can edit your personal and emergency contact information. Contact HR to update administrative fields.
+            {t("employeeProfile.personal.selfServiceNotice")}
           </div>
         )}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Personal Email</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.personalEmail")}</label>
             <input type="email" value={form.personal_email} onChange={(e) => set("personal_email", e.target.value)} className={canEditField("personal_email") ? inputClass : disabledClass} disabled={!canEditField("personal_email")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Contact Number</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.contactNumber")}</label>
             <input type="text" value={form.contact_number} onChange={(e) => set("contact_number", e.target.value)} className={canEditField("contact_number") ? inputClass : disabledClass} disabled={!canEditField("contact_number")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Gender</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.gender")}</label>
             <select value={form.gender} onChange={(e) => set("gender", e.target.value)} className={canEditField("gender") ? inputClass : disabledClass} disabled={!canEditField("gender")}>
-              <option value="">Select</option>
-              <option value="male">Male</option>
-              <option value="female">Female</option>
-              <option value="other">Other</option>
+              <option value="">{t("employeeProfile.select.placeholder")}</option>
+              <option value="male">{t("employeeProfile.gender.male")}</option>
+              <option value="female">{t("employeeProfile.gender.female")}</option>
+              <option value="other">{t("employeeProfile.gender.other")}</option>
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Date of Birth</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.dateOfBirth")}</label>
             {/* #1406 — DOB cannot be in the future */}
             <input type="date" max={new Date().toISOString().slice(0, 10)} value={form.date_of_birth} onChange={(e) => set("date_of_birth", e.target.value)} className={canEditField("date_of_birth") ? inputClass : disabledClass} disabled={!canEditField("date_of_birth")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Blood Group</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.bloodGroup")}</label>
             <input type="text" value={form.blood_group} onChange={(e) => set("blood_group", e.target.value)} className={canEditField("blood_group") ? inputClass : disabledClass} disabled={!canEditField("blood_group")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Marital Status</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.maritalStatus")}</label>
             <select value={form.marital_status} onChange={(e) => set("marital_status", e.target.value)} className={canEditField("marital_status") ? inputClass : disabledClass} disabled={!canEditField("marital_status")}>
-              <option value="">Select</option>
-              <option value="single">Single</option>
-              <option value="married">Married</option>
-              <option value="divorced">Divorced</option>
-              <option value="widowed">Widowed</option>
+              <option value="">{t("employeeProfile.select.placeholder")}</option>
+              <option value="single">{t("employeeProfile.maritalStatus.single")}</option>
+              <option value="married">{t("employeeProfile.maritalStatus.married")}</option>
+              <option value="divorced">{t("employeeProfile.maritalStatus.divorced")}</option>
+              <option value="widowed">{t("employeeProfile.maritalStatus.widowed")}</option>
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Nationality</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.nationality")}</label>
             <input type="text" value={form.nationality} onChange={(e) => set("nationality", e.target.value)} className={canEditField("nationality") ? inputClass : disabledClass} disabled={!canEditField("nationality")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Aadhar Number</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.aadharNumber")}</label>
             <input
               type="text"
               value={form.aadhar_number}
@@ -606,14 +608,14 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
               onBlur={(e) => setIdErrors((p) => ({ ...p, aadhar_number: validateIdDoc("aadhar_number", e.target.value) || undefined }))}
               inputMode="numeric"
               maxLength={12}
-              placeholder="12 digits"
+              placeholder={t("employeeProfile.placeholder.aadhar")}
               className={`${canEditField("aadhar_number") ? inputClass : disabledClass} ${idErrors.aadhar_number ? "border-red-500 focus:ring-red-500" : ""}`}
               disabled={!canEditField("aadhar_number")}
             />
-            {idErrors.aadhar_number && <p className="text-xs text-red-600 mt-1">{idErrors.aadhar_number}</p>}
+            {idErrors.aadhar_number && <p className="text-xs text-red-600 mt-1">{t(idErrors.aadhar_number)}</p>}
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">PAN Number</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.panNumber")}</label>
             <input
               type="text"
               value={form.pan_number}
@@ -623,14 +625,14 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
               }}
               onBlur={(e) => setIdErrors((p) => ({ ...p, pan_number: validateIdDoc("pan_number", e.target.value) || undefined }))}
               maxLength={10}
-              placeholder="ABCDE1234F"
+              placeholder={t("employeeProfile.placeholder.pan")}
               className={`${canEditField("pan_number") ? inputClass : disabledClass} ${idErrors.pan_number ? "border-red-500 focus:ring-red-500" : ""}`}
               disabled={!canEditField("pan_number")}
             />
-            {idErrors.pan_number && <p className="text-xs text-red-600 mt-1">{idErrors.pan_number}</p>}
+            {idErrors.pan_number && <p className="text-xs text-red-600 mt-1">{t(idErrors.pan_number)}</p>}
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">UAN Number</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.uanNumber")}</label>
             <input
               type="text"
               value={form.uan_number}
@@ -642,14 +644,14 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
               onBlur={(e) => setIdErrors((p) => ({ ...p, uan_number: validateIdDoc("uan_number", e.target.value) || undefined }))}
               inputMode="numeric"
               maxLength={12}
-              placeholder="12 digits"
+              placeholder={t("employeeProfile.placeholder.uan")}
               className={`${canEditField("uan_number") ? inputClass : disabledClass} ${idErrors.uan_number ? "border-red-500 focus:ring-red-500" : ""}`}
               disabled={!canEditField("uan_number")}
             />
-            {idErrors.uan_number && <p className="text-xs text-red-600 mt-1">{idErrors.uan_number}</p>}
+            {idErrors.uan_number && <p className="text-xs text-red-600 mt-1">{t(idErrors.uan_number)}</p>}
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Passport Number</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.passportNumber")}</label>
             <input
               type="text"
               value={form.passport_number}
@@ -659,44 +661,44 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
               }}
               onBlur={(e) => setIdErrors((p) => ({ ...p, passport_number: validateIdDoc("passport_number", e.target.value) || undefined }))}
               maxLength={8}
-              placeholder="A1234567"
+              placeholder={t("employeeProfile.placeholder.passport")}
               className={`${canEditField("passport_number") ? inputClass : disabledClass} ${idErrors.passport_number ? "border-red-500 focus:ring-red-500" : ""}`}
               disabled={!canEditField("passport_number")}
             />
-            {idErrors.passport_number && <p className="text-xs text-red-600 mt-1">{idErrors.passport_number}</p>}
+            {idErrors.passport_number && <p className="text-xs text-red-600 mt-1">{t(idErrors.passport_number)}</p>}
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Passport Expiry</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.passportExpiry")}</label>
             <input type="date" value={form.passport_expiry} onChange={(e) => set("passport_expiry", e.target.value)} className={canEditField("passport_expiry") ? inputClass : disabledClass} disabled={!canEditField("passport_expiry")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Visa Status</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.visaStatus")}</label>
             <input type="text" value={form.visa_status} onChange={(e) => set("visa_status", e.target.value)} className={canEditField("visa_status") ? inputClass : disabledClass} disabled={!canEditField("visa_status")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Visa Expiry</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.visaExpiry")}</label>
             <input type="date" value={form.visa_expiry} onChange={(e) => set("visa_expiry", e.target.value)} className={canEditField("visa_expiry") ? inputClass : disabledClass} disabled={!canEditField("visa_expiry")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Emergency Contact</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.emergencyContact")}</label>
             <input type="text" value={form.emergency_contact_name} onChange={(e) => set("emergency_contact_name", e.target.value)} className={canEditField("emergency_contact_name") ? inputClass : disabledClass} disabled={!canEditField("emergency_contact_name")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Emergency Phone</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.emergencyPhone")}</label>
             <input type="text" value={form.emergency_contact_phone} onChange={(e) => set("emergency_contact_phone", e.target.value)} className={canEditField("emergency_contact_phone") ? inputClass : disabledClass} disabled={!canEditField("emergency_contact_phone")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Emergency Relation</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.emergencyRelation")}</label>
             <input type="text" value={form.emergency_contact_relation} onChange={(e) => set("emergency_contact_relation", e.target.value)} className={canEditField("emergency_contact_relation") ? inputClass : disabledClass} disabled={!canEditField("emergency_contact_relation")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Notice Period (days)</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.noticePeriodDays")}</label>
             <input type="number" value={form.notice_period_days} onChange={(e) => set("notice_period_days", e.target.value)} className={canEditField("notice_period_days") ? inputClass : disabledClass} disabled={!canEditField("notice_period_days")} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Reporting Manager</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.reportingManager")}</label>
             <select value={form.reporting_manager_id} onChange={(e) => set("reporting_manager_id", e.target.value)} className={canEditField("reporting_manager_id") ? inputClass : disabledClass} disabled={!canEditField("reporting_manager_id")}>
-              <option value="">No Manager</option>
+              <option value="">{t("employeeProfile.reportingManager.none")}</option>
               {(allUsers || [])
                 .filter((u: any) => u.id !== userId && ["manager", "hr_admin", "org_admin", "super_admin"].includes(u.role))
                 .map((u: any) => (
@@ -726,9 +728,9 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
           {/* #1423 — Department (HR-only). Self-service users see a disabled
               dropdown so they're aware it exists but can't change it. */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Department</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.department")}</label>
             <select value={form.department_id} onChange={(e) => set("department_id", e.target.value)} className={!selfService ? inputClass : disabledClass} disabled={selfService}>
-              <option value="">No department</option>
+              <option value="">{t("employeeProfile.department.none")}</option>
               {(departments || []).map((d: any) => (
                 <option key={d.id} value={d.id}>{d.name}</option>
               ))}
@@ -737,9 +739,9 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
           {/* #1423 — Shift (HR-only). Sent as shift_id; the server creates a
               user_shift_assignments row starting today when this changes. */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Shift</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.shift")}</label>
             <select value={form.shift_id} onChange={(e) => set("shift_id", e.target.value)} className={!selfService ? inputClass : disabledClass} disabled={selfService}>
-              <option value="">No shift</option>
+              <option value="">{t("employeeProfile.shift.none")}</option>
               {(shifts || []).map((s: any) => (
                 <option key={s.id} value={s.id}>{s.name}</option>
               ))}
@@ -747,21 +749,21 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
           </div>
           {/* #1424 — Designation. HR can edit; employees see it read-only. */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Designation</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.designation")}</label>
             <input
               type="text"
               value={form.designation}
               onChange={(e) => set("designation", e.target.value)}
               className={!selfService ? inputClass : disabledClass}
               disabled={selfService}
-              placeholder={selfService ? "Contact HR to change" : "e.g. Senior Engineer"}
+              placeholder={selfService ? t("employeeProfile.placeholder.designationSelfService") : t("employeeProfile.placeholder.designation")}
             />
           </div>
           {/* emp-payroll#246 — Employee Code. HR-editable; employees see it
               read-only. Used downstream by emp-payroll for the My Profile
               header and the salary slip. */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Employee Code</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">{t("employeeProfile.field.employeeCode")}</label>
             <input
               type="text"
               value={form.emp_code}
@@ -769,7 +771,7 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
               className={!selfService ? inputClass : disabledClass}
               disabled={selfService}
               maxLength={50}
-              placeholder={selfService ? "Contact HR to set" : "e.g. EMP001"}
+              placeholder={selfService ? t("employeeProfile.placeholder.empCodeSelfService") : t("employeeProfile.placeholder.empCode")}
             />
           </div>
         </div>
@@ -791,7 +793,7 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
             disabled={saving}
             className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
           >
-            <Check className="h-4 w-4" /> {saving ? "Saving..." : "Save Changes"}
+            <Check className="h-4 w-4" /> {saving ? t("employeeProfile.saving") : t("employeeProfile.saveChanges")}
           </button>
         </div>
       </div>
@@ -800,55 +802,55 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
 
   return (
     <dl>
-      <FieldRow label="Personal Email" value={profile.personal_email} />
-      <FieldRow label="Contact Number" value={profile.contact_number} />
-      <FieldRow label="Gender" value={profile.gender} />
+      <FieldRow label={t("employeeProfile.field.personalEmail")} value={profile.personal_email} />
+      <FieldRow label={t("employeeProfile.field.contactNumber")} value={profile.contact_number} />
+      <FieldRow label={t("employeeProfile.field.gender")} value={profile.gender} />
       <FieldRow
-        label="Date of Birth"
+        label={t("employeeProfile.field.dateOfBirth")}
         value={profile.date_of_birth ? new Date(profile.date_of_birth).toLocaleDateString() : null}
       />
-      <FieldRow label="Blood Group" value={profile.blood_group} />
-      <FieldRow label="Marital Status" value={profile.marital_status} />
-      <FieldRow label="Nationality" value={profile.nationality} />
-      <FieldRow label="Aadhar Number" value={profile.aadhar_number} />
-      <FieldRow label="PAN Number" value={profile.pan_number} />
-      <FieldRow label="UAN Number" value={profile.uan_number} />
-      <FieldRow label="Passport Number" value={profile.passport_number} />
+      <FieldRow label={t("employeeProfile.field.bloodGroup")} value={profile.blood_group} />
+      <FieldRow label={t("employeeProfile.field.maritalStatus")} value={profile.marital_status} />
+      <FieldRow label={t("employeeProfile.field.nationality")} value={profile.nationality} />
+      <FieldRow label={t("employeeProfile.field.aadharNumber")} value={profile.aadhar_number} />
+      <FieldRow label={t("employeeProfile.field.panNumber")} value={profile.pan_number} />
+      <FieldRow label={t("employeeProfile.field.uanNumber")} value={profile.uan_number} />
+      <FieldRow label={t("employeeProfile.field.passportNumber")} value={profile.passport_number} />
       <FieldRow
-        label="Passport Expiry"
+        label={t("employeeProfile.field.passportExpiry")}
         value={profile.passport_expiry ? new Date(profile.passport_expiry).toLocaleDateString() : null}
       />
-      <FieldRow label="Visa Status" value={profile.visa_status} />
+      <FieldRow label={t("employeeProfile.field.visaStatus")} value={profile.visa_status} />
       <FieldRow
-        label="Visa Expiry"
+        label={t("employeeProfile.field.visaExpiry")}
         value={profile.visa_expiry ? new Date(profile.visa_expiry).toLocaleDateString() : null}
       />
-      <FieldRow label="Emergency Contact" value={profile.emergency_contact_name} />
-      <FieldRow label="Emergency Phone" value={profile.emergency_contact_phone} />
-      <FieldRow label="Emergency Relation" value={profile.emergency_contact_relation} />
+      <FieldRow label={t("employeeProfile.field.emergencyContact")} value={profile.emergency_contact_name} />
+      <FieldRow label={t("employeeProfile.field.emergencyPhone")} value={profile.emergency_contact_phone} />
+      <FieldRow label={t("employeeProfile.field.emergencyRelation")} value={profile.emergency_contact_relation} />
       <FieldRow
-        label="Probation Start"
+        label={t("employeeProfile.field.probationStart")}
         value={profile.probation_start_date ? new Date(profile.probation_start_date).toLocaleDateString() : null}
       />
       <FieldRow
-        label="Probation End"
+        label={t("employeeProfile.field.probationEnd")}
         value={profile.probation_end_date ? new Date(profile.probation_end_date).toLocaleDateString() : null}
       />
       <FieldRow
-        label="Confirmation Date"
+        label={t("employeeProfile.field.confirmationDate")}
         value={profile.confirmation_date ? new Date(profile.confirmation_date).toLocaleDateString() : null}
       />
-      <FieldRow label="Notice Period (days)" value={profile.notice_period_days} />
-      <FieldRow label="Reporting Manager" value={profile.reporting_manager_name || (profile.reporting_manager_id ? `User #${profile.reporting_manager_id}` : null)} />
+      <FieldRow label={t("employeeProfile.field.noticePeriodDays")} value={profile.notice_period_days} />
+      <FieldRow label={t("employeeProfile.field.reportingManager")} value={profile.reporting_manager_name || (profile.reporting_manager_id ? `User #${profile.reporting_manager_id}` : null)} />
       <AdditionalManagersReadRow userId={profile.id} />
       <CustomRolesReadRow userId={profile.id} />
       {/* #1423 / #1424 — surface designation, department and current shift in
           the read-only view so self-service employees can see them even if
           they can't edit them. */}
-      <FieldRow label="Designation" value={profile.designation} />
-      <FieldRow label="Employee Code" value={profile.emp_code} />
-      <FieldRow label="Department" value={profile.department_name || (profile.department_id ? `Dept #${profile.department_id}` : null)} />
-      <FieldRow label="Shift" value={profile.shift_name || (profile.shift_id ? `Shift #${profile.shift_id}` : null)} />
+      <FieldRow label={t("employeeProfile.field.designation")} value={profile.designation} />
+      <FieldRow label={t("employeeProfile.field.employeeCode")} value={profile.emp_code} />
+      <FieldRow label={t("employeeProfile.field.department")} value={profile.department_name || (profile.department_id ? `Dept #${profile.department_id}` : null)} />
+      <FieldRow label={t("employeeProfile.field.shift")} value={profile.shift_name || (profile.shift_id ? `Shift #${profile.shift_id}` : null)} />
     </dl>
   );
 }
@@ -856,6 +858,7 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
 // Read-only chip list of the user's assigned custom roles. Renders nothing
 // when there are no custom roles so the summary stays compact.
 function CustomRolesReadRow({ userId }: { userId?: number }) {
+  const { t } = useTranslation();
   // Only viewers with roles:view / roles:manage can read a user's custom-role
   // assignments. Without this gate the query fired for every profile viewer
   // (e.g. an employee on their own profile) and 403'd on /roles/users/:id.
@@ -870,7 +873,7 @@ function CustomRolesReadRow({ userId }: { userId?: number }) {
   if (!Array.isArray(data) || data.length === 0) return null;
   return (
     <div className="grid grid-cols-3 gap-x-4 py-2 border-b border-gray-100">
-      <dt className="text-sm font-medium text-gray-500 col-span-1">Custom Roles</dt>
+      <dt className="text-sm font-medium text-gray-500 col-span-1">{t("employeeProfile.field.customRoles")}</dt>
       <dd className="text-sm text-gray-900 col-span-2 flex flex-wrap gap-1.5">
         {data.map((r: any) => (
           <span
@@ -891,6 +894,7 @@ function CustomRolesReadRow({ userId }: { userId?: number }) {
 // `managers` array enriched server-side so we don't depend on a paginated
 // /users list to look up names.
 function AdditionalManagersReadRow({ userId }: { userId?: number }) {
+  const { t } = useTranslation();
   const { data } = useQuery({
     queryKey: ["employee-additional-managers", userId],
     queryFn: () =>
@@ -902,7 +906,7 @@ function AdditionalManagersReadRow({ userId }: { userId?: number }) {
   if (managers.length === 0) return null;
   return (
     <div className="grid grid-cols-3 gap-x-4 py-2 border-b border-gray-100">
-      <dt className="text-sm font-medium text-gray-500 col-span-1">Additional Managers</dt>
+      <dt className="text-sm font-medium text-gray-500 col-span-1">{t("employeeProfile.field.additionalManagers")}</dt>
       <dd className="text-sm text-gray-900 col-span-2 flex flex-wrap gap-1.5">
         {managers.map((u) => (
           <span
@@ -952,6 +956,7 @@ function AdditionalManagersField({
   primaryManagerId: number | null;
   canEdit: boolean;
 }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery({
@@ -1038,13 +1043,13 @@ function AdditionalManagersField({
     return (
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-1">
-          Additional Managers
+          {t("employeeProfile.field.additionalManagers")}
         </label>
         <div className="min-h-[40px] flex flex-wrap items-center gap-1.5 border border-gray-200 rounded-md bg-gray-50 px-2 py-2">
           {isLoading ? (
-            <span className="text-sm text-gray-400">Loading…</span>
+            <span className="text-sm text-gray-400">{t("employeeProfile.additionalManagers.loading")}</span>
           ) : selected.length === 0 ? (
-            <span className="text-sm text-gray-400">No additional managers</span>
+            <span className="text-sm text-gray-400">{t("employeeProfile.additionalManagers.none")}</span>
           ) : (
             selected.map((id) => {
               const u = usersById.get(id);
@@ -1057,7 +1062,7 @@ function AdditionalManagersField({
                     {(u?.first_name?.[0] || "?")}{(u?.last_name?.[0] || "")}
                   </span>
                   <span className="truncate max-w-[160px]">
-                    {u ? `${u.first_name} ${u.last_name}` : `User #${id}`}
+                    {u ? `${u.first_name} ${u.last_name}` : t("employeeProfile.additionalManagers.userFallback", { id })}
                   </span>
                 </span>
               );
@@ -1072,16 +1077,15 @@ function AdditionalManagersField({
   return (
     <div ref={containerRef}>
       <label className="block text-sm font-medium text-gray-700 mb-1">
-        Additional Managers
+        {t("employeeProfile.field.additionalManagers")}
         {selected.length > 0 && (
           <span className="ml-2 text-xs font-normal text-gray-400">
-            ({selected.length} selected)
+            {t("employeeProfile.additionalManagers.selectedCount", { count: selected.length })}
           </span>
         )}
       </label>
       <p className="text-xs text-gray-500 mb-2">
-        Co-managers with the same team-scope access as the primary Reporting
-        Manager. Honoured by every team-scoped permission.
+        {t("employeeProfile.additionalManagers.helpText")}
       </p>
 
       {/* Selected-chips + search input wrapper */}
@@ -1101,13 +1105,13 @@ function AdditionalManagersField({
                   {(u?.first_name?.[0] || "?")}{(u?.last_name?.[0] || "")}
                 </span>
                 <span className="truncate max-w-[160px]">
-                  {u ? `${u.first_name} ${u.last_name}` : `User #${id}`}
+                  {u ? `${u.first_name} ${u.last_name}` : t("employeeProfile.additionalManagers.userFallback", { id })}
                 </span>
                 <button
                   type="button"
                   onClick={(e) => { e.stopPropagation(); remove(id); }}
                   className="ml-0.5 h-4 w-4 flex items-center justify-center rounded-full hover:bg-brand-200"
-                  aria-label={`Remove ${u ? `${u.first_name} ${u.last_name}` : "manager"}`}
+                  aria-label={t("employeeProfile.additionalManagers.removeAria", { name: u ? `${u.first_name} ${u.last_name}` : t("employeeProfile.additionalManagers.removeAriaFallback") })}
                 >
                   <X className="h-3 w-3" />
                 </button>
@@ -1119,7 +1123,7 @@ function AdditionalManagersField({
             value={query}
             onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
             onFocus={() => setOpen(true)}
-            placeholder={selected.length === 0 ? "Search by name or email…" : "Add another…"}
+            placeholder={selected.length === 0 ? t("employeeProfile.additionalManagers.searchPlaceholder") : t("employeeProfile.additionalManagers.addPlaceholder")}
             className="flex-1 min-w-[140px] outline-none text-sm py-0.5 bg-transparent"
           />
         </div>
@@ -1129,7 +1133,7 @@ function AdditionalManagersField({
           <div className="absolute left-0 right-0 top-full mt-1 z-20 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-y-auto">
             {filtered.length === 0 ? (
               <div className="px-3 py-2 text-sm text-gray-400">
-                {query ? "No matching users" : "All eligible users already selected"}
+                {query ? t("employeeProfile.additionalManagers.noMatches") : t("employeeProfile.additionalManagers.allSelected")}
               </div>
             ) : (
               filtered.map((u: any) => (
@@ -1168,16 +1172,16 @@ function AdditionalManagersField({
           disabled={!dirty || mutation.isPending}
           className="px-3 py-1.5 text-sm font-medium text-white bg-brand-600 rounded-md hover:bg-brand-700 disabled:opacity-50"
         >
-          {mutation.isPending ? "Saving…" : "Save additional managers"}
+          {mutation.isPending ? t("employeeProfile.additionalManagers.savingButton") : t("employeeProfile.additionalManagers.saveButton")}
         </button>
         {dirty && !mutation.isPending && (
-          <span className="text-xs text-amber-600">unsaved changes</span>
+          <span className="text-xs text-amber-600">{t("employeeProfile.additionalManagers.unsavedChanges")}</span>
         )}
         {mutation.isSuccess && !dirty && (
-          <span className="text-xs text-green-600">Saved</span>
+          <span className="text-xs text-green-600">{t("employeeProfile.additionalManagers.saved")}</span>
         )}
         {mutation.isError && (
-          <span className="text-xs text-red-600">{extractApiError(mutation.error)}</span>
+          <span className="text-xs text-red-600">{extractApiError(mutation.error, t("employeeProfile.apiError.requestFailed"))}</span>
         )}
       </div>
     </div>
@@ -1185,7 +1189,9 @@ function AdditionalManagersField({
 }
 
 
-function extractApiError(err: any): string {
+// `fallback` lets the caller pass a translated last-resort message
+// (t("employeeProfile.apiError.requestFailed")) without making this helper a hook.
+function extractApiError(err: any, fallback = "Request failed"): string {
   const resp = err?.response?.data?.error;
   const details: any[] = Array.isArray(resp?.details) ? resp.details : [];
   if (details.length > 0) {
@@ -1194,7 +1200,7 @@ function extractApiError(err: any): string {
       .filter(Boolean)
       .join("; ");
   }
-  return resp?.message || err?.message || "Request failed";
+  return resp?.message || err?.message || fallback;
 }
 
 // ---------------------------------------------------------------------------
@@ -1202,6 +1208,7 @@ function extractApiError(err: any): string {
 // ---------------------------------------------------------------------------
 
 function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number; canEdit: boolean }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -1227,20 +1234,20 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
   const createMutation = useMutation({
     mutationFn: (payload: any) => api.post(`/employees/${userId}/education`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, payload }: { id: number; payload: any }) =>
       api.put(`/employees/${userId}/education/${id}`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => api.delete(`/employees/${userId}/education/${id}`),
     onSuccess: () => { invalidate(); setDeleteId(null); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   function resetForm() {
@@ -1275,7 +1282,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
     setError(null);
     const payload = buildPayload();
     if (!payload.degree || !payload.institution) {
-      setError("Degree and Institution are required");
+      setError(t("employeeProfile.education.validation.required"));
       return;
     }
     // #1405 — end year must not be before start year
@@ -1284,7 +1291,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
       payload.end_year != null &&
       payload.end_year < payload.start_year
     ) {
-      setError("End year must be on or after start year");
+      setError(t("employeeProfile.education.validation.endYear"));
       return;
     }
     if (editingId) updateMutation.mutate({ id: editingId, payload });
@@ -1306,7 +1313,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
             onClick={startAdd}
             className="flex items-center gap-1.5 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700"
           >
-            <Plus className="h-4 w-4" /> Add Education
+            <Plus className="h-4 w-4" /> {t("employeeProfile.education.add")}
           </button>
         </div>
       )}
@@ -1314,30 +1321,30 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
       {showForm && (
         <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50">
           <h4 className="text-sm font-semibold text-gray-700 mb-3">
-            {editingId ? "Edit Education" : "Add Education"}
+            {editingId ? t("employeeProfile.education.edit") : t("employeeProfile.education.add")}
           </h4>
           <SubResourceError error={error} />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Degree *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.education.field.degree")} *</label>
               <input
                 value={form.degree || ""}
                 onChange={(e) => setForm({ ...form, degree: e.target.value })}
                 className={subInputClass}
-                placeholder="e.g. B.Tech"
+                placeholder={t("employeeProfile.education.placeholder.degree")}
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Institution *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.education.field.institution")} *</label>
               <input
                 value={form.institution || ""}
                 onChange={(e) => setForm({ ...form, institution: e.target.value })}
                 className={subInputClass}
-                placeholder="e.g. IIT Delhi"
+                placeholder={t("employeeProfile.education.placeholder.institution")}
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Field of Study</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.education.field.fieldOfStudy")}</label>
               <input
                 value={form.field_of_study || ""}
                 onChange={(e) => setForm({ ...form, field_of_study: e.target.value })}
@@ -1345,7 +1352,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Grade</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.education.field.grade")}</label>
               <input
                 value={form.grade || ""}
                 onChange={(e) => setForm({ ...form, grade: e.target.value })}
@@ -1353,7 +1360,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Start Year</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.education.field.startYear")}</label>
               <input
                 type="number"
                 value={form.start_year || ""}
@@ -1362,7 +1369,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">End Year</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.education.field.endYear")}</label>
               <input
                 type="number"
                 value={form.end_year || ""}
@@ -1377,20 +1384,20 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               disabled={saving}
               className="flex items-center gap-1 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700 disabled:opacity-50"
             >
-              <Check className="h-3.5 w-3.5" /> {saving ? "Saving..." : "Save"}
+              <Check className="h-3.5 w-3.5" /> {saving ? t("employeeProfile.saving") : t("employeeProfile.save")}
             </button>
             <button
               onClick={resetForm}
               className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5"
             >
-              <X className="h-3.5 w-3.5" /> Cancel
+              <X className="h-3.5 w-3.5" /> {t("employeeProfile.cancel")}
             </button>
           </div>
         </div>
       )}
 
       {!data || data.length === 0 ? (
-        !showForm && <p className="text-sm text-gray-400">No education records added yet.</p>
+        !showForm && <p className="text-sm text-gray-400">{t("employeeProfile.education.empty")}</p>
       ) : (
         <div className="space-y-4">
           {data.map((edu: any) => (
@@ -1405,9 +1412,9 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
                   {edu.start_year && edu.end_year
                     ? `${edu.start_year} - ${edu.end_year}`
                     : edu.start_year
-                    ? `From ${edu.start_year}`
+                    ? t("employeeProfile.education.fromYear", { year: edu.start_year })
                     : ""}
-                  {edu.grade ? ` | Grade: ${edu.grade}` : ""}
+                  {edu.grade ? ` | ${t("employeeProfile.education.gradeSuffix", { grade: edu.grade })}` : ""}
                 </p>
               </div>
               {canEdit && (
@@ -1415,14 +1422,14 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
                   <button
                     onClick={() => startEdit(edu)}
                     className="p-1.5 text-gray-400 hover:text-brand-600 rounded hover:bg-gray-100"
-                    title="Edit"
+                    title={t("employeeProfile.edit")}
                   >
                     <Pencil className="h-4 w-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(edu.id)}
                     className="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100"
-                    title="Delete"
+                    title={t("employeeProfile.delete")}
                   >
                     <Trash2 className="h-4 w-4" />
                   </button>
@@ -1435,8 +1442,8 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
 
       <ConfirmDialog
         open={deleteId !== null}
-        title="Delete this education record?"
-        confirmText="Delete"
+        title={t("employeeProfile.education.deleteDialog.title")}
+        confirmText={t("employeeProfile.delete")}
         variant="danger"
         loading={deleteMutation.isPending}
         onConfirm={() => deleteId !== null && deleteMutation.mutate(deleteId)}
@@ -1451,6 +1458,7 @@ function EducationTab({ data, userId, canEdit }: { data?: any[]; userId: number;
 // ---------------------------------------------------------------------------
 
 function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number; canEdit: boolean }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -1483,20 +1491,20 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
   const createMutation = useMutation({
     mutationFn: (payload: any) => api.post(`/employees/${userId}/experience`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, payload }: { id: number; payload: any }) =>
       api.put(`/employees/${userId}/experience/${id}`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => api.delete(`/employees/${userId}/experience/${id}`),
     onSuccess: () => { invalidate(); setDeleteId(null); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   function resetForm() {
@@ -1528,7 +1536,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
   function handleSave() {
     setError(null);
     if (!form.company_name.trim() || !form.designation.trim() || !form.start_date) {
-      setError("Company, Designation and Start Date are required");
+      setError(t("employeeProfile.experience.validation.required"));
       return;
     }
     const payload = buildPayload();
@@ -1551,7 +1559,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
             onClick={startAdd}
             className="flex items-center gap-1.5 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700"
           >
-            <Plus className="h-4 w-4" /> Add Experience
+            <Plus className="h-4 w-4" /> {t("employeeProfile.experience.add")}
           </button>
         </div>
       )}
@@ -1559,12 +1567,12 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
       {showForm && (
         <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50">
           <h4 className="text-sm font-semibold text-gray-700 mb-3">
-            {editingId ? "Edit Experience" : "Add Experience"}
+            {editingId ? t("employeeProfile.experience.edit") : t("employeeProfile.experience.add")}
           </h4>
           <SubResourceError error={error} />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Company *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.experience.field.company")} *</label>
               <input
                 value={form.company_name}
                 onChange={(e) => setForm({ ...form, company_name: e.target.value })}
@@ -1572,7 +1580,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Designation *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.experience.field.designation")} *</label>
               <input
                 value={form.designation}
                 onChange={(e) => setForm({ ...form, designation: e.target.value })}
@@ -1580,7 +1588,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Start Date *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.experience.field.startDate")} *</label>
               <input
                 type="date"
                 value={form.start_date}
@@ -1589,7 +1597,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">End Date</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.experience.field.endDate")}</label>
               <input
                 type="date"
                 value={form.end_date}
@@ -1606,11 +1614,11 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
                   onChange={(e) => setForm({ ...form, is_current: e.target.checked })}
                   className="rounded border-gray-300 text-brand-600"
                 />
-                Currently working here
+                {t("employeeProfile.experience.currentlyWorking")}
               </label>
             </div>
             <div className="md:col-span-2">
-              <label className="block text-xs font-medium text-gray-600 mb-1">Description</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.experience.field.description")}</label>
               <textarea
                 rows={3}
                 value={form.description}
@@ -1625,20 +1633,20 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
               disabled={saving}
               className="flex items-center gap-1 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700 disabled:opacity-50"
             >
-              <Check className="h-3.5 w-3.5" /> {saving ? "Saving..." : "Save"}
+              <Check className="h-3.5 w-3.5" /> {saving ? t("employeeProfile.saving") : t("employeeProfile.save")}
             </button>
             <button
               onClick={resetForm}
               className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5"
             >
-              <X className="h-3.5 w-3.5" /> Cancel
+              <X className="h-3.5 w-3.5" /> {t("employeeProfile.cancel")}
             </button>
           </div>
         </div>
       )}
 
       {!data || data.length === 0 ? (
-        !showForm && <p className="text-sm text-gray-400">No work experience records added yet.</p>
+        !showForm && <p className="text-sm text-gray-400">{t("employeeProfile.experience.empty")}</p>
       ) : (
         <div className="space-y-4">
           {data.map((exp: any) => (
@@ -1649,7 +1657,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
                     <h3 className="text-sm font-semibold text-gray-900">{exp.designation}</h3>
                     {exp.is_current && (
                       <span className="text-xs bg-green-50 text-green-700 px-2 py-0.5 rounded-full font-medium">
-                        Current
+                        {t("employeeProfile.experience.current")}
                       </span>
                     )}
                   </div>
@@ -1657,7 +1665,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
                   <p className="text-xs text-gray-400 mt-1">
                     {exp.start_date ? new Date(exp.start_date).toLocaleDateString() : ""} -{" "}
                     {exp.is_current
-                      ? "Present"
+                      ? t("employeeProfile.experience.present")
                       : exp.end_date
                       ? new Date(exp.end_date).toLocaleDateString()
                       : ""}
@@ -1671,14 +1679,14 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
                     <button
                       onClick={() => startEdit(exp)}
                       className="p-1.5 text-gray-400 hover:text-brand-600 rounded hover:bg-gray-100"
-                      title="Edit"
+                      title={t("employeeProfile.edit")}
                     >
                       <Pencil className="h-4 w-4" />
                     </button>
                     <button
                       onClick={() => handleDelete(exp.id)}
                       className="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100"
-                      title="Delete"
+                      title={t("employeeProfile.delete")}
                     >
                       <Trash2 className="h-4 w-4" />
                     </button>
@@ -1692,8 +1700,8 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
 
       <ConfirmDialog
         open={deleteId !== null}
-        title="Delete this experience record?"
-        confirmText="Delete"
+        title={t("employeeProfile.experience.deleteDialog.title")}
+        confirmText={t("employeeProfile.delete")}
         variant="danger"
         loading={deleteMutation.isPending}
         onConfirm={() => deleteId !== null && deleteMutation.mutate(deleteId)}
@@ -1708,6 +1716,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
 // ---------------------------------------------------------------------------
 
 function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number; canEdit: boolean }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -1743,20 +1752,20 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
   const createMutation = useMutation({
     mutationFn: (payload: any) => api.post(`/employees/${userId}/dependents`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, payload }: { id: number; payload: any }) =>
       api.put(`/employees/${userId}/dependents/${id}`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => api.delete(`/employees/${userId}/dependents/${id}`),
     onSuccess: () => { invalidate(); setDeleteId(null); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   function resetForm() {
@@ -1788,7 +1797,7 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
   function handleSave() {
     setError(null);
     if (!form.name.trim() || !form.relationship.trim()) {
-      setError("Name and Relationship are required");
+      setError(t("employeeProfile.dependents.validation.required"));
       return;
     }
     const payload = buildPayload();
@@ -1811,7 +1820,7 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
             onClick={startAdd}
             className="flex items-center gap-1.5 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700"
           >
-            <Plus className="h-4 w-4" /> Add Dependent
+            <Plus className="h-4 w-4" /> {t("employeeProfile.dependents.add")}
           </button>
         </div>
       )}
@@ -1819,12 +1828,12 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
       {showForm && (
         <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50">
           <h4 className="text-sm font-semibold text-gray-700 mb-3">
-            {editingId ? "Edit Dependent" : "Add Dependent"}
+            {editingId ? t("employeeProfile.dependents.edit") : t("employeeProfile.dependents.add")}
           </h4>
           <SubResourceError error={error} />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Name *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.dependents.field.name")} *</label>
               <input
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -1832,16 +1841,16 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Relationship *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.dependents.field.relationship")} *</label>
               <input
                 value={form.relationship}
                 onChange={(e) => setForm({ ...form, relationship: e.target.value })}
-                placeholder="e.g. Spouse, Child, Parent"
+                placeholder={t("employeeProfile.dependents.placeholder.relationship")}
                 className={subInputClass}
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Date of Birth</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.dependents.field.dateOfBirth")}</label>
               {/* #1406 — DOB cannot be in the future */}
               <input
                 type="date"
@@ -1852,16 +1861,16 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Gender</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.dependents.field.gender")}</label>
               <select
                 value={form.gender}
                 onChange={(e) => setForm({ ...form, gender: e.target.value })}
                 className={subInputClass}
               >
-                <option value="">Select</option>
-                <option value="male">Male</option>
-                <option value="female">Female</option>
-                <option value="other">Other</option>
+                <option value="">{t("employeeProfile.select.placeholder")}</option>
+                <option value="male">{t("employeeProfile.gender.male")}</option>
+                <option value="female">{t("employeeProfile.gender.female")}</option>
+                <option value="other">{t("employeeProfile.gender.other")}</option>
               </select>
             </div>
             <div>
@@ -1872,12 +1881,12 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
                   onChange={(e) => setForm({ ...form, is_nominee: e.target.checked })}
                   className="rounded border-gray-300 text-brand-600"
                 />
-                Is Nominee
+                {t("employeeProfile.dependents.isNominee")}
               </label>
             </div>
             {form.is_nominee && (
               <div>
-                <label className="block text-xs font-medium text-gray-600 mb-1">Nominee %</label>
+                <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.dependents.field.nomineePercent")}</label>
                 <input
                   type="number"
                   min={0}
@@ -1895,31 +1904,31 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
               disabled={saving}
               className="flex items-center gap-1 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700 disabled:opacity-50"
             >
-              <Check className="h-3.5 w-3.5" /> {saving ? "Saving..." : "Save"}
+              <Check className="h-3.5 w-3.5" /> {saving ? t("employeeProfile.saving") : t("employeeProfile.save")}
             </button>
             <button
               onClick={resetForm}
               className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5"
             >
-              <X className="h-3.5 w-3.5" /> Cancel
+              <X className="h-3.5 w-3.5" /> {t("employeeProfile.cancel")}
             </button>
           </div>
         </div>
       )}
 
       {!data || data.length === 0 ? (
-        !showForm && <p className="text-sm text-gray-400">No dependents added yet.</p>
+        !showForm && <p className="text-sm text-gray-400">{t("employeeProfile.dependents.empty")}</p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead className="bg-gray-50">
               <tr>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">Name</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">Relationship</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">DOB</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">Gender</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">Nominee</th>
-                {canEdit && <th className="text-right text-xs font-medium text-gray-500 uppercase px-4 py-2">Actions</th>}
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">{t("employeeProfile.dependents.column.name")}</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">{t("employeeProfile.dependents.column.relationship")}</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">{t("employeeProfile.dependents.column.dob")}</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">{t("employeeProfile.dependents.column.gender")}</th>
+                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-2">{t("employeeProfile.dependents.column.nominee")}</th>
+                {canEdit && <th className="text-right text-xs font-medium text-gray-500 uppercase px-4 py-2">{t("employeeProfile.dependents.column.actions")}</th>}
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
@@ -1928,16 +1937,16 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
                   <td className="px-4 py-3 text-sm text-gray-900">{dep.name}</td>
                   <td className="px-4 py-3 text-sm text-gray-500">{dep.relationship}</td>
                   <td className="px-4 py-3 text-sm text-gray-500">
-                    {dep.date_of_birth ? new Date(dep.date_of_birth).toLocaleDateString() : "-"}
+                    {dep.date_of_birth ? new Date(dep.date_of_birth).toLocaleDateString() : t("employeeProfile.fieldRow.empty")}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500 capitalize">{dep.gender || "-"}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500 capitalize">{dep.gender || t("employeeProfile.fieldRow.empty")}</td>
                   <td className="px-4 py-3 text-sm">
                     {dep.is_nominee ? (
                       <span className="text-green-700 font-medium">
-                        Yes {dep.nominee_percentage ? `(${dep.nominee_percentage}%)` : ""}
+                        {t("employeeProfile.dependents.nomineeYes")} {dep.nominee_percentage ? `(${dep.nominee_percentage}%)` : ""}
                       </span>
                     ) : (
-                      <span className="text-gray-400">No</span>
+                      <span className="text-gray-400">{t("employeeProfile.dependents.nomineeNo")}</span>
                     )}
                   </td>
                   {canEdit && (
@@ -1946,14 +1955,14 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
                         <button
                           onClick={() => startEdit(dep)}
                           className="p-1.5 text-gray-400 hover:text-brand-600 rounded hover:bg-gray-100"
-                          title="Edit"
+                          title={t("employeeProfile.edit")}
                         >
                           <Pencil className="h-4 w-4" />
                         </button>
                         <button
                           onClick={() => handleDelete(dep.id)}
                           className="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100"
-                          title="Delete"
+                          title={t("employeeProfile.delete")}
                         >
                           <Trash2 className="h-4 w-4" />
                         </button>
@@ -1969,8 +1978,8 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
 
       <ConfirmDialog
         open={deleteId !== null}
-        title="Delete this dependent?"
-        confirmText="Delete"
+        title={t("employeeProfile.dependents.deleteDialog.title")}
+        confirmText={t("employeeProfile.delete")}
         variant="danger"
         loading={deleteMutation.isPending}
         onConfirm={() => deleteId !== null && deleteMutation.mutate(deleteId)}
@@ -1985,6 +1994,7 @@ function DependentsTab({ data, userId, canEdit }: { data?: any[]; userId: number
 // ---------------------------------------------------------------------------
 
 function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number; canEdit: boolean }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -2019,20 +2029,20 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
   const createMutation = useMutation({
     mutationFn: (payload: any) => api.post(`/employees/${userId}/addresses`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const updateMutation = useMutation({
     mutationFn: ({ id, payload }: { id: number; payload: any }) =>
       api.put(`/employees/${userId}/addresses/${id}`, payload),
     onSuccess: () => { invalidate(); resetForm(); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => api.delete(`/employees/${userId}/addresses/${id}`),
     onSuccess: () => { invalidate(); setDeleteId(null); },
-    onError: (err: any) => setError(extractApiError(err)),
+    onError: (err: any) => setError(extractApiError(err, t("employeeProfile.apiError.requestFailed"))),
   });
 
   function resetForm() {
@@ -2065,7 +2075,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
   function handleSave() {
     setError(null);
     if (!form.line1.trim() || !form.city.trim() || !form.state.trim() || !form.zipcode.trim()) {
-      setError("Address line 1, City, State and Zipcode are required");
+      setError(t("employeeProfile.addresses.validation.required"));
       return;
     }
     const payload = buildPayload();
@@ -2088,7 +2098,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
             onClick={startAdd}
             className="flex items-center gap-1.5 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700"
           >
-            <Plus className="h-4 w-4" /> Add Address
+            <Plus className="h-4 w-4" /> {t("employeeProfile.addresses.add")}
           </button>
         </div>
       )}
@@ -2096,23 +2106,23 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
       {showForm && (
         <div className="border border-gray-200 rounded-lg p-4 mb-4 bg-gray-50">
           <h4 className="text-sm font-semibold text-gray-700 mb-3">
-            {editingId ? "Edit Address" : "Add Address"}
+            {editingId ? t("employeeProfile.addresses.edit") : t("employeeProfile.addresses.add")}
           </h4>
           <SubResourceError error={error} />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Type *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.type")} *</label>
               <select
                 value={form.type}
                 onChange={(e) => setForm({ ...form, type: e.target.value })}
                 className={subInputClass}
               >
-                <option value="current">Current</option>
-                <option value="permanent">Permanent</option>
+                <option value="current">{t("employeeProfile.addresses.type.current")}</option>
+                <option value="permanent">{t("employeeProfile.addresses.type.permanent")}</option>
               </select>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Country</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.country")}</label>
               <input
                 value={form.country}
                 onChange={(e) => setForm({ ...form, country: e.target.value })}
@@ -2120,7 +2130,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div className="md:col-span-2">
-              <label className="block text-xs font-medium text-gray-600 mb-1">Address Line 1 *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.line1")} *</label>
               <input
                 value={form.line1}
                 onChange={(e) => setForm({ ...form, line1: e.target.value })}
@@ -2128,7 +2138,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div className="md:col-span-2">
-              <label className="block text-xs font-medium text-gray-600 mb-1">Address Line 2</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.line2")}</label>
               <input
                 value={form.line2}
                 onChange={(e) => setForm({ ...form, line2: e.target.value })}
@@ -2136,7 +2146,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">City *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.city")} *</label>
               <input
                 value={form.city}
                 onChange={(e) => setForm({ ...form, city: e.target.value })}
@@ -2144,7 +2154,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">State *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.state")} *</label>
               <input
                 value={form.state}
                 onChange={(e) => setForm({ ...form, state: e.target.value })}
@@ -2152,7 +2162,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Zipcode *</label>
+              <label className="block text-xs font-medium text-gray-600 mb-1">{t("employeeProfile.addresses.field.zipcode")} *</label>
               {/* #1407 — zipcode must be digits only */}
               <input
                 inputMode="numeric"
@@ -2169,27 +2179,27 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
               disabled={saving}
               className="flex items-center gap-1 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700 disabled:opacity-50"
             >
-              <Check className="h-3.5 w-3.5" /> {saving ? "Saving..." : "Save"}
+              <Check className="h-3.5 w-3.5" /> {saving ? t("employeeProfile.saving") : t("employeeProfile.save")}
             </button>
             <button
               onClick={resetForm}
               className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5"
             >
-              <X className="h-3.5 w-3.5" /> Cancel
+              <X className="h-3.5 w-3.5" /> {t("employeeProfile.cancel")}
             </button>
           </div>
         </div>
       )}
 
       {!data || data.length === 0 ? (
-        !showForm && <p className="text-sm text-gray-400">No addresses added yet.</p>
+        !showForm && <p className="text-sm text-gray-400">{t("employeeProfile.addresses.empty")}</p>
       ) : (
         <div className="space-y-4">
           {data.map((addr: any) => (
             <div key={addr.id} className="border border-gray-100 rounded-lg p-4 flex items-start justify-between">
               <div className="flex-1">
                 <span className="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-medium uppercase mb-2 inline-block">
-                  {addr.type}
+                  {t(`employeeProfile.addresses.type.${addr.type}`, { defaultValue: addr.type })}
                 </span>
                 <p className="text-sm text-gray-900">{addr.line1}</p>
                 {addr.line2 && <p className="text-sm text-gray-600">{addr.line2}</p>}
@@ -2203,14 +2213,14 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
                   <button
                     onClick={() => startEdit(addr)}
                     className="p-1.5 text-gray-400 hover:text-brand-600 rounded hover:bg-gray-100"
-                    title="Edit"
+                    title={t("employeeProfile.edit")}
                   >
                     <Pencil className="h-4 w-4" />
                   </button>
                   <button
                     onClick={() => handleDelete(addr.id)}
                     className="p-1.5 text-gray-400 hover:text-red-600 rounded hover:bg-gray-100"
-                    title="Delete"
+                    title={t("employeeProfile.delete")}
                   >
                     <Trash2 className="h-4 w-4" />
                   </button>
@@ -2223,8 +2233,8 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
 
       <ConfirmDialog
         open={deleteId !== null}
-        title="Delete this address?"
-        confirmText="Delete"
+        title={t("employeeProfile.addresses.deleteDialog.title")}
+        confirmText={t("employeeProfile.delete")}
         variant="danger"
         loading={deleteMutation.isPending}
         onConfirm={() => deleteId !== null && deleteMutation.mutate(deleteId)}
@@ -2264,6 +2274,7 @@ type FieldDef = {
 };
 
 function CustomFieldsTab({ entityId }: { entityId: number }) {
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [formValues, setFormValues] = useState<Record<number, unknown>>({});
@@ -2299,7 +2310,7 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
       setError(null);
     },
     onError: (err: any) => {
-      setError(err.response?.data?.error?.message || "Failed to save custom fields");
+      setError(err.response?.data?.error?.message || t("employeeProfile.customFields.saveFailed"));
     },
   });
 
@@ -2324,17 +2335,17 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
   }
 
   if (isLoading) {
-    return <p className="text-sm text-gray-400">Loading custom fields...</p>;
+    return <p className="text-sm text-gray-400">{t("employeeProfile.customFields.loading")}</p>;
   }
 
   if (definitions.length === 0) {
     return (
       <div className="text-center py-6">
         <p className="text-sm text-gray-400">
-          No custom fields have been defined for employees yet.
+          {t("employeeProfile.customFields.emptyTitle")}
         </p>
         <p className="text-xs text-gray-400 mt-1">
-          HR administrators can create custom fields from the Custom Fields settings page.
+          {t("employeeProfile.customFields.emptyHint")}
         </p>
       </div>
     );
@@ -2343,7 +2354,7 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
   // Group definitions by section
   const sections: Record<string, FieldDef[]> = {};
   for (const def of definitions) {
-    const sec = def.section || "Custom Fields";
+    const sec = def.section || t("employeeProfile.customFields.defaultSection");
     if (!sections[sec]) sections[sec] = [];
     sections[sec].push(def);
   }
@@ -2357,14 +2368,14 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-semibold text-gray-700">Custom Fields</h3>
+        <h3 className="text-sm font-semibold text-gray-700">{t("employeeProfile.customFields.heading")}</h3>
         {!editing ? (
           <button
             onClick={startEditing}
             className="flex items-center gap-1 text-sm text-brand-600 hover:text-brand-700"
           >
             <Pencil className="h-3.5 w-3.5" />
-            Edit
+            {t("employeeProfile.edit")}
           </button>
         ) : (
           <div className="flex items-center gap-2">
@@ -2374,7 +2385,7 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
               className="flex items-center gap-1 text-sm bg-brand-600 text-white px-3 py-1.5 rounded-lg hover:bg-brand-700 disabled:opacity-50"
             >
               <Check className="h-3.5 w-3.5" />
-              Save
+              {t("employeeProfile.save")}
             </button>
             <button
               onClick={() => {
@@ -2384,7 +2395,7 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
               className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 px-3 py-1.5"
             >
               <X className="h-3.5 w-3.5" />
-              Cancel
+              {t("employeeProfile.cancel")}
             </button>
           </div>
         )}
@@ -2430,11 +2441,12 @@ function CustomFieldsTab({ entityId }: { entityId: number }) {
 }
 
 function CustomFieldDisplay({ def, value }: { def: FieldDef; value: unknown }) {
-  let displayValue: string = "-";
+  const { t } = useTranslation();
+  let displayValue: string = t("employeeProfile.fieldRow.empty");
 
   if (value !== null && value !== undefined && value !== "") {
     if (def.field_type === "checkbox") {
-      displayValue = value ? "Yes" : "No";
+      displayValue = value ? t("employeeProfile.customFields.display.yes") : t("employeeProfile.customFields.display.no");
     } else if (def.field_type === "multi_select" && Array.isArray(value)) {
       displayValue = value.join(", ");
     } else if (def.field_type === "date" || def.field_type === "datetime") {
@@ -2468,6 +2480,7 @@ function CustomFieldEdit({
   value: unknown;
   onChange: (val: unknown) => void;
 }) {
+  const { t } = useTranslation();
   const inputClass =
     "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500";
 
@@ -2539,7 +2552,7 @@ function CustomFieldEdit({
           onChange={(e) => onChange(e.target.value || null)}
           className={inputClass}
         >
-          <option value="">Select...</option>
+          <option value="">{t("employeeProfile.customFields.selectPlaceholder")}</option>
           {(def.options || []).map((opt) => (
             <option key={opt} value={opt}>
               {opt}
@@ -2592,7 +2605,7 @@ function CustomFieldEdit({
           type="text"
           value={String(value ?? "")}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={def.placeholder || "File reference or path"}
+          placeholder={def.placeholder || t("employeeProfile.customFields.filePlaceholder")}
           className={inputClass}
         />
       );


### PR DESCRIPTION
## Summary
Fully localizes the **Employee Profile** page (`/employees/:id`) — a large (~2623-line) page with 13 rendering components and ~150 hardcoded English strings — under an `employeeProfile.*` namespace (179 keys). This was the largest single page in the un-translated backlog.

## What's translated (179 keys, all 9 locales)
- Page chrome: tab labels, the Invalid-Employee / Access-Denied / Not-Found states, "Back to Directory", photo controls + the remove-photo confirm dialog, Edit/Edit-My-Info, self-service notice
- **Personal tab**: every field label, the gender / marital-status option maps, the Indian ID-doc placeholders (PAN/Aadhaar/UAN/Passport), department/shift/manager "none" options
- **Additional Managers** picker: search, chips, the pluralized "(N selected)", help text, save states
- **Education / Experience / Dependents / Addresses** sub-resource tabs: add/edit forms, field labels, placeholders, validation messages, empty states, delete-confirm dialogs
- **Custom Fields** tab: display + edit
- The two module-level pure helpers were made hook-free but translatable: `validateIdDoc` now returns an i18n KEY (rendered via `t()` at the 4 ID-error sites), and `extractApiError` takes an optional translated `fallback` that all 14 call sites pass.

## How it was built (multi-agent)
A multi-agent workflow extracted the 179-key inventory, translated all 8 locales in parallel, and adversarially verified each — **28 issues caught and auto-fixed**. A static post-check found the extractor had left the count-based "(N selected)" string inconsistent across locales (DE produced `_one`/`_other`, others a single form, ES even crammed two forms with a `|`); I normalized it to proper i18next `_one`/`_other` plurals in every locale.

## Verification
- Renders fully in **all 8 non-English languages** — verified live via headless Chrome against `/employees/12`, 6/6 strings matched per language (tabs, gender, department, Edit Profile)
- German (the flagged locale) and Arabic (RTL, `dir=rtl`) confirmed
- **Zero** "returned an object" console errors
- 0 TypeScript errors; full key parity (179 keys) across all 9 locales

Branched off the latest `main`.