### PR TITLE
fix(positions): validate assignment dates as dates and enforce ordering

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1210,12 +1210,17 @@ export const updatePositionSchema = createPositionSchema.partial().extend({
   status: positionStatusEnum.optional(),
 });
 
-export const assignPositionSchema = z.object({
-  user_id: z.number().int().positive(),
-  start_date: z.string(),
-  end_date: z.string().optional().nullable(),
-  is_primary: z.boolean().default(true),
-});
+export const assignPositionSchema = z
+  .object({
+    user_id: z.number().int().positive(),
+    start_date: z.string().date(),
+    end_date: z.string().date().optional().nullable(),
+    is_primary: z.boolean().default(true),
+  })
+  .refine((d) => !d.end_date || d.end_date >= d.start_date, {
+    message: "end_date must be on or after start_date",
+    path: ["end_date"],
+  });
 
 export const positionQuerySchema = paginationSchema.extend({
   department_id: z.coerce.number().int().positive().optional(),


### PR DESCRIPTION
assignPositionSchema accepted start_date/end_date as any string, so malformed or end-before-start ranges were saved verbatim. Validate both as YYYY-MM-DD dates (matching the date inputs the UI sends) and reject end_date earlier than start_date.