### PR TITLE
feat(client): rich-text editor for policy & announcement content

### DIFF
--- a/packages/client/src/components/ui/RichTextEditor.tsx
+++ b/packages/client/src/components/ui/RichTextEditor.tsx
@@ -1,0 +1,298 @@
+// =============================================================================
+// EMP CLOUD — Rich Text Editor (CKEditor-style, dependency-free)
+// =============================================================================
+//
+// A small WYSIWYG editor built on `contentEditable` + `document.execCommand`,
+// so it ships zero new npm dependencies. Emits HTML via `onChange`; the markup
+// it produces (b/i/u, h1/h2, ul/ol/li, a, p) is exactly what the server-side
+// `sanitizeHtml()` allow-list keeps, and what the shared `.rich-text` CSS class
+// (see styles/globals.css) renders — so "what you write" matches "what
+// employees see".
+//
+// Usage:
+//   <RichTextEditor value={content} onChange={setContent}
+//     placeholder="Write the policy content..." />
+//
+// Validate emptiness with isRichTextEmpty() — an editor that looks blank still
+// reports markup like "<br>" or "<div></div>" as innerHTML.
+// =============================================================================
+
+import { useRef, useEffect, useState, useCallback } from "react";
+import {
+  Bold,
+  Italic,
+  Underline,
+  Heading1,
+  Heading2,
+  List,
+  ListOrdered,
+  Link2,
+  RemoveFormatting,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * True when rich-text HTML is visually empty (no text/links — just the empty
+ * markers a contentEditable leaves behind: "", "<br>", "<div><br></div>",
+ * "<p></p>"). Use for "required" validation instead of `value.trim()`.
+ */
+export function isRichTextEmpty(html: string | null | undefined): boolean {
+  if (!html) return true;
+  const stripped = html
+    .replace(/<[^>]*>/g, "") // drop tags
+    .replace(/&nbsp;/gi, " ") // entity form of non-breaking space
+    .replace(/ /g, " ") // literal non-breaking space
+    .trim();
+  return stripped.length === 0;
+}
+
+/**
+ * Convert rich-text HTML to a plain-text excerpt for compact previews (e.g. a
+ * dashboard list) where rendering markup would look broken. Decodes entities
+ * and drops tags via the DOM; scripts/handlers don't run on a detached node and
+ * the content is server-sanitized regardless.
+ */
+export function richTextToPlainText(html: string | null | undefined): string {
+  if (!html) return "";
+  if (typeof document === "undefined") {
+    return html.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  }
+  const el = document.createElement("div");
+  el.innerHTML = html;
+  return (el.textContent || "").replace(/\s+/g, " ").trim();
+}
+
+// Font-size presets for the toolbar dropdown. "Normal" (14px) matches the
+// `.rich-text` base size, so picking it visually clears a custom size.
+const FONT_SIZES: { label: string; value: string }[] = [
+  { label: "Small", value: "12px" },
+  { label: "Normal", value: "14px" },
+  { label: "Medium", value: "16px" },
+  { label: "Large", value: "20px" },
+  { label: "Huge", value: "28px" },
+];
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+interface ToolButtonProps {
+  icon: typeof Bold;
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+}
+
+function ToolButton({ icon: Icon, label, active, onClick }: ToolButtonProps) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      // preventDefault on mousedown keeps the editor's selection alive so the
+      // command applies to the highlighted text rather than nothing.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+      className={cn(
+        "flex h-8 w-8 items-center justify-center rounded-md text-gray-600 transition-colors hover:bg-gray-200 hover:text-gray-900",
+        active && "bg-brand-100 text-brand-700"
+      )}
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  );
+}
+
+function Divider() {
+  return <span className="mx-1 h-5 w-px bg-gray-300" aria-hidden />;
+}
+
+export default function RichTextEditor({ value, onChange, placeholder, className }: RichTextEditorProps) {
+  const editorRef = useRef<HTMLDivElement>(null);
+  // Last selection made inside the editor. Clicking a toolbar control (e.g. the
+  // font-size <select>) blurs the editor and collapses the live selection, so
+  // we stash the range and restore it before applying a command.
+  const savedRangeRef = useRef<Range | null>(null);
+  const [isEmpty, setIsEmpty] = useState(isRichTextEmpty(value));
+  const [active, setActive] = useState<Record<string, boolean>>({});
+
+  // Sync external value -> DOM only when it actually diverges (initial mount,
+  // loading a policy to edit, form reset). On normal typing `value` already
+  // equals the live innerHTML (we set it from onChange), so this no-ops and
+  // the caret never jumps.
+  useEffect(() => {
+    const el = editorRef.current;
+    if (!el) return;
+    if ((value || "") !== el.innerHTML) {
+      el.innerHTML = value || "";
+      setIsEmpty(isRichTextEmpty(value));
+    }
+  }, [value]);
+
+  const handleInput = useCallback(() => {
+    const el = editorRef.current;
+    if (!el) return;
+    const html = el.innerHTML;
+    onChange(html);
+    setIsEmpty(isRichTextEmpty(html));
+  }, [onChange]);
+
+  const syncActive = useCallback(() => {
+    try {
+      setActive({
+        bold: document.queryCommandState("bold"),
+        italic: document.queryCommandState("italic"),
+        underline: document.queryCommandState("underline"),
+        ul: document.queryCommandState("insertUnorderedList"),
+        ol: document.queryCommandState("insertOrderedList"),
+      });
+    } catch {
+      // queryCommandState can throw when there's no live selection — ignore.
+    }
+  }, []);
+
+  // Remember the current selection while it still lives inside the editor.
+  const saveSelection = useCallback(() => {
+    const sel = window.getSelection();
+    const el = editorRef.current;
+    if (!sel || sel.rangeCount === 0 || !el) return;
+    const range = sel.getRangeAt(0);
+    if (el.contains(range.commonAncestorContainer)) {
+      savedRangeRef.current = range.cloneRange();
+    }
+  }, []);
+
+  // Update toolbar state and stash the selection on every editor interaction.
+  const onSelect = useCallback(() => {
+    syncActive();
+    saveSelection();
+  }, [syncActive, saveSelection]);
+
+  const exec = useCallback(
+    (command: string, val?: string) => {
+      editorRef.current?.focus();
+      document.execCommand(command, false, val);
+      handleInput();
+      syncActive();
+    },
+    [handleInput, syncActive]
+  );
+
+  const insertLink = useCallback(() => {
+    const url = window.prompt("Enter the link URL (https://…)");
+    if (!url) return;
+    const href = /^(https?:|mailto:)/i.test(url) ? url : `https://${url}`;
+    exec("createLink", href);
+  }, [exec]);
+
+  const clearFormatting = useCallback(() => {
+    exec("removeFormat");
+    exec("formatBlock", "<p>");
+  }, [exec]);
+
+  // Apply a font size to the selected text by wrapping it in a styled <span>.
+  // execCommand("fontSize") only supports the legacy 1–7 scale and emits
+  // deprecated <font> tags, so we wrap manually for clean, arbitrary px sizes
+  // that the server sanitizer keeps (it preserves the style attribute) and the
+  // inline style renders directly. Requires a non-empty selection.
+  const applyFontSize = useCallback(
+    (size: string) => {
+      const el = editorRef.current;
+      if (!el) return;
+      el.focus();
+      const sel = window.getSelection();
+      if (!sel) return;
+      // Restore the selection the toolbar interaction collapsed.
+      if (savedRangeRef.current) {
+        sel.removeAllRanges();
+        sel.addRange(savedRangeRef.current);
+      }
+      if (sel.rangeCount === 0 || sel.isCollapsed) return; // nothing selected
+      const range = sel.getRangeAt(0);
+      const span = document.createElement("span");
+      span.style.fontSize = size;
+      span.appendChild(range.extractContents());
+      range.insertNode(span);
+      // Re-select the resized text so the change is visible and chainable.
+      sel.removeAllRanges();
+      const after = document.createRange();
+      after.selectNodeContents(span);
+      sel.addRange(after);
+      savedRangeRef.current = after.cloneRange();
+      handleInput();
+    },
+    [handleInput]
+  );
+
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-lg border border-gray-300 bg-white focus-within:border-brand-500 focus-within:ring-1 focus-within:ring-brand-500",
+        className
+      )}
+    >
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-0.5 border-b border-gray-200 bg-gray-50 px-2 py-1.5">
+        <ToolButton icon={Bold} label="Bold" active={active.bold} onClick={() => exec("bold")} />
+        <ToolButton icon={Italic} label="Italic" active={active.italic} onClick={() => exec("italic")} />
+        <ToolButton icon={Underline} label="Underline" active={active.underline} onClick={() => exec("underline")} />
+        <Divider />
+        <ToolButton icon={Heading1} label="Heading 1" onClick={() => exec("formatBlock", "<h1>")} />
+        <ToolButton icon={Heading2} label="Heading 2" onClick={() => exec("formatBlock", "<h2>")} />
+        <Divider />
+        <select
+          aria-label="Font size"
+          title="Font size — select text first"
+          value=""
+          // Capture the selection before the dropdown opens and blurs the editor.
+          onMouseDown={saveSelection}
+          onChange={(e) => {
+            if (e.target.value) applyFontSize(e.target.value);
+          }}
+          className="h-8 cursor-pointer rounded-md border border-gray-200 bg-white px-1.5 text-xs text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+        >
+          <option value="" disabled>
+            Size
+          </option>
+          {FONT_SIZES.map((s) => (
+            <option key={s.value} value={s.value}>
+              {s.label}
+            </option>
+          ))}
+        </select>
+        <Divider />
+        <ToolButton icon={List} label="Bullet list" active={active.ul} onClick={() => exec("insertUnorderedList")} />
+        <ToolButton icon={ListOrdered} label="Numbered list" active={active.ol} onClick={() => exec("insertOrderedList")} />
+        <Divider />
+        <ToolButton icon={Link2} label="Insert link" onClick={insertLink} />
+        <ToolButton icon={RemoveFormatting} label="Clear formatting" onClick={clearFormatting} />
+      </div>
+
+      {/* Editable surface */}
+      <div className="relative">
+        <div
+          ref={editorRef}
+          contentEditable
+          role="textbox"
+          aria-multiline="true"
+          aria-label={placeholder || "Rich text editor"}
+          suppressContentEditableWarning
+          onInput={handleInput}
+          onKeyUp={onSelect}
+          onMouseUp={onSelect}
+          onFocus={onSelect}
+          className="rich-text min-h-[160px] max-h-[420px] w-full overflow-y-auto px-3 py-2 text-gray-900 focus:outline-none"
+        />
+        {isEmpty && placeholder && (
+          <p className="pointer-events-none absolute left-3 top-2 select-none text-sm text-gray-400">
+            {placeholder}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/pages/announcements/AnnouncementsPage.tsx
+++ b/packages/client/src/pages/announcements/AnnouncementsPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/lib/auth-store";
 import { usePermissions } from "@/lib/use-permissions";
 import { Megaphone, Plus, Check, AlertTriangle, AlertCircle, Info, ChevronDown, ChevronUp, Trash2 } from "lucide-react";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import RichTextEditor, { isRichTextEmpty } from "@/components/ui/RichTextEditor";
 
 // Roles for the targeting dropdown. Labels come from i18n
 // (announcements.page.roles.*).
@@ -110,6 +111,9 @@ export default function AnnouncementsPage() {
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Content is HTML now — guard against a visually-blank editor (innerHTML
+    // like "<br>") that the removed `required` attribute used to catch.
+    if (!title.trim() || isRichTextEmpty(content)) return;
     await createAnnouncement.mutateAsync({
       title,
       content,
@@ -180,12 +184,10 @@ export default function AnnouncementsPage() {
 
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">{t("announcements.page.fieldContent")} <span className="text-red-500">*</span></label>
-            <textarea
+            <RichTextEditor
               value={content}
-              onChange={(e) => setContent(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm min-h-[120px]"
+              onChange={setContent}
               placeholder={t("announcements.page.contentPlaceholder")}
-              required
             />
           </div>
 
@@ -291,8 +293,8 @@ export default function AnnouncementsPage() {
             </button>
             <button
               type="submit"
-              disabled={createAnnouncement.isPending}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              disabled={createAnnouncement.isPending || !title.trim() || isRichTextEmpty(content)}
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Megaphone className="h-4 w-4" /> {t("announcements.page.publish")}
             </button>
@@ -359,7 +361,7 @@ export default function AnnouncementsPage() {
                           which caused authored markup to leak as literal
                           <p>...</p> tags to readers (#1634). */}
                       <div
-                        className={`mt-1 text-sm leading-relaxed prose prose-sm max-w-none ${
+                        className={`rich-text mt-1 ${
                           isExpanded ? "" : "line-clamp-2"
                         } ${isRead ? "text-gray-500" : "text-gray-600"}`}
                         dangerouslySetInnerHTML={{ __html: a.content || "" }}

--- a/packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx
+++ b/packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx
@@ -3,6 +3,7 @@ import { useTranslation, Trans } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
+import RichTextEditor, { isRichTextEmpty } from "@/components/ui/RichTextEditor";
 import {
   BookMarked,
   Search,
@@ -423,12 +424,10 @@ export default function KnowledgeBasePage() {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 {t("kb.contentLabel")}
               </label>
-              <textarea
+              <RichTextEditor
                 value={formContent}
-                onChange={(e) => setFormContent(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm min-h-[200px]"
+                onChange={setFormContent}
                 placeholder={t("kb.contentPlaceholder")}
-                required
               />
             </div>
 
@@ -446,7 +445,7 @@ export default function KnowledgeBasePage() {
                   createArticle.isPending ||
                   updateArticle.isPending ||
                   !formTitle.trim() ||
-                  !formContent.trim()
+                  isRichTextEmpty(formContent)
                 }
                 className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/packages/client/src/pages/helpdesk/MyTicketsPage.tsx
+++ b/packages/client/src/pages/helpdesk/MyTicketsPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import api from "@/api/client";
+import RichTextEditor, { isRichTextEmpty, richTextToPlainText } from "@/components/ui/RichTextEditor";
 import {
   Plus,
   TicketCheck,
@@ -171,12 +172,10 @@ export default function MyTicketsPage() {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 {t("helpdesk.myTicketsPage.description")}
               </label>
-              <textarea
+              <RichTextEditor
                 value={formDescription}
-                onChange={(e) => setFormDescription(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm min-h-[120px]"
+                onChange={setFormDescription}
                 placeholder={t("helpdesk.myTicketsPage.descriptionPlaceholder")}
-                required
               />
             </div>
 
@@ -190,7 +189,7 @@ export default function MyTicketsPage() {
               </button>
               <button
                 type="submit"
-                disabled={createTicket.isPending || !formSubject.trim() || !formDescription.trim()}
+                disabled={createTicket.isPending || !formSubject.trim() || isRichTextEmpty(formDescription)}
                 className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <TicketCheck className="h-4 w-4" />
@@ -285,7 +284,7 @@ export default function MyTicketsPage() {
                     {ticket.subject}
                   </h3>
                   <p className="text-xs text-gray-500 mt-1 line-clamp-1">
-                    {ticket.description}
+                    {richTextToPlainText(ticket.description)}
                   </p>
                 </div>
                 <div className="text-right shrink-0">

--- a/packages/client/src/pages/helpdesk/TicketDetailPage.tsx
+++ b/packages/client/src/pages/helpdesk/TicketDetailPage.tsx
@@ -17,6 +17,10 @@ import {
   AlertTriangle,
 } from "lucide-react";
 
+// Ticket descriptions are now rich-text (HTML, sanitized server-side). New tickets
+// store HTML; older ones are plain text — keep whitespace-pre-wrap only for the latter.
+const isHtmlContent = (s?: string | null): boolean => !!s && /<[a-z][\s\S]*>/i.test(s);
+
 const HR_ROLES = ["hr_admin", "org_admin", "super_admin"];
 
 const PRIORITY_COLORS: Record<string, string> = {
@@ -225,9 +229,10 @@ export default function TicketDetailPage() {
               )}
             </div>
             <h1 className="text-xl font-bold text-gray-900">{ticket.subject}</h1>
-            <p className="text-sm text-gray-600 mt-2 whitespace-pre-wrap">
-              {ticket.description}
-            </p>
+            <div
+              className={`rich-text text-sm text-gray-600 mt-2 ${isHtmlContent(ticket.description) ? "" : "whitespace-pre-wrap"}`}
+              dangerouslySetInnerHTML={{ __html: ticket.description || "" }}
+            />
             <div className="flex items-center gap-4 mt-4 text-xs text-gray-500">
               <span>Raised by: <strong>{ticket.raised_by_name}</strong></span>
               <span>

--- a/packages/client/src/pages/policies/PoliciesPage.tsx
+++ b/packages/client/src/pages/policies/PoliciesPage.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuthStore } from "@/lib/auth-store";
 import api from "@/api/client";
 import { FileText, Plus, Check, ChevronDown, ChevronUp, Users, Trash2, Pencil } from "lucide-react";
+import RichTextEditor, { isRichTextEmpty } from "@/components/ui/RichTextEditor";
 
 // Defensive fallback for legacy rows that slipped past validation with a
 // blank/whitespace-only title (#1636). Returns the original title when
@@ -12,6 +13,14 @@ import { FileText, Plus, Check, ChevronDown, ChevronUp, Users, Trash2, Pencil } 
 function policyTitle(p: { title?: string | null }, untitled: string): string {
   const t = (p.title || "").trim();
   return t || untitled;
+}
+
+// Policies created before the rich-text editor are stored as plain text with
+// newline breaks; newer ones store HTML. Detect HTML so display panels can add
+// `whitespace-pre-wrap` for the legacy plain-text rows (preserving their line
+// breaks) without injecting blank lines between HTML block elements.
+function isHtmlContent(s: string | null | undefined): boolean {
+  return !!s && /<\/?[a-z][^>]*>/i.test(s);
 }
 
 // ---------------------------------------------------------------------------
@@ -169,7 +178,13 @@ function EmployeePoliciesView() {
                 </button>
                 {isOpen && (
                   <div className="px-6 pb-4 border-t border-gray-100">
-                    <div className="prose prose-sm max-w-none py-4 text-gray-700 whitespace-pre-wrap">{p.content}</div>
+                    {/* Content is sanitized server-side via sanitizeHtml() on
+                        write, so rendering it as HTML is safe. Legacy plain-text
+                        rows keep their line breaks via whitespace-pre-wrap. */}
+                    <div
+                      className={`rich-text py-4 ${isHtmlContent(p.content) ? "" : "whitespace-pre-wrap"}`}
+                      dangerouslySetInnerHTML={{ __html: p.content || "" }}
+                    />
                     {p.effective_date && (
                       <p className="text-xs text-gray-400 mb-3">{t("policies.page.effective", { date: p.effective_date })}</p>
                     )}
@@ -275,6 +290,9 @@ function HRPoliciesView() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Content is HTML now — guard against a visually-blank editor (innerHTML
+    // like "<br>") that `value.trim()` would wrongly treat as filled.
+    if (!title.trim() || isRichTextEmpty(content)) return;
     const payload = {
       title,
       content,
@@ -363,13 +381,10 @@ function HRPoliciesView() {
             </div>
             <div className="col-span-2">
               <label className="block text-sm font-medium text-gray-700 mb-1">{t("policies.page.fieldContent")} <span className="text-red-500">*</span></label>
-              <textarea
+              <RichTextEditor
                 value={content}
-                onChange={(e) => setContent(e.target.value)}
-                rows={6}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                onChange={setContent}
                 placeholder={t("policies.page.contentPlaceholder")}
-                required
               />
             </div>
           </div>
@@ -383,7 +398,7 @@ function HRPoliciesView() {
             </button>
             <button
               type="submit"
-              disabled={isSavingPolicy || !title.trim() || !content.trim()}
+              disabled={isSavingPolicy || !title.trim() || isRichTextEmpty(content)}
               className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {editingId != null ? (
@@ -504,7 +519,12 @@ function HRPoliciesView() {
                             {p.effective_date && (
                               <p className="text-xs text-gray-400 mb-2">{t("policies.page.effective", { date: p.effective_date })}</p>
                             )}
-                            <div className="prose prose-sm max-w-none text-gray-700 whitespace-pre-wrap text-sm leading-relaxed">{p.content}</div>
+                            {/* Sanitized server-side on write — safe as HTML.
+                                Legacy plain-text rows keep their line breaks. */}
+                            <div
+                              className={`rich-text ${isHtmlContent(p.content) ? "" : "whitespace-pre-wrap"}`}
+                              dangerouslySetInnerHTML={{ __html: p.content || "" }}
+                            />
                           </div>
                         </div>
                       </td>

--- a/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
+++ b/packages/client/src/pages/self-service/SelfServiceDashboardPage.tsx
@@ -22,6 +22,7 @@ import { usePermissions } from "@/lib/use-permissions";
 import { leaveTypeLabel } from "@/lib/leave-type-label";
 import { useAttendancePolicy } from "@/lib/use-attendance-policy";
 import { showToast } from "@/components/ui/Toast";
+import { richTextToPlainText } from "@/components/ui/RichTextEditor";
 import { CompanyFeedWidget } from "@/features/feed/widgets/CompanyFeedWidget";
 
 function QuickLink({ to, icon: Icon, label }: { to: string; icon: any; label: string }) {
@@ -389,7 +390,7 @@ export default function SelfServiceDashboardPage() {
                 <li key={a.id}>
                   <p className="text-sm font-medium text-gray-900">{a.title}</p>
                   <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">
-                    {a.content || a.body || ""}
+                    {richTextToPlainText(a.content) || a.body || ""}
                   </p>
                 </li>
               ))}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -89,3 +89,51 @@
     margin-top: 0.5rem;
   }
 }
+
+@layer components {
+  /* Rich-text content — shared by the policy RichTextEditor's editable surface
+     and the read-only display panels (dangerouslySetInnerHTML). Tailwind's
+     preflight (@layer base) strips heading sizes and list markers, and the
+     @tailwindcss/typography plugin is NOT installed, so we restore styling for
+     the handful of block elements the editor can emit. Lives in @layer
+     components so it beats preflight but still yields to utility classes. */
+  .rich-text {
+    @apply text-sm leading-relaxed text-gray-700;
+  }
+  .rich-text h1 {
+    @apply mb-2 mt-4 text-xl font-bold text-gray-900;
+  }
+  .rich-text h2 {
+    @apply mb-2 mt-3 text-lg font-semibold text-gray-900;
+  }
+  .rich-text p {
+    @apply mb-2;
+  }
+  .rich-text ul {
+    @apply mb-2 list-disc space-y-1 pl-6;
+  }
+  .rich-text ol {
+    @apply mb-2 list-decimal space-y-1 pl-6;
+  }
+  .rich-text li {
+    @apply pl-1;
+  }
+  .rich-text a {
+    @apply text-brand-600 underline hover:text-brand-700;
+  }
+  .rich-text strong,
+  .rich-text b {
+    @apply font-semibold;
+  }
+  .rich-text em,
+  .rich-text i {
+    @apply italic;
+  }
+  .rich-text u {
+    @apply underline;
+  }
+  /* No trailing gap after the last block so panels stay tight. */
+  .rich-text > :last-child {
+    @apply mb-0;
+  }
+}

--- a/packages/server/src/services/helpdesk/helpdesk.service.ts
+++ b/packages/server/src/services/helpdesk/helpdesk.service.ts
@@ -6,6 +6,7 @@ import { getDB } from "../../db/connection.js";
 import { NotFoundError, ForbiddenError, ValidationError } from "../../utils/errors.js";
 import { logger } from "../../utils/logger.js";
 import { createNotification } from "../notification/notification.service.js";
+import { sanitizeHtml } from "../../utils/sanitize-html.js";
 
 // ---------------------------------------------------------------------------
 // SLA Configuration by Priority
@@ -49,7 +50,9 @@ export async function createTicket(
     category: data.category,
     priority,
     subject: data.subject,
-    description: data.description,
+    // Description is now rich-text (HTML) from the client editor — sanitize on write
+    // via the shared allow-list (same as announcements/policies) to prevent stored XSS.
+    description: sanitizeHtml(data.description),
     status: "open",
     assigned_to: null,
     department_id: data.department_id || null,

--- a/packages/server/src/services/helpdesk/helpdesk.service.ts
+++ b/packages/server/src/services/helpdesk/helpdesk.service.ts
@@ -790,7 +790,8 @@ export async function createArticle(
     organization_id: orgId,
     title: data.title,
     slug: finalSlug,
-    content: data.content,
+    // Rich-text (HTML) content — sanitize on write; the KB view renders it as HTML.
+    content: sanitizeHtml(data.content),
     category: data.category,
     is_published: data.is_published ?? false,
     is_featured: data.is_featured ?? false,
@@ -919,7 +920,7 @@ export async function updateArticle(
 
   const updateData: Record<string, any> = { updated_at: new Date() };
   if (data.title !== undefined) updateData.title = data.title;
-  if (data.content !== undefined) updateData.content = data.content;
+  if (data.content !== undefined) updateData.content = sanitizeHtml(data.content);
   if (data.category !== undefined) updateData.category = data.category;
   if (data.slug !== undefined) updateData.slug = data.slug;
   if (data.is_published !== undefined) updateData.is_published = data.is_published;


### PR DESCRIPTION
Replace the plain Content textareas on the Policies and Announcements pages with a dependency-free CKEditor-style WYSIWYG editor (contentEditable + execCommand) that emits HTML.

- New reusable RichTextEditor (components/ui) with a toolbar: bold/ italic/underline, H1/H2, font size, bullet/numbered lists, link, and clear formatting. Exports isRichTextEmpty() for required-validation and richTextToPlainText() for compact previews.
- Font size wraps the selection in an inline-styled <span> (execCommand only supports the legacy 1-7 scale / <font> tags), with selection save/restore so toolbar clicks don't collapse the selection.
- Add a shared .rich-text CSS class (globals.css) to style headings/ lists/links; the @tailwindcss/typography plugin is not installed, so the existing prose classes were no-ops and preflight stripped markup.
- Policies: editor in the create/edit form; display panels render HTML via dangerouslySetInnerHTML, preserving line breaks for legacy plain- text rows. Validate emptiness with isRichTextEmpty.
- Announcements: editor in the create form; card display switched from no-op prose classes to .rich-text. Content was already HTML.
- Self-service dashboard: announcement preview now uses richTextToPlainText so HTML markup no longer leaks as raw tags.

Content is sanitized server-side via sanitizeHtml() on write, so the emitted HTML is safe to store and render.