### PR TITLE
fix(wellness): make My Wellness page full-width

### DIFF
--- a/packages/client/src/pages/wellness/MyWellnessPage.tsx
+++ b/packages/client/src/pages/wellness/MyWellnessPage.tsx
@@ -145,7 +145,7 @@ export default function MyWellnessPage() {
 
   if (isLoading) {
     return (
-      <div className="max-w-7xl mx-auto space-y-8">
+      <div className="space-y-8">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">{t("myWellness.header.title")}</h1>
           <p className="text-gray-500 mt-1">{t("myWellness.header.subtitle")}</p>
@@ -170,7 +170,7 @@ export default function MyWellnessPage() {
 
   if (isError) {
     return (
-      <div className="max-w-7xl mx-auto space-y-8">
+      <div className="space-y-8">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">{t("myWellness.header.title")}</h1>
           <p className="text-gray-500 mt-1">{t("myWellness.header.subtitle")}</p>
@@ -187,7 +187,7 @@ export default function MyWellnessPage() {
   const checkIns = checkInsData?.data || [];
 
   return (
-    <div className="max-w-7xl mx-auto space-y-8">
+    <div className="space-y-8">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary

The **My Wellness** page (`/wellness/my`) constrained its content to `max-w-7xl mx-auto`, which left large empty margins on the left and right on wider screens (see the wasted side space in the report).

## Change

Removed `max-w-7xl mx-auto` (kept `space-y-8`) from all three render states — loading skeleton, error, and the main view — so the page fills the available content area.

This matches the **full-width convention** already used by most other pages (Asset Categories, Policies, Event Dashboard, Employee Directory). The dashboard layout wrapper already applies `p-4 md:p-8` padding around the outlet, so content keeps proper edge gutters — it just no longer caps at 1280px and centers.

## Verification

- 0 TypeScript errors (client-local tsc).
- Pure Tailwind class change, no logic touched; three occurrences updated consistently.
