### PR TITLE
fix(positions): surface errors when inline status change fails

### DIFF
--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -87,6 +87,17 @@ export default function PositionDetailPage() {
       queryClient.invalidateQueries({ queryKey: ["position", id] });
       queryClient.invalidateQueries({ queryKey: ["positions"] });
     },
+    onError: (err: any) => {
+      // Without this the inline status <select> silently keeps the value the user
+      // picked even when the change was rejected, so it looks like it worked.
+      // The query invalidation on settle snaps it back to the true status.
+      const msg =
+        err?.response?.data?.error?.message ||
+        err?.response?.data?.message ||
+        "Failed to update position status.";
+      showToast("error", msg);
+      queryClient.invalidateQueries({ queryKey: ["position", id] });
+    },
   });
 
   // #1544 — surface server-side validation errors. The form was previously


### PR DESCRIPTION
updateStatusMutation had no onError, so a rejected status change failed silently and the dropdown kept showing the value the user picked instead of the real one. Add an error toast (matching the assign/update mutations) and invalidate the position query so the select snaps back to the true status.