### PR TITLE
feat(positions): add quarter filter to headcount plans list

### DIFF
--- a/packages/server/src/api/routes/position.routes.ts
+++ b/packages/server/src/api/routes/position.routes.ts
@@ -81,6 +81,7 @@ router.get("/headcount-plans", authenticate, requirePermission("positions:view",
       fiscal_year: query.fiscal_year,
       status: query.status,
       department_id: query.department_id,
+      quarter: query.quarter,
       search: query.search,
     });
     sendPaginated(res, result.plans, result.total, query.page, query.per_page);

--- a/packages/server/src/services/position/position.service.ts
+++ b/packages/server/src/services/position/position.service.ts
@@ -485,6 +485,7 @@ export async function listHeadcountPlans(
     fiscal_year?: string;
     status?: string;
     department_id?: number;
+    quarter?: string;
     search?: string;
   }
 ) {
@@ -503,6 +504,9 @@ export async function listHeadcountPlans(
   }
   if (params?.department_id) {
     query = query.where({ "headcount_plans.department_id": params.department_id });
+  }
+  if (params?.quarter) {
+    query = query.where({ "headcount_plans.quarter": params.quarter });
   }
   if (params?.search) {
     const s = `%${params.search}%`;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1254,6 +1254,7 @@ export const headcountPlanQuerySchema = paginationSchema.extend({
   fiscal_year: z.string().optional(),
   status: headcountPlanStatusEnum.optional(),
   department_id: z.coerce.number().int().positive().optional(),
+  quarter: headcountQuarterEnum.optional(),
   search: z.string().optional(),
 });
 


### PR DESCRIPTION
Headcount plans have a quarter (Q1-Q4/annual) but the list couldn't be filtered by it. Add an optional quarter to headcountPlanQuerySchema, filter on it in listHeadcountPlans, and pass it through the route — enabling drill-downs like 'FY2026 Q2 plans'.