### PR TITLE
feat(positions): success toast after creating a position

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "وظيفة حرجة",
       "creating": "جاري الإنشاء...",
       "failedCreate": "فشل إنشاء الوظيفة",
+      "createSuccess": "تم إنشاء الوظيفة \"{{title}}\" بنجاح.",
       "searchPlaceholder": "البحث بالعنوان أو الرمز...",
       "allDepartments": "جميع الأقسام",
       "allStatuses": "جميع الحالات",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "Kritische Rolle",
       "creating": "Wird erstellt...",
       "failedCreate": "Position konnte nicht erstellt werden",
+      "createSuccess": "Position „{{title}}“ erfolgreich erstellt.",
       "searchPlaceholder": "Nach Titel oder Code suchen...",
       "allDepartments": "Alle Abteilungen",
       "allStatuses": "Alle Status",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "Critical Role",
       "creating": "Creating...",
       "failedCreate": "Failed to create position",
+      "createSuccess": "Position \"{{title}}\" created successfully.",
       "searchPlaceholder": "Search by title or code...",
       "allDepartments": "All Departments",
       "allStatuses": "All Statuses",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "Rol Crítico",
       "creating": "Creando...",
       "failedCreate": "Error al crear la posición",
+      "createSuccess": "Puesto \"{{title}}\" creado correctamente.",
       "searchPlaceholder": "Buscar por título o código...",
       "allDepartments": "Todos los departamentos",
       "allStatuses": "Todos los estados",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "Rôle critique",
       "creating": "Création...",
       "failedCreate": "Échec de la création du poste",
+      "createSuccess": "Poste « {{title}} » créé avec succès.",
       "searchPlaceholder": "Rechercher par titre ou code...",
       "allDepartments": "Tous les départements",
       "allStatuses": "Tous les statuts",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "महत्वपूर्ण भूमिका",
       "creating": "बना रहा है...",
       "failedCreate": "पद बनाने में विफल",
+      "createSuccess": "पद \"{{title}}\" सफलतापूर्वक बनाया गया।",
       "searchPlaceholder": "शीर्षक या कोड से खोजें...",
       "allDepartments": "सभी विभाग",
       "allStatuses": "सभी स्थितियाँ",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "重要な役割",
       "creating": "作成中...",
       "failedCreate": "ポジションの作成に失敗しました",
+      "createSuccess": "ポジション「{{title}}」を作成しました。",
       "searchPlaceholder": "タイトルまたはコードで検索...",
       "allDepartments": "すべての部門",
       "allStatuses": "すべてのステータス",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "Cargo Crítico",
       "creating": "Criando...",
       "failedCreate": "Falha ao criar o cargo",
+      "createSuccess": "Cargo \"{{title}}\" criado com sucesso.",
       "searchPlaceholder": "Buscar por título ou código...",
       "allDepartments": "Todos os departamentos",
       "allStatuses": "Todos os status",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -1757,6 +1757,7 @@
       "criticalRole": "关键岗位",
       "creating": "创建中...",
       "failedCreate": "创建职位失败",
+      "createSuccess": "已成功创建职位\"{{title}}\"。",
       "searchPlaceholder": "按标题或编号搜索...",
       "allDepartments": "所有部门",
       "allStatuses": "所有状态",

--- a/packages/client/src/pages/positions/PositionListPage.tsx
+++ b/packages/client/src/pages/positions/PositionListPage.tsx
@@ -5,6 +5,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import { Search, Plus, ChevronLeft, ChevronRight, AlertTriangle, Trash2, Loader2 } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments } from "@/api/hooks";
+import { showToast } from "@/components/ui/Toast";
 
 export default function PositionListPage() {
   const { t } = useTranslation();
@@ -118,8 +119,9 @@ export default function PositionListPage() {
 
   const createMutation = useMutation({
     mutationFn: (data: object) => api.post("/positions", data).then((r) => r.data.data),
-    onSuccess: () => {
+    onSuccess: (created: any) => {
       queryClient.invalidateQueries({ queryKey: ["positions"] });
+      queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
       setShowCreate(false);
       setForm({
         title: "",
@@ -132,7 +134,10 @@ export default function PositionListPage() {
         max_salary: "",
         currency: "INR",
       });
+      showToast("success", tx("createSuccess", { title: created?.title ?? "" }) as string);
     },
+    // Create errors are already surfaced inline under the form (see the
+    // createMutation.isError block in the JSX), so we don't also toast.
   });
 
   const handleCreate = (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
Creating a position on the Positions page closed the form silently — no confirmation the position was created.

## Change
- Show a **success toast** (naming the created position) after a successful create, using the app's standard `showToast`.
- Also invalidate the `position-dashboard` query so dashboard counts refresh.
- **Errors** are left on the existing **inline error** shown under the form (`createMutation.isError`) to avoid double-messaging — matching this page's existing convention.

Adds i18n key `positions.list.createSuccess` across all 9 locales.

## Test
Positions → Create Position → fill Title → **Create Position**: success toast appears, the form closes, and the new position shows in the list.
