### PR TITLE
feat(events): add Edit Event to the Manage Events dashboard

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -4042,7 +4042,9 @@
         "endBeforeStart": "لا يمكن أن يكون تاريخ الانتهاء قبل تاريخ البدء."
       },
       "cancel": "إلغاء",
-      "submit": "إنشاء فعالية"
+      "submit": "إنشاء فعالية",
+      "editTitle": "تعديل الفعالية",
+      "updateSubmit": "تحديث الفعالية"
     },
     "upcoming": {
       "title": "الفعاليات القادمة",
@@ -4057,7 +4059,9 @@
       "attending_two": "مشاركان ({{count}})",
       "attending_few": "{{count}} مشاركين",
       "attending_many": "{{count}} مشاركًا",
-      "attending_other": "{{count}} مشارك"
+      "attending_other": "{{count}} مشارك",
+      "edit": "تعديل",
+      "editTitle": "تعديل الفعالية"
     },
     "deleteModal": {
       "title": "حذف الفعالية؟",
@@ -4066,6 +4070,12 @@
       "confirm": "حذف",
       "deleting": "جارٍ الحذف...",
       "error": "فشل حذف الفعالية"
+    },
+    "toast": {
+      "created": "تم إنشاء الفعالية",
+      "updated": "تم تحديث الفعالية",
+      "createFailed": "تعذّر إنشاء الفعالية",
+      "updateFailed": "تعذّر تحديث الفعالية"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "Das Enddatum darf nicht vor dem Startdatum liegen."
       },
       "cancel": "Abbrechen",
-      "submit": "Event erstellen"
+      "submit": "Event erstellen",
+      "editTitle": "Ereignis bearbeiten",
+      "updateSubmit": "Ereignis aktualisieren"
     },
     "upcoming": {
       "title": "Anstehende Events",
@@ -3897,7 +3899,9 @@
       "cancel": "Absagen",
       "deleteTitle": "Event löschen",
       "attending_one": "{{count}} Teilnahme",
-      "attending_other": "{{count}} Teilnahmen"
+      "attending_other": "{{count}} Teilnahmen",
+      "edit": "Bearbeiten",
+      "editTitle": "Ereignis bearbeiten"
     },
     "deleteModal": {
       "title": "Event löschen?",
@@ -3906,6 +3910,12 @@
       "confirm": "Löschen",
       "deleting": "Wird gelöscht...",
       "error": "Event konnte nicht gelöscht werden"
+    },
+    "toast": {
+      "created": "Ereignis erstellt",
+      "updated": "Ereignis aktualisiert",
+      "createFailed": "Ereignis konnte nicht erstellt werden",
+      "updateFailed": "Ereignis konnte nicht aktualisiert werden"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "End date cannot be before start date."
       },
       "cancel": "Cancel",
-      "submit": "Create Event"
+      "submit": "Create Event",
+      "editTitle": "Edit Event",
+      "updateSubmit": "Update Event"
     },
     "upcoming": {
       "title": "Upcoming Events",
@@ -3897,7 +3899,9 @@
       "cancel": "Cancel",
       "deleteTitle": "Delete event",
       "attending_one": "{{count}} attending",
-      "attending_other": "{{count}} attending"
+      "attending_other": "{{count}} attending",
+      "edit": "Edit",
+      "editTitle": "Edit event"
     },
     "deleteModal": {
       "title": "Delete event?",
@@ -3906,6 +3910,12 @@
       "confirm": "Delete",
       "deleting": "Deleting...",
       "error": "Failed to delete event"
+    },
+    "toast": {
+      "created": "Event created",
+      "updated": "Event updated",
+      "createFailed": "Failed to create event",
+      "updateFailed": "Failed to update event"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "La fecha de fin no puede ser anterior a la de inicio."
       },
       "cancel": "Cancelar",
-      "submit": "Crear evento"
+      "submit": "Crear evento",
+      "editTitle": "Editar evento",
+      "updateSubmit": "Actualizar evento"
     },
     "upcoming": {
       "title": "Próximos eventos",
@@ -3897,7 +3899,9 @@
       "cancel": "Cancelar",
       "deleteTitle": "Eliminar evento",
       "attending_one": "{{count}} asistente",
-      "attending_other": "{{count}} asistentes"
+      "attending_other": "{{count}} asistentes",
+      "edit": "Editar",
+      "editTitle": "Editar evento"
     },
     "deleteModal": {
       "title": "¿Eliminar evento?",
@@ -3906,6 +3910,12 @@
       "confirm": "Eliminar",
       "deleting": "Eliminando...",
       "error": "No se pudo eliminar el evento"
+    },
+    "toast": {
+      "created": "Evento creado",
+      "updated": "Evento actualizado",
+      "createFailed": "No se pudo crear el evento",
+      "updateFailed": "No se pudo actualizar el evento"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "La date de fin ne peut pas être antérieure à la date de début."
       },
       "cancel": "Annuler",
-      "submit": "Créer un événement"
+      "submit": "Créer un événement",
+      "editTitle": "Modifier l'événement",
+      "updateSubmit": "Mettre à jour l'événement"
     },
     "upcoming": {
       "title": "Événements à venir",
@@ -3897,7 +3899,9 @@
       "cancel": "Annuler",
       "deleteTitle": "Supprimer l'événement",
       "attending_one": "{{count}} participant",
-      "attending_other": "{{count}} participants"
+      "attending_other": "{{count}} participants",
+      "edit": "Modifier",
+      "editTitle": "Modifier l'événement"
     },
     "deleteModal": {
       "title": "Supprimer l'événement ?",
@@ -3906,6 +3910,12 @@
       "confirm": "Supprimer",
       "deleting": "Suppression...",
       "error": "Échec de la suppression de l'événement"
+    },
+    "toast": {
+      "created": "Événement créé",
+      "updated": "Événement mis à jour",
+      "createFailed": "Échec de la création de l'événement",
+      "updateFailed": "Échec de la mise à jour de l'événement"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "समाप्ति तिथि आरंभ तिथि से पहले नहीं हो सकती।"
       },
       "cancel": "रद्द करें",
-      "submit": "इवेंट बनाएं"
+      "submit": "इवेंट बनाएं",
+      "editTitle": "इवेंट संपादित करें",
+      "updateSubmit": "इवेंट अपडेट करें"
     },
     "upcoming": {
       "title": "आगामी इवेंट",
@@ -3897,7 +3899,9 @@
       "cancel": "रद्द करें",
       "deleteTitle": "इवेंट हटाएं",
       "attending_one": "{{count}} उपस्थित",
-      "attending_other": "{{count}} उपस्थित"
+      "attending_other": "{{count}} उपस्थित",
+      "edit": "संपादित करें",
+      "editTitle": "इवेंट संपादित करें"
     },
     "deleteModal": {
       "title": "इवेंट हटाएं?",
@@ -3906,6 +3910,12 @@
       "confirm": "हटाएं",
       "deleting": "हटाया जा रहा है...",
       "error": "इवेंट हटाने में विफल"
+    },
+    "toast": {
+      "created": "इवेंट बनाया गया",
+      "updated": "इवेंट अपडेट किया गया",
+      "createFailed": "इवेंट बनाने में विफल",
+      "updateFailed": "इवेंट अपडेट करने में विफल"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "終了日は開始日より前に設定できません。"
       },
       "cancel": "キャンセル",
-      "submit": "イベントを作成"
+      "submit": "イベントを作成",
+      "editTitle": "イベントを編集",
+      "updateSubmit": "イベントを更新"
     },
     "upcoming": {
       "title": "今後のイベント",
@@ -3897,7 +3899,9 @@
       "cancel": "キャンセル",
       "deleteTitle": "イベントを削除",
       "attending_one": "{{count}}人が参加",
-      "attending_other": "{{count}}人が参加"
+      "attending_other": "{{count}}人が参加",
+      "edit": "編集",
+      "editTitle": "イベントを編集"
     },
     "deleteModal": {
       "title": "イベントを削除しますか？",
@@ -3906,6 +3910,12 @@
       "confirm": "削除",
       "deleting": "削除中...",
       "error": "イベントの削除に失敗しました"
+    },
+    "toast": {
+      "created": "イベントを作成しました",
+      "updated": "イベントを更新しました",
+      "createFailed": "イベントの作成に失敗しました",
+      "updateFailed": "イベントの更新に失敗しました"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "A data de término não pode ser anterior à data de início."
       },
       "cancel": "Cancelar",
-      "submit": "Criar evento"
+      "submit": "Criar evento",
+      "editTitle": "Editar evento",
+      "updateSubmit": "Atualizar evento"
     },
     "upcoming": {
       "title": "Próximos eventos",
@@ -3897,7 +3899,9 @@
       "cancel": "Cancelar",
       "deleteTitle": "Excluir evento",
       "attending_one": "{{count}} confirmado",
-      "attending_other": "{{count}} confirmados"
+      "attending_other": "{{count}} confirmados",
+      "edit": "Editar",
+      "editTitle": "Editar evento"
     },
     "deleteModal": {
       "title": "Excluir evento?",
@@ -3906,6 +3910,12 @@
       "confirm": "Excluir",
       "deleting": "Excluindo...",
       "error": "Falha ao excluir o evento"
+    },
+    "toast": {
+      "created": "Evento criado",
+      "updated": "Evento atualizado",
+      "createFailed": "Falha ao criar o evento",
+      "updateFailed": "Falha ao atualizar o evento"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -3886,7 +3886,9 @@
         "endBeforeStart": "结束日期不能早于开始日期。"
       },
       "cancel": "取消",
-      "submit": "创建活动"
+      "submit": "创建活动",
+      "editTitle": "编辑活动",
+      "updateSubmit": "更新活动"
     },
     "upcoming": {
       "title": "即将举行的活动",
@@ -3897,7 +3899,9 @@
       "cancel": "取消",
       "deleteTitle": "删除活动",
       "attending_one": "{{count}} 人参加",
-      "attending_other": "{{count}} 人参加"
+      "attending_other": "{{count}} 人参加",
+      "edit": "编辑",
+      "editTitle": "编辑活动"
     },
     "deleteModal": {
       "title": "删除活动？",
@@ -3906,6 +3910,12 @@
       "confirm": "删除",
       "deleting": "删除中…",
       "error": "删除活动失败"
+    },
+    "toast": {
+      "created": "活动已创建",
+      "updated": "活动已更新",
+      "createFailed": "创建活动失败",
+      "updateFailed": "更新活动失败"
     }
   },
   "surveyBuilder": {

--- a/packages/client/src/pages/events/EventDashboardPage.tsx
+++ b/packages/client/src/pages/events/EventDashboardPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "@/api/client";
+import { showToast } from "@/components/ui/Toast";
 import { Link } from "react-router-dom";
 import {
   Calendar,
@@ -13,6 +14,7 @@ import {
   Clock,
   CalendarDays,
   Trash2,
+  Pencil,
   Loader2,
 } from "lucide-react";
 
@@ -43,6 +45,8 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
 export default function EventDashboardPage() {
   const { t } = useTranslation();
   const [showForm, setShowForm] = useState(false);
+  // When set, the form is editing an existing event (PUT) rather than creating one (POST).
+  const [editingId, setEditingId] = useState<number | null>(null);
   const queryClient = useQueryClient();
 
   // Form state
@@ -70,6 +74,18 @@ export default function EventDashboardPage() {
       queryClient.invalidateQueries({ queryKey: ["events-dashboard"] });
       queryClient.invalidateQueries({ queryKey: ["events"] });
       resetForm();
+      showToast("success", t("eventDashboard.toast.created"));
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: object }) =>
+      api.put(`/events/${id}`, data).then((r) => r.data.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["events-dashboard"] });
+      queryClient.invalidateQueries({ queryKey: ["events"] });
+      resetForm();
+      showToast("success", t("eventDashboard.toast.updated"));
     },
   });
 
@@ -109,12 +125,50 @@ export default function EventDashboardPage() {
     setTargetIds("");
     setMaxAttendees("");
     setIsMandatory(false);
+    setDateError("");
+    setEditingId(null);
     setShowForm(false);
   }
 
+  // `<input type="datetime-local">` expects "YYYY-MM-DDTHH:mm" in LOCAL time. The
+  // API returns an ISO/UTC timestamp, so convert to a local wall-clock string
+  // (subtracting the tz offset) before binding, else the value shows blank.
+  function toLocalInput(value?: string | null): string {
+    if (!value) return "";
+    const d = new Date(value);
+    if (isNaN(d.getTime())) return "";
+    const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+    return local.toISOString().slice(0, 16);
+  }
+
+  const startEdit = (event: any) => {
+    setEditingId(event.id);
+    setTitle(event.title || "");
+    setDescription(event.description || "");
+    setEventType(event.event_type || "other");
+    setStartDate(toLocalInput(event.start_date));
+    setEndDate(toLocalInput(event.end_date));
+    setIsAllDay(!!event.is_all_day);
+    setLocation(event.location || "");
+    setVirtualLink(event.virtual_link || "");
+    setTargetType(event.target_type || "all");
+    setTargetIds(
+      event.target_ids == null
+        ? ""
+        : typeof event.target_ids === "string"
+          ? event.target_ids
+          : JSON.stringify(event.target_ids),
+    );
+    setMaxAttendees(event.max_attendees != null ? String(event.max_attendees) : "");
+    setIsMandatory(!!event.is_mandatory);
+    setDateError("");
+    setShowForm(true);
+    if (typeof window !== "undefined") window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
   const [dateError, setDateError] = useState("");
 
-  const handleCreate = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setDateError("");
 
@@ -123,7 +177,7 @@ export default function EventDashboardPage() {
       return;
     }
 
-    await createMutation.mutateAsync({
+    const payload = {
       title,
       description: description || null,
       event_type: eventType,
@@ -136,7 +190,24 @@ export default function EventDashboardPage() {
       target_ids: targetIds || null,
       max_attendees: maxAttendees ? parseInt(maxAttendees) : null,
       is_mandatory: isMandatory,
-    });
+    };
+
+    const isEditing = editingId != null;
+    try {
+      if (isEditing) {
+        await updateMutation.mutateAsync({ id: editingId, data: payload });
+      } else {
+        await createMutation.mutateAsync(payload);
+      }
+    } catch (err: any) {
+      // Keep the form open with the user's input intact so they can retry.
+      showToast(
+        "error",
+        err?.response?.data?.error?.message ||
+          err?.response?.data?.message ||
+          (isEditing ? t("eventDashboard.toast.updateFailed") : t("eventDashboard.toast.createFailed")),
+      );
+    }
   };
 
   return (
@@ -147,7 +218,16 @@ export default function EventDashboardPage() {
           <p className="text-gray-500 mt-1">{t("eventDashboard.header.subtitle")}</p>
         </div>
         <button
-          onClick={() => setShowForm(!showForm)}
+          onClick={() => {
+            // Toggling the header button always starts a fresh CREATE, even if
+            // the form was previously opened in edit mode.
+            if (showForm) {
+              resetForm();
+            } else {
+              setEditingId(null);
+              setShowForm(true);
+            }
+          }}
           className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {t("eventDashboard.header.createEvent")}
@@ -224,10 +304,12 @@ export default function EventDashboardPage() {
         </div>
       )}
 
-      {/* Create Event Form */}
+      {/* Create / Edit Event Form */}
       {showForm && (
-        <form onSubmit={handleCreate} className="bg-white rounded-xl border border-gray-200 p-6 mb-6 space-y-4">
-          <h2 className="text-lg font-semibold text-gray-900">{t("eventDashboard.form.title")}</h2>
+        <form onSubmit={handleSubmit} className="bg-white rounded-xl border border-gray-200 p-6 mb-6 space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {editingId != null ? t("eventDashboard.form.editTitle") : t("eventDashboard.form.title")}
+          </h2>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="sm:col-span-2">
@@ -402,10 +484,11 @@ export default function EventDashboardPage() {
             </button>
             <button
               type="submit"
-              disabled={createMutation.isPending}
+              disabled={createMutation.isPending || updateMutation.isPending}
               className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
             >
-              <Calendar className="h-4 w-4" /> {t("eventDashboard.form.submit")}
+              <Calendar className="h-4 w-4" />{" "}
+              {editingId != null ? t("eventDashboard.form.updateSubmit") : t("eventDashboard.form.submit")}
             </button>
           </div>
         </form>
@@ -459,6 +542,16 @@ export default function EventDashboardPage() {
                   >
                     {t("eventDashboard.upcoming.view")}
                   </Link>
+                  {event.status !== "cancelled" && (
+                    <button
+                      onClick={() => startEdit(event)}
+                      className="flex items-center gap-1 text-xs text-gray-500 hover:text-brand-600"
+                      title={t("eventDashboard.upcoming.editTitle")}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                      {t("eventDashboard.upcoming.edit")}
+                    </button>
+                  )}
                   {event.status !== "cancelled" && (
                     <button
                       onClick={() => cancelMutation.mutate(event.id)}


### PR DESCRIPTION
## Summary

The **Manage Events** dashboard (`/events/dashboard`) could create, cancel, and delete events — but there was **no way to edit an existing event**, even though the backend already exposes `PUT /api/v1/events/:id` (guarded by `events:manage`). This PR wires that endpoint into the UI.

## Changes (`EventDashboardPage.tsx`)

- **Edit action** — a pencil "Edit" button on each non-cancelled event in the upcoming list. It pre-fills the existing create form and switches the heading → **"Edit Event"** and the submit button → **"Update Event"**.
- **Update mutation** — `PUT /events/:id`. On success: **"Event updated"** toast + form reset. On failure: error toast (server message, falling back to "Failed to update event"), and the form stays open with the user's input intact.
- **Create feedback** — creating an event now also shows an **"Event created"** / error toast (it was previously silent).
- **Date pre-fill** — `start_date`/`end_date` are converted from the stored UTC timestamp to a local `YYYY-MM-DDTHH:mm` value so the `datetime-local` inputs populate correctly when editing (otherwise they'd render blank / tz-shifted).
- The header **"Create Event"** button always starts a fresh create, even if the form was previously open in edit mode.

## i18n

Added to all 9 locales:
- `eventDashboard.form.{editTitle, updateSubmit}`
- `eventDashboard.upcoming.{edit, editTitle}`
- `eventDashboard.toast.{created, updated, createFailed, updateFailed}`

## Verification

- **End-to-end** against the running server: a create → edit → delete round-trip through the real API using the form's exact payload succeeded (title, event type, date, location, max-attendees, mandatory all updated and persisted).
- 0 TypeScript errors (client-local tsc).
- Full locale parity for the new keys across all 9 languages.

No backend changes needed — the `PUT /events/:id` route and `updateEventSchema` already existed.
