### PR TITLE
feat(positions): add department and fiscal-year filters to headcount …

### DIFF
--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1688,6 +1688,8 @@
       "close": "Close",
       "failedCreate": "Failed to create plan",
       "allStatuses": "All Statuses",
+      "allDepartments": "All Departments",
+      "allYears": "All Years",
       "statusDraft": "Draft",
       "statusSubmitted": "Submitted",
       "statusApproved": "Approved",

--- a/packages/client/src/pages/positions/HeadcountPlanPage.tsx
+++ b/packages/client/src/pages/positions/HeadcountPlanPage.tsx
@@ -14,6 +14,8 @@ export default function HeadcountPlanPage() {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("");
+  const [departmentFilter, setDepartmentFilter] = useState<string>("");
+  const [fiscalYearFilter, setFiscalYearFilter] = useState<string>("");
   const [showCreate, setShowCreate] = useState(false);
   // #1548 — Detail modal: plans are clickable and open this full-detail view
   // so the notes, budget and all other fields captured at creation time are
@@ -29,7 +31,10 @@ export default function HeadcountPlanPage() {
   const deptList = departments || [];
 
   const { data, isLoading } = useQuery({
-    queryKey: ["headcount-plans", { page, status: statusFilter, search }],
+    queryKey: [
+      "headcount-plans",
+      { page, status: statusFilter, search, department_id: departmentFilter, fiscal_year: fiscalYearFilter },
+    ],
     queryFn: () =>
       api
         .get("/positions/headcount-plans", {
@@ -38,6 +43,8 @@ export default function HeadcountPlanPage() {
             per_page: 10,
             ...(statusFilter ? { status: statusFilter } : {}),
             ...(search ? { search } : {}),
+            ...(departmentFilter ? { department_id: departmentFilter } : {}),
+            ...(fiscalYearFilter ? { fiscal_year: fiscalYearFilter } : {}),
           },
         })
         .then((r) => r.data),
@@ -313,6 +320,26 @@ export default function HeadcountPlanPage() {
           <option value="submitted">{tx("statusSubmitted")}</option>
           <option value="approved">{tx("statusApproved")}</option>
           <option value="rejected">{tx("statusRejected")}</option>
+        </select>
+        <select
+          value={departmentFilter}
+          onChange={(e) => { setDepartmentFilter(e.target.value); setPage(1); }}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+        >
+          <option value="">{tx("allDepartments")}</option>
+          {deptList.map((d: any) => (
+            <option key={d.id} value={d.id}>{d.name}</option>
+          ))}
+        </select>
+        <select
+          value={fiscalYearFilter}
+          onChange={(e) => { setFiscalYearFilter(e.target.value); setPage(1); }}
+          className="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+        >
+          <option value="">{tx("allYears")}</option>
+          {fiscalYearOptions.map((y) => (
+            <option key={y} value={y}>{y}</option>
+          ))}
         </select>
       </div>
 


### PR DESCRIPTION
…plans page

The Headcount Plans page only filtered by status and search, though the backend already supports department_id and fiscal_year. Add Department and Fiscal Year dropdowns (reusing the departments the page already loads and the existing fiscalYearOptions), wire them into the query key + params, and reset to page 1 on change.