### PR TITLE
feat(assets): toast feedback on asset category add/update/deactivate

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -6579,6 +6579,13 @@
     },
     "errors": {
       "deactivateFailed": "فشل إلغاء تنشيط الفئة"
+    },
+    "toast": {
+      "created": "تمت إضافة الفئة",
+      "updated": "تم تحديث الفئة",
+      "deactivated": "تم إلغاء تنشيط الفئة",
+      "createFailed": "فشل في إضافة الفئة",
+      "updateFailed": "فشل في تحديث الفئة"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "Kategorie konnte nicht deaktiviert werden"
+    },
+    "toast": {
+      "created": "Kategorie hinzugefügt",
+      "updated": "Kategorie aktualisiert",
+      "deactivated": "Kategorie deaktiviert",
+      "createFailed": "Kategorie konnte nicht hinzugefügt werden",
+      "updateFailed": "Kategorie konnte nicht aktualisiert werden"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "Failed to deactivate category"
+    },
+    "toast": {
+      "created": "Category added",
+      "updated": "Category updated",
+      "deactivated": "Category deactivated",
+      "createFailed": "Failed to add category",
+      "updateFailed": "Failed to update category"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "No se pudo desactivar la categoría"
+    },
+    "toast": {
+      "created": "Categoría añadida",
+      "updated": "Categoría actualizada",
+      "deactivated": "Categoría desactivada",
+      "createFailed": "No se pudo añadir la categoría",
+      "updateFailed": "No se pudo actualizar la categoría"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "Échec de la désactivation de la catégorie"
+    },
+    "toast": {
+      "created": "Catégorie ajoutée",
+      "updated": "Catégorie mise à jour",
+      "deactivated": "Catégorie désactivée",
+      "createFailed": "Échec de l'ajout de la catégorie",
+      "updateFailed": "Échec de la mise à jour de la catégorie"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "श्रेणी निष्क्रिय करने में विफल"
+    },
+    "toast": {
+      "created": "श्रेणी जोड़ी गई",
+      "updated": "श्रेणी अपडेट की गई",
+      "deactivated": "श्रेणी निष्क्रिय की गई",
+      "createFailed": "श्रेणी जोड़ने में विफल",
+      "updateFailed": "श्रेणी अपडेट करने में विफल"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "カテゴリの無効化に失敗しました"
+    },
+    "toast": {
+      "created": "カテゴリを追加しました",
+      "updated": "カテゴリを更新しました",
+      "deactivated": "カテゴリを無効化しました",
+      "createFailed": "カテゴリの追加に失敗しました",
+      "updateFailed": "カテゴリの更新に失敗しました"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "Falha ao desativar a categoria"
+    },
+    "toast": {
+      "created": "Categoria adicionada",
+      "updated": "Categoria atualizada",
+      "deactivated": "Categoria desativada",
+      "createFailed": "Falha ao adicionar categoria",
+      "updateFailed": "Falha ao atualizar categoria"
     }
   },
   "myAssets": {

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -6227,6 +6227,13 @@
     },
     "errors": {
       "deactivateFailed": "停用类别失败"
+    },
+    "toast": {
+      "created": "已添加类别",
+      "updated": "已更新类别",
+      "deactivated": "已停用类别",
+      "createFailed": "添加类别失败",
+      "updateFailed": "更新类别失败"
     }
   },
   "myAssets": {

--- a/packages/client/src/pages/assets/AssetCategoriesPage.tsx
+++ b/packages/client/src/pages/assets/AssetCategoriesPage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import api from "@/api/client";
+import { showToast } from "@/components/ui/Toast";
 import {
   Plus,
   FolderOpen,
@@ -33,6 +34,7 @@ export default function AssetCategoriesPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["asset-categories"] });
       resetForm();
+      showToast("success", t("assetCategories.toast.created"));
     },
   });
 
@@ -42,6 +44,7 @@ export default function AssetCategoriesPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["asset-categories"] });
       resetForm();
+      showToast("success", t("assetCategories.toast.updated"));
     },
   });
 
@@ -51,6 +54,7 @@ export default function AssetCategoriesPage() {
       queryClient.invalidateQueries({ queryKey: ["asset-categories"] });
       setDeleteTarget(null);
       setDeleteError(null);
+      showToast("success", t("assetCategories.toast.deactivated"));
     },
     onError: (err: any) =>
       setDeleteError(err?.response?.data?.error?.message || t("assetCategories.errors.deactivateFailed")),
@@ -73,10 +77,21 @@ export default function AssetCategoriesPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const data = { name: formName, description: formDescription || null };
-    if (editingId) {
-      await updateCategory.mutateAsync({ id: editingId, data });
-    } else {
-      await createCategory.mutateAsync(data);
+    const isEditing = editingId != null;
+    try {
+      if (isEditing) {
+        await updateCategory.mutateAsync({ id: editingId, data });
+      } else {
+        await createCategory.mutateAsync(data);
+      }
+    } catch (err: any) {
+      // Keep the form open with the user's input so they can retry.
+      showToast(
+        "error",
+        err?.response?.data?.error?.message ||
+          err?.response?.data?.message ||
+          (isEditing ? t("assetCategories.toast.updateFailed") : t("assetCategories.toast.createFailed")),
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

Adding, editing, or deactivating an asset category on the **Asset Categories** page gave no confirmation — the form/dialog just closed, and a failed add/edit reset silently with no error shown.

This adds toast feedback to the category flow.

## Changes (`AssetCategoriesPage.tsx`)

- **Create** → **"Category added"** toast on success.
- **Edit** → **"Category updated"** toast on success.
- **Deactivate** → **"Category deactivated"** toast on success (the delete already showed errors inline; now it also confirms success).
- **Add/edit failure** → error toast (server message, falling back to "Failed to add/update category"), and the form **stays open with the user's input** so they can retry.

Added `assetCategories.toast.{created, updated, deactivated, createFailed, updateFailed}` to **all 9 locales**. The existing `assetCategories.errors.deactivateFailed` is reused for the inline delete-error message.

## Verification

- **End-to-end** against the running server: a create → update → delete round-trip through the real API with the form's payload succeeded.
- 0 TypeScript errors (client-local tsc).
- Full locale parity for the new keys across all 9 languages.
