### PR TITLE
feat(policies): show success/error toast on policy save

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "هل أنت متأكد أنك تريد حذف",
       "deleteConfirmSuffix": "؟ ستُخفى السياسة عن الموظفين؛ ويتم الاحتفاظ بالإقرارات الحالية للتدقiق.",
       "deleteConfirmGeneric": "هل أنت متأكد أنك تريد حذف هذه السياسة؟"
+    },
+    "toast": {
+      "updated": "تم تحديث السياسة",
+      "created": "تم إنشاء السياسة",
+      "updateFailed": "تعذّر تحديث السياسة",
+      "createFailed": "تعذّر إنشاء السياسة"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "Möchten Sie wirklich",
       "deleteConfirmSuffix": " löschen? Die Richtlinie wird für Mitarbeiter ausgeblendet; vorhandene Bestätigungen werden für die Prüfung aufbewahrt.",
       "deleteConfirmGeneric": "Möchten Sie diese Richtlinie wirklich löschen?"
+    },
+    "toast": {
+      "updated": "Richtlinie aktualisiert",
+      "created": "Richtlinie erstellt",
+      "updateFailed": "Richtlinie konnte nicht aktualisiert werden",
+      "createFailed": "Richtlinie konnte nicht erstellt werden"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "Are you sure you want to delete",
       "deleteConfirmSuffix": "? The policy will be hidden from employees; existing acknowledgments are retained for audit.",
       "deleteConfirmGeneric": "Are you sure you want to delete this policy?"
+    },
+    "toast": {
+      "updated": "Policy updated",
+      "created": "Policy created",
+      "updateFailed": "Failed to update policy",
+      "createFailed": "Failed to create policy"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "¿Seguro que quieres eliminar",
       "deleteConfirmSuffix": "? La política se ocultará a los empleados; las confirmaciones existentes se conservan para auditoría.",
       "deleteConfirmGeneric": "¿Seguro que quieres eliminar esta política?"
+    },
+    "toast": {
+      "updated": "Política actualizada",
+      "created": "Política creada",
+      "updateFailed": "No se pudo actualizar la política",
+      "createFailed": "No se pudo crear la política"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "Voulez-vous vraiment supprimer",
       "deleteConfirmSuffix": " ? La politique sera masquée pour les employés ; les accusés de réception existants sont conservés à des fins d'audit.",
       "deleteConfirmGeneric": "Voulez-vous vraiment supprimer cette politique ?"
+    },
+    "toast": {
+      "updated": "Politique mise à jour",
+      "created": "Politique créée",
+      "updateFailed": "Échec de la mise à jour de la politique",
+      "createFailed": "Échec de la création de la politique"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "क्या आप वाकई हटाना चाहते हैं",
       "deleteConfirmSuffix": "? नीति कर्मचारियों से छिपा दी जाएगी; मौजूदा स्वीकृतियां ऑडिट के लिए बनी रहेंगी।",
       "deleteConfirmGeneric": "क्या आप वाकई इस नीति को हटाना चाहते हैं?"
+    },
+    "toast": {
+      "updated": "नीति अपडेट की गई",
+      "created": "नीति बनाई गई",
+      "updateFailed": "नीति अपडेट करने में विफल",
+      "createFailed": "नीति बनाने में विफल"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "本当に削除しますか:",
       "deleteConfirmSuffix": "？ この方針は従業員に非表示になります。既存の承認は監査のために保持されます。",
       "deleteConfirmGeneric": "この方針を本当に削除しますか？"
+    },
+    "toast": {
+      "updated": "ポリシーを更新しました",
+      "created": "ポリシーを作成しました",
+      "updateFailed": "ポリシーの更新に失敗しました",
+      "createFailed": "ポリシーの作成に失敗しました"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "Tem certeza de que deseja excluir",
       "deleteConfirmSuffix": "? A política ficará oculta para os funcionários; as confirmações existentes são mantidas para auditoria.",
       "deleteConfirmGeneric": "Tem certeza de que deseja excluir esta política?"
+    },
+    "toast": {
+      "updated": "Política atualizada",
+      "created": "Política criada",
+      "updateFailed": "Falha ao atualizar a política",
+      "createFailed": "Falha ao criar a política"
     }
   },
   "announcements": {

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -848,6 +848,12 @@
       "deleteConfirmPrefix": "确定要删除",
       "deleteConfirmSuffix": "吗？该政策将对员工隐藏；现有确认记录将保留以供审计。",
       "deleteConfirmGeneric": "确定要删除此政策吗？"
+    },
+    "toast": {
+      "updated": "政策已更新",
+      "created": "政策已创建",
+      "updateFailed": "政策更新失败",
+      "createFailed": "政策创建失败"
     }
   },
   "announcements": {

--- a/packages/client/src/pages/policies/PoliciesPage.tsx
+++ b/packages/client/src/pages/policies/PoliciesPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/lib/auth-store";
 import api from "@/api/client";
+import { showToast } from "@/components/ui/Toast";
 import { FileText, Plus, Check, ChevronDown, ChevronUp, Users, Trash2, Pencil } from "lucide-react";
 
 // Defensive fallback for legacy rows that slipped past validation with a
@@ -281,12 +282,23 @@ function HRPoliciesView() {
       category: category || null,
       effective_date: effectiveDate || null,
     };
-    if (editingId != null) {
-      await updatePolicy.mutateAsync({ id: editingId, data: payload });
-    } else {
-      await createPolicy.mutateAsync(payload);
+    const isEditing = editingId != null;
+    try {
+      if (isEditing) {
+        await updatePolicy.mutateAsync({ id: editingId, data: payload });
+      } else {
+        await createPolicy.mutateAsync(payload);
+      }
+      showToast("success", isEditing ? t("policies.toast.updated") : t("policies.toast.created"));
+      resetForm();
+    } catch (err: any) {
+      // Keep the form open with the user's edits intact so they can retry.
+      const msg =
+        err?.response?.data?.error?.message ||
+        err?.response?.data?.message ||
+        (isEditing ? t("policies.toast.updateFailed") : t("policies.toast.createFailed"));
+      showToast("error", msg);
     }
-    resetForm();
   };
 
   const isSavingPolicy = editingId != null ? updatePolicy.isPending : createPolicy.isPending;


### PR DESCRIPTION
## Summary

Saving a company policy previously gave **no feedback**. On success the edit form just closed; on **failure it also closed silently** — discarding the user's edits with no error shown.

This adds proper toast feedback to the create/edit flow on the Policies page.

## Changes

`handleSubmit` in `PoliciesPage.tsx` now:
- **On success** — shows a green toast: **"Policy updated"** when editing, **"Policy created"** when creating, then resets the form.
- **On failure** — shows a red error toast (the server's error message, falling back to "Failed to update/create policy") and **keeps the form open with the user's input intact** so they can fix and retry.

Added `policies.toast.{updated, created, updateFailed, createFailed}` to **all 9 locales** (en, pt, es, fr, de, hi, ja, zh, ar).

## Verification

- 0 TypeScript errors (client-local tsc).
- `ToastContainer` is globally mounted in `App.tsx`, so the toast renders on the Policies page.
- Locale parity: the 4 new keys present in all 9 locale files.
