### PR TITLE
fix(positions): refresh vacancies/list/dashboard after ending an assi…

### DIFF
--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -75,7 +75,13 @@ export default function PositionDetailPage() {
   const removeMutation = useMutation({
     mutationFn: (assignmentId: number) => api.delete(`/positions/assignments/${assignmentId}`),
     onSuccess: () => {
+      // Ending an assignment lowers headcount_filled and can reopen the position
+      // (filled -> active), so refresh the vacancies, list and dashboard views too —
+      // not just this position's detail.
       queryClient.invalidateQueries({ queryKey: ["position", id] });
+      queryClient.invalidateQueries({ queryKey: ["position-vacancies"] });
+      queryClient.invalidateQueries({ queryKey: ["positions"] });
+      queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
       setEndAssignmentId(null);
     },
   });


### PR DESCRIPTION
…gnment

removeMutation only invalidated the position detail query, so the Vacancies list and Dashboard kept stale counts after an assignment ended (which reopens a seat). Also invalidate position-vacancies, positions and position-dashboard.