### PR TITLE
fix(leave): align balance-card progress bars across all cards

### DIFF
--- a/packages/client/src/pages/leave/LeaveDashboardPage.tsx
+++ b/packages/client/src/pages/leave/LeaveDashboardPage.tsx
@@ -346,7 +346,7 @@ export default function LeaveDashboardPage() {
               return (
                 <div
                   key={type.id}
-                  className="bg-white rounded-xl border border-gray-200 p-5"
+                  className="bg-white rounded-xl border border-gray-200 p-5 flex flex-col h-full"
                 >
                   <div className="flex items-center gap-3 mb-1">
                     <div
@@ -429,14 +429,16 @@ export default function LeaveDashboardPage() {
                     const den = usePeriod ? periodQuota : total;
                     const pct = den > 0 ? Math.min(100, (num / den) * 100) : 0;
                     return (
-                      <div className="mt-3 w-full bg-gray-100 rounded-full h-2">
-                        <div
-                          className="h-2 rounded-full transition-all"
-                          style={{
-                            width: `${pct}%`,
-                            backgroundColor: typeColor,
-                          }}
-                        />
+                      <div className="mt-auto pt-3">
+                        <div className="w-full bg-gray-100 rounded-full h-2">
+                          <div
+                            className="h-2 rounded-full transition-all"
+                            style={{
+                              width: `${pct}%`,
+                              backgroundColor: typeColor,
+                            }}
+                          />
+                        </div>
                       </div>
                     );
                   })()}


### PR DESCRIPTION
## Summary
Leave-balance cards on the Leave Dashboard rendered their progress bar in normal flow right after the **optional** "This period · FY" footer. Cards that lacked that footer had their bar float up, misaligning against cards that showed it and leaving an empty gap below.

## Fix
- Make each balance card a flex column (`h-full`).
- Pin the progress bar to the bottom via `mt-auto`, so bars align on the same baseline regardless of whether the period/FY footer is present.

Pure layout change — the fiscal-year footer and all balance logic are unchanged.

## Test
Leave → Leave dashboard: the balance-card progress bars line up along the same bottom edge whether or not a card shows the "This period · FY" line.
