### PR TITLE
feat(wellness): success/error toast on wellness goal creation

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -4571,7 +4571,8 @@
       "cancel": "إلغاء",
       "creating": "جارٍ الإنشاء...",
       "submit": "إنشاء الهدف",
-      "errorEndBeforeStart": "لا يمكن أن يكون تاريخ الانتهاء قبل تاريخ البدء."
+      "errorEndBeforeStart": "لا يمكن أن يكون تاريخ الانتهاء قبل تاريخ البدء.",
+      "createSuccess": "تم إنشاء الهدف"
     },
     "progressModal": {
       "title": "تحديث التقدم",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -4375,7 +4375,8 @@
       "cancel": "Abbrechen",
       "creating": "Wird erstellt ...",
       "submit": "Ziel erstellen",
-      "errorEndBeforeStart": "Das Enddatum darf nicht vor dem Startdatum liegen."
+      "errorEndBeforeStart": "Das Enddatum darf nicht vor dem Startdatum liegen.",
+      "createSuccess": "Ziel erstellt"
     },
     "progressModal": {
       "title": "Fortschritt aktualisieren",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -4375,7 +4375,8 @@
       "cancel": "Cancel",
       "creating": "Creating...",
       "submit": "Create Goal",
-      "errorEndBeforeStart": "End date cannot be before the start date."
+      "errorEndBeforeStart": "End date cannot be before the start date.",
+      "createSuccess": "Goal created"
     },
     "progressModal": {
       "title": "Update Progress",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -4375,7 +4375,8 @@
       "cancel": "Cancelar",
       "creating": "Creando...",
       "submit": "Crear meta",
-      "errorEndBeforeStart": "La fecha de fin no puede ser anterior a la fecha de inicio."
+      "errorEndBeforeStart": "La fecha de fin no puede ser anterior a la fecha de inicio.",
+      "createSuccess": "Objetivo creado"
     },
     "progressModal": {
       "title": "Actualizar progreso",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -4375,7 +4375,8 @@
       "cancel": "Annuler",
       "creating": "Création...",
       "submit": "Créer l'objectif",
-      "errorEndBeforeStart": "La date de fin ne peut pas être antérieure à la date de début."
+      "errorEndBeforeStart": "La date de fin ne peut pas être antérieure à la date de début.",
+      "createSuccess": "Objectif créé"
     },
     "progressModal": {
       "title": "Mettre à jour la progression",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -4375,7 +4375,8 @@
       "cancel": "रद्द करें",
       "creating": "बनाया जा रहा है...",
       "submit": "लक्ष्य बनाएं",
-      "errorEndBeforeStart": "समाप्ति तिथि आरंभ तिथि से पहले नहीं हो सकती।"
+      "errorEndBeforeStart": "समाप्ति तिथि आरंभ तिथि से पहले नहीं हो सकती।",
+      "createSuccess": "लक्ष्य बनाया गया"
     },
     "progressModal": {
       "title": "प्रगति अपडेट करें",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -4375,7 +4375,8 @@
       "cancel": "キャンセル",
       "creating": "作成中...",
       "submit": "目標を作成",
-      "errorEndBeforeStart": "終了日は開始日より前に設定できません。"
+      "errorEndBeforeStart": "終了日は開始日より前に設定できません。",
+      "createSuccess": "目標を作成しました"
     },
     "progressModal": {
       "title": "進捗の更新",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -4375,7 +4375,8 @@
       "cancel": "Cancelar",
       "creating": "Criando...",
       "submit": "Criar Meta",
-      "errorEndBeforeStart": "A data de término não pode ser anterior à data de início."
+      "errorEndBeforeStart": "A data de término não pode ser anterior à data de início.",
+      "createSuccess": "Meta criada"
     },
     "progressModal": {
       "title": "Atualizar Progresso",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -4375,7 +4375,8 @@
       "cancel": "取消",
       "creating": "创建中...",
       "submit": "创建目标",
-      "errorEndBeforeStart": "结束日期不能早于开始日期。"
+      "errorEndBeforeStart": "结束日期不能早于开始日期。",
+      "createSuccess": "目标已创建"
     },
     "progressModal": {
       "title": "更新进度",

--- a/packages/client/src/pages/wellness/MyWellnessPage.tsx
+++ b/packages/client/src/pages/wellness/MyWellnessPage.tsx
@@ -94,6 +94,15 @@ export default function MyWellnessPage() {
         start_date: new Date().toISOString().split("T")[0],
         end_date: "",
       });
+      showToast("success", t("myWellness.goalModal.createSuccess"));
+    },
+    onError: (err: any) => {
+      showToast(
+        "error",
+        err?.response?.data?.error?.message ||
+          err?.response?.data?.message ||
+          t("myWellness.goalModal.errorCreateFailed"),
+      );
     },
   });
 


### PR DESCRIPTION
## Summary

Creating a wellness goal gave no confirmation on success — the modal just closed. Failures were only shown via a small inline `isError` message inside the modal, which the user never sees once it closes.

This adds toast feedback to the goal-creation flow on the **My Wellness** page.

## Changes

The `createGoalMutation` in `MyWellnessPage.tsx` now:
- **On success** — shows a green toast: **"Goal created"** (in addition to closing + resetting the modal).
- **On failure** — shows a red error toast with the server's message, falling back to the existing **"Failed to create goal"** string.

Added `myWellness.goalModal.createSuccess` to **all 9 locales** (en, pt, es, fr, de, hi, ja, zh, ar). `errorCreateFailed` already existed and is reused for the error toast.

## Verification

- 0 TypeScript errors (client-local tsc).
- `ToastContainer` is globally mounted in `App.tsx`, so the toast renders on the My Wellness page.
- Locale parity: the new key present in all 9 locale files.

Part of a small consistency pass adding save/delete/create toasts (companions: #2185 policy save, #2186 policy delete). Independent — branched from `main`.
