### PR TITLE
fix(positions): block headcount approval bypass via plain update

### DIFF
--- a/packages/server/src/services/position/position.service.ts
+++ b/packages/server/src/services/position/position.service.ts
@@ -550,6 +550,16 @@ export async function updateHeadcountPlan(
     throw new ValidationError("Cannot update an approved headcount plan");
   }
 
+  // Approval/rejection must go through the dedicated approve/reject endpoints, which
+  // set approved_headcount/approved_by and write audit logs. A plain update may only
+  // move a plan between draft and submitted (the Submit action PUTs status:"submitted");
+  // block it from jumping straight to approved/rejected, which would skip that workflow.
+  if (data.status && data.status !== "draft" && data.status !== "submitted") {
+    throw new ValidationError(
+      `Cannot set status "${data.status}" via update; use the approve or reject action instead`
+    );
+  }
+
   await db("headcount_plans")
     .where({ id: planId })
     .update({


### PR DESCRIPTION
updateHeadcountPlan accepted any status value, so a draft could be PUT straight to "approved" — skipping approveHeadcountPlan (which sets approved_headcount/approved_by and writes the audit log). Restrict status changes made through the update endpoint to draft/submitted (the Submit action legitimately PUTs status:"submitted"); approved and rejected must go through the dedicated approve/reject endpoints.