### PR TITLE
feat(positions): add "Critical only" filter to positions list

### DIFF
--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1754,6 +1754,7 @@
       "searchPlaceholder": "Search by title or code...",
       "allDepartments": "All Departments",
       "allStatuses": "All Statuses",
+      "criticalOnly": "Critical only",
       "statusActive": "Active",
       "statusFilled": "Filled",
       "statusFrozen": "Frozen",

--- a/packages/client/src/pages/positions/PositionListPage.tsx
+++ b/packages/client/src/pages/positions/PositionListPage.tsx
@@ -23,6 +23,7 @@ export default function PositionListPage() {
   const [search, setSearch] = useState("");
   const [departmentId, setDepartmentId] = useState<string>("");
   const [status, setStatus] = useState<string>(initialStatus);
+  const [criticalOnly, setCriticalOnly] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; title: string } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -70,7 +71,7 @@ export default function PositionListPage() {
   });
 
   const { data, isLoading } = useQuery({
-    queryKey: ["positions", { page, search, department_id: departmentId, status }],
+    queryKey: ["positions", { page, search, department_id: departmentId, status, is_critical: criticalOnly }],
     queryFn: () =>
       api
         .get("/positions", {
@@ -80,6 +81,7 @@ export default function PositionListPage() {
             ...(search ? { search } : {}),
             ...(departmentId ? { department_id: departmentId } : {}),
             ...(status ? { status } : {}),
+            ...(criticalOnly ? { is_critical: true } : {}),
           },
         })
         .then((r) => r.data),
@@ -312,6 +314,15 @@ export default function PositionListPage() {
           <option value="frozen">{tx("statusFrozen")}</option>
           <option value="closed">{tx("statusClosed")}</option>
         </select>
+        <label className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 cursor-pointer whitespace-nowrap">
+          <input
+            type="checkbox"
+            checked={criticalOnly}
+            onChange={(e) => { setCriticalOnly(e.target.checked); setPage(1); }}
+            className="h-4 w-4 text-brand-600 border-gray-300 rounded focus:ring-brand-500"
+          />
+          {tx("criticalOnly")}
+        </label>
       </div>
 
       {/* Table */}


### PR DESCRIPTION
The positions list had no way to show only critical roles, though is_critical is a first-class backend filter. Add a 'Critical only' checkbox that sends is_critical=true and resets to page 1 on change.

Pairs with the backend fix that forwards is_critical from the route to listPositions (branch fix/positions-is-critical-filter); that PR must land for the filter to take effect end-to-end.