### PR TITLE
fix(positions): reject min_salary greater than max_salary

### DIFF
--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1190,7 +1190,10 @@ const positionStatusEnum = z.enum(["active", "filled", "frozen", "closed"]);
 const headcountPlanStatusEnum = z.enum(["draft", "submitted", "approved", "rejected"]);
 const headcountQuarterEnum = z.enum(["Q1", "Q2", "Q3", "Q4", "annual"]);
 
-export const createPositionSchema = z.object({
+// Base object shape shared by create/update. Kept as a plain ZodObject so
+// updatePositionSchema can still call .partial() on it — applying .refine() here
+// would turn it into a ZodEffects that no longer exposes .partial().
+const positionBaseSchema = z.object({
   title: z.string().min(1).max(200),
   code: z.preprocess((v) => (v === "" ? undefined : v), z.string().max(50).optional().nullable()),
   department_id: z.preprocess((v) => (v === "" || v === 0 ? null : v), z.number().int().positive().optional().nullable()),
@@ -1206,9 +1209,22 @@ export const createPositionSchema = z.object({
   is_critical: z.boolean().default(false),
 });
 
-export const updatePositionSchema = createPositionSchema.partial().extend({
-  status: positionStatusEnum.optional(),
+// max_salary must be >= min_salary when both are provided.
+const salaryOrderCheck = (d: { min_salary?: number | null; max_salary?: number | null }) =>
+  d.min_salary == null || d.max_salary == null || d.max_salary >= d.min_salary;
+
+export const createPositionSchema = positionBaseSchema.refine(salaryOrderCheck, {
+  message: "max_salary must be greater than or equal to min_salary",
+  path: ["max_salary"],
 });
+
+export const updatePositionSchema = positionBaseSchema
+  .partial()
+  .extend({ status: positionStatusEnum.optional() })
+  .refine(salaryOrderCheck, {
+    message: "max_salary must be greater than or equal to min_salary",
+    path: ["max_salary"],
+  });
 
 export const assignPositionSchema = z.object({
   user_id: z.number().int().positive(),


### PR DESCRIPTION
createPositionSchema allowed a position to be created (or updated) with min_salary above max_salary. Extract the shared object shape into positionBaseSchema so updatePositionSchema can still .partial() it, then add a refine on both create and update requiring max_salary >= min_salary when both are set.