### PR TITLE
feat(positions): add department/employment-type/critical filters to v…

### DIFF
--- a/packages/server/src/api/routes/position.routes.ts
+++ b/packages/server/src/api/routes/position.routes.ts
@@ -36,7 +36,12 @@ router.get("/dashboard", authenticate, requirePermission("positions:view", "posi
 // GET /api/v1/positions/vacancies — Open vacancies
 router.get("/vacancies", authenticate, requirePermission("positions:view", "positions:manage"), async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const vacancies = await positionService.getVacancies(req.user!.org_id);
+    const query = positionQuerySchema.parse(req.query);
+    const vacancies = await positionService.getVacancies(req.user!.org_id, {
+      department_id: query.department_id,
+      employment_type: query.employment_type,
+      is_critical: query.is_critical,
+    });
     sendSuccess(res, vacancies);
   } catch (err) { next(err); }
 });

--- a/packages/server/src/services/position/position.service.ts
+++ b/packages/server/src/services/position/position.service.ts
@@ -421,12 +421,31 @@ export async function getPositionHierarchy(orgId: number) {
 // Get Vacancies (positions where filled < budget)
 // ---------------------------------------------------------------------------
 
-export async function getVacancies(orgId: number) {
+export async function getVacancies(
+  orgId: number,
+  params?: {
+    department_id?: number;
+    employment_type?: string;
+    is_critical?: boolean;
+  }
+) {
   const db = getDB();
 
-  const vacancies = await db("positions")
+  let query = db("positions")
     .where({ "positions.organization_id": orgId, "positions.status": "active" })
-    .whereRaw("positions.headcount_filled < positions.headcount_budget")
+    .whereRaw("positions.headcount_filled < positions.headcount_budget");
+
+  if (params?.department_id) {
+    query = query.where({ "positions.department_id": params.department_id });
+  }
+  if (params?.employment_type) {
+    query = query.where({ "positions.employment_type": params.employment_type });
+  }
+  if (params?.is_critical !== undefined) {
+    query = query.where({ "positions.is_critical": params.is_critical });
+  }
+
+  const vacancies = await query
     .select(
       "positions.*",
       "organization_departments.name as department_name",


### PR DESCRIPTION
…acancies

GET /positions/vacancies returned every open role with no way to narrow it. Accept the department_id, employment_type and is_critical query filters (parsed from the existing positionQuerySchema) so recruiters and API consumers can scope the vacancy list. No pagination is added — vacancies is a small set the UI groups client-side.