### PR TITLE
fix(positions): refresh vacancies/list/dashboard after assigning a user

### DIFF
--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -55,7 +55,13 @@ export default function PositionDetailPage() {
   const assignMutation = useMutation({
     mutationFn: (body: object) => api.post(`/positions/${id}/assign`, body).then((r) => r.data.data),
     onSuccess: () => {
+      // Assigning a user raises headcount_filled and can flip the position to
+      // "filled", removing it from vacancies — refresh those views too, not just
+      // this position's detail.
       queryClient.invalidateQueries({ queryKey: ["position", id] });
+      queryClient.invalidateQueries({ queryKey: ["position-vacancies"] });
+      queryClient.invalidateQueries({ queryKey: ["positions"] });
+      queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
       setShowAssign(false);
       setAssignForm({ user_id: "", start_date: "", is_primary: true });
     },


### PR DESCRIPTION
assignMutation only invalidated the position detail query, so the Vacancies list and Dashboard kept stale counts after an assignment (which can fill a seat and drop the position off vacancies). Also invalidate position-vacancies, positions and position-dashboard.