### PR TITLE
fix(positions): require positions:view permission on GET /positions/:id

### DIFF
--- a/packages/server/src/api/routes/position.routes.ts
+++ b/packages/server/src/api/routes/position.routes.ts
@@ -193,7 +193,7 @@ router.get("/", authenticate, requirePermission("positions:view", "positions:man
 });
 
 // GET /api/v1/positions/:id
-router.get("/:id", authenticate, async (req: Request, res: Response, next: NextFunction) => {
+router.get("/:id", authenticate, requirePermission("positions:view", "positions:manage"), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const position = await positionService.getPosition(req.user!.org_id, paramInt(req.params.id));
     sendSuccess(res, position);


### PR DESCRIPTION
The position detail route only ran `authenticate` while every sibling read route also requires positions:view/manage. Any authenticated user — including roles without position-view rights — could read a position's full detail, including salary bands and the assignee roster. Add the same requirePermission check used across the module.