### PR TITLE
feat(positions): add location filter to positions list

### DIFF
--- a/packages/server/src/api/routes/position.routes.ts
+++ b/packages/server/src/api/routes/position.routes.ts
@@ -184,6 +184,7 @@ router.get("/", authenticate, requirePermission("positions:view", "positions:man
       page: query.page,
       perPage: query.per_page,
       department_id: query.department_id,
+      location_id: query.location_id,
       status: query.status,
       employment_type: query.employment_type,
       search: query.search,

--- a/packages/server/src/services/position/position.service.ts
+++ b/packages/server/src/services/position/position.service.ts
@@ -105,6 +105,7 @@ export async function listPositions(
     page?: number;
     perPage?: number;
     department_id?: number;
+    location_id?: number;
     status?: string;
     employment_type?: string;
     search?: string;
@@ -123,6 +124,9 @@ export async function listPositions(
   }
   if (params?.department_id) {
     query = query.where({ "positions.department_id": params.department_id });
+  }
+  if (params?.location_id) {
+    query = query.where({ "positions.location_id": params.location_id });
   }
   if (params?.employment_type) {
     query = query.where({ "positions.employment_type": params.employment_type });

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1219,6 +1219,7 @@ export const assignPositionSchema = z.object({
 
 export const positionQuerySchema = paginationSchema.extend({
   department_id: z.coerce.number().int().positive().optional(),
+  location_id: z.coerce.number().int().positive().optional(),
   status: positionStatusEnum.optional(),
   employment_type: positionEmploymentTypeEnum.optional(),
   search: z.string().optional(),


### PR DESCRIPTION
Positions carry a location (already joined and shown as location_name), but the list couldn't be filtered by it. Add an optional location_id to positionQuerySchema, filter on it in listPositions, and pass it through the route so multi-site orgs can scope the list to one office/location.