### PR TITLE
feat(positions): add edit action to the positions list

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -1771,6 +1771,7 @@
       "colCritical": "حرجة",
       "noPositions": "لم يتم العثور على وظائف",
       "deleteTooltip": "حذف الوظيفة",
+      "editTooltip": "تعديل الوظيفة",
       "pageOf": "صفحة {{page}} من {{total_pages}} (المجموع {{total}})",
       "deleteTitle": "حذف الوظيفة؟",
       "deleteConfirm": "هل تريد حذف {{title}}؟ ستنتهي التعيينات النشطة وستُغلق الوظيفة. لا يمكن التراجع عن هذا الإجراء.",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -1771,6 +1771,7 @@
       "colCritical": "Kritisch",
       "noPositions": "Keine Positionen gefunden",
       "deleteTooltip": "Position löschen",
+      "editTooltip": "Position bearbeiten",
       "pageOf": "Seite {{page}} von {{total_pages}} ({{total}} insgesamt)",
       "deleteTitle": "Position löschen?",
       "deleteConfirm": "{{title}} löschen? Aktive Zuweisungen werden beendet und die Position wird geschlossen. Dies kann nicht rückgängig gemacht werden.",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1771,6 +1771,7 @@
       "colCritical": "Critical",
       "noPositions": "No positions found",
       "deleteTooltip": "Delete position",
+      "editTooltip": "Edit position",
       "pageOf": "Page {{page}} of {{total_pages}} ({{total}} total)",
       "deleteTitle": "Delete position?",
       "deleteConfirm": "Delete {{title}}? Active assignments are ended and the position is closed. This cannot be undone.",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -1771,6 +1771,7 @@
       "colCritical": "Crítica",
       "noPositions": "No se encontraron posiciones",
       "deleteTooltip": "Eliminar posición",
+      "editTooltip": "Editar puesto",
       "pageOf": "Página {{page}} de {{total_pages}} ({{total}} en total)",
       "deleteTitle": "¿Eliminar posición?",
       "deleteConfirm": "¿Eliminar {{title}}? Las asignaciones activas finalizan y la posición se cierra. Esta acción no se puede deshacer.",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -1771,6 +1771,7 @@
       "colCritical": "Critique",
       "noPositions": "Aucun poste trouvé",
       "deleteTooltip": "Supprimer le poste",
+      "editTooltip": "Modifier le poste",
       "pageOf": "Page {{page}} sur {{total_pages}} ({{total}} au total)",
       "deleteTitle": "Supprimer le poste ?",
       "deleteConfirm": "Supprimer {{title}} ? Les affectations actives sont clôturées et le poste est fermé. Cette action est irréversible.",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -1771,6 +1771,7 @@
       "colCritical": "महत्वपूर्ण",
       "noPositions": "कोई पद नहीं मिला",
       "deleteTooltip": "पद हटाएँ",
+      "editTooltip": "पद संपादित करें",
       "pageOf": "पृष्ठ {{page}} / {{total_pages}} (कुल {{total}})",
       "deleteTitle": "पद हटाएँ?",
       "deleteConfirm": "{{title}} हटाएँ? सक्रिय असाइनमेंट समाप्त हो जाते हैं और पद बंद हो जाता है। यह क्रिया वापस नहीं की जा सकती।",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -1771,6 +1771,7 @@
       "colCritical": "重要",
       "noPositions": "ポジションが見つかりません",
       "deleteTooltip": "ポジションを削除",
+      "editTooltip": "ポジションを編集",
       "pageOf": "{{total_pages}} ページ中 {{page}} ページ (合計 {{total}} 件)",
       "deleteTitle": "ポジションを削除しますか?",
       "deleteConfirm": "{{title}} を削除しますか? 有効な割当は終了し、ポジションは閉じられます。この操作は取り消せません。",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -1771,6 +1771,7 @@
       "colCritical": "Crítico",
       "noPositions": "Nenhum cargo encontrado",
       "deleteTooltip": "Excluir cargo",
+      "editTooltip": "Editar cargo",
       "pageOf": "Página {{page}} de {{total_pages}} ({{total}} no total)",
       "deleteTitle": "Excluir cargo?",
       "deleteConfirm": "Excluir {{title}}? As atribuições ativas são encerradas e o cargo é fechado. Esta ação não pode ser desfeita.",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -1771,6 +1771,7 @@
       "colCritical": "关键",
       "noPositions": "未找到职位",
       "deleteTooltip": "删除职位",
+      "editTooltip": "编辑职位",
       "pageOf": "第 {{page}} 页,共 {{total_pages}} 页(共 {{total}} 条)",
       "deleteTitle": "删除职位?",
       "deleteConfirm": "删除 {{title}}?活动分配将被终止,职位将关闭。此操作无法撤消。",

--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, UserPlus, X, Briefcase, AlertTriangle, MapPin, Pencil, Trash2, Save, Loader2 } from "lucide-react";
 import { useDepartments } from "@/api/hooks";
@@ -12,6 +12,7 @@ export default function PositionDetailPage() {
   const { t } = useTranslation();
   const { id } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [showAssign, setShowAssign] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
@@ -149,6 +150,29 @@ export default function PositionDetailPage() {
     onError: (err: any) =>
       setDeleteError(err?.response?.data?.error?.message || t("positionDetail.error.deleteFailed")),
   });
+
+  // Deep-link support: opening this page with ?edit=1 (e.g. the pencil on the
+  // positions list) prefills and opens the edit form automatically, then
+  // strips the param so a refresh/back doesn't re-open it.
+  useEffect(() => {
+    if (searchParams.get("edit") !== "1" || !data) return;
+    setEditForm({
+      title: data.title || "",
+      department_id: data.department_id ? String(data.department_id) : "",
+      employment_type: data.employment_type || "full_time",
+      headcount_budget: data.headcount_budget != null ? String(data.headcount_budget) : "1",
+      is_critical: data.is_critical || false,
+      job_description: data.job_description || "",
+      min_salary: data.min_salary ? String(data.min_salary) : "",
+      max_salary: data.max_salary ? String(data.max_salary) : "",
+      currency: data.currency || "INR",
+    });
+    setShowEdit(true);
+    const next = new URLSearchParams(searchParams);
+    next.delete("edit");
+    setSearchParams(next, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, searchParams]);
 
   if (isLoading) {
     return <div className="flex items-center justify-center h-64"><div className="text-gray-400">{t("positionDetail.loading")}</div></div>;

--- a/packages/client/src/pages/positions/PositionListPage.tsx
+++ b/packages/client/src/pages/positions/PositionListPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { Link, useSearchParams } from "react-router-dom";
-import { Search, Plus, ChevronLeft, ChevronRight, AlertTriangle, Trash2, Loader2 } from "lucide-react";
+import { Search, Plus, ChevronLeft, ChevronRight, AlertTriangle, Pencil, Trash2, Loader2 } from "lucide-react";
 import api from "@/api/client";
 import { useDepartments } from "@/api/hooks";
 
@@ -425,16 +425,25 @@ export default function PositionListPage() {
                     )}
                   </td>
                   <td className="px-6 py-4 text-right">
-                    <button
-                      onClick={() => {
-                        setDeleteTarget({ id: pos.id, title: pos.title });
-                        setDeleteError(null);
-                      }}
-                      className="p-1.5 rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-600"
-                      title={tx("deleteTooltip") as string}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </button>
+                    <div className="flex items-center justify-end gap-1">
+                      <Link
+                        to={`/positions/${pos.id}?edit=1`}
+                        className="p-1.5 rounded-lg text-gray-400 hover:bg-brand-50 hover:text-brand-600"
+                        title={tx("editTooltip") as string}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Link>
+                      <button
+                        onClick={() => {
+                          setDeleteTarget({ id: pos.id, title: pos.title });
+                          setDeleteError(null);
+                        }}
+                        className="p-1.5 rounded-lg text-gray-400 hover:bg-red-50 hover:text-red-600"
+                        title={tx("deleteTooltip") as string}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))


### PR DESCRIPTION
## Summary
The positions list only exposed a **delete** action. To edit a position you had to open its detail page and find the Edit button. Add an **edit** action directly on the list.

## Change
- Add a **pencil** icon to each row's Actions cell that deep-links to the position's detail page with its edit form already open: `/positions/:id?edit=1`.
- The detail page detects `?edit=1`, prefills and opens its (existing, tested) edit form, then strips the param so a refresh/back doesn't re-open it.

This **reuses the existing detail-page edit form** rather than duplicating the 9-field form on the list — no risk of the two drifting apart, minimal new code. Editing already saved via `PUT /positions/:id`; no server change.

Adds i18n key `positions.list.editTooltip` across all 9 locales.

## Test
Positions → click the pencil on any row → it opens the detail page with the edit form already populated → change a field → Save.
