### PR TITLE
feat(positions): success toast after editing a position

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -5045,6 +5045,7 @@
       "headcountMinError": "يجب ألا يقل عدد الوظائف المخطّط عن 1.",
       "saving": "جارٍ الحفظ...",
       "saveChanges": "حفظ التغييرات",
+      "updateSuccess": "تم تحديث الوظيفة \"{{title}}\" بنجاح.",
       "updateFailedInline": "تعذّر تحديث المنصب"
     },
     "employmentType": {

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "Das Stellenbudget muss mindestens 1 betragen.",
       "saving": "Wird gespeichert...",
       "saveChanges": "Änderungen speichern",
+      "updateSuccess": "Position „{{title}}“ erfolgreich aktualisiert.",
       "updateFailedInline": "Position konnte nicht aktualisiert werden"
     },
     "employmentType": {

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "Headcount Budget must be at least 1.",
       "saving": "Saving...",
       "saveChanges": "Save Changes",
+      "updateSuccess": "Position \"{{title}}\" updated successfully.",
       "updateFailedInline": "Failed to update position"
     },
     "employmentType": {

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "La plantilla presupuestada debe ser al menos 1.",
       "saving": "Guardando...",
       "saveChanges": "Guardar cambios",
+      "updateSuccess": "Puesto \"{{title}}\" actualizado correctamente.",
       "updateFailedInline": "No se pudo actualizar el puesto"
     },
     "employmentType": {

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "L'effectif budgété doit être d'au moins 1.",
       "saving": "Enregistrement...",
       "saveChanges": "Enregistrer les modifications",
+      "updateSuccess": "Poste « {{title}} » mis à jour avec succès.",
       "updateFailedInline": "Échec de la mise à jour du poste"
     },
     "employmentType": {

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "नियुक्ति बजट कम से कम 1 होना चाहिए।",
       "saving": "सहेज रहा है...",
       "saveChanges": "बदलाव सहेजें",
+      "updateSuccess": "पद \"{{title}}\" सफलतापूर्वक अपडेट किया गया।",
       "updateFailedInline": "पद अपडेट करने में विफल"
     },
     "employmentType": {

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "定員数は1以上である必要があります。",
       "saving": "保存中...",
       "saveChanges": "変更を保存",
+      "updateSuccess": "ポジション「{{title}}」を更新しました。",
       "updateFailedInline": "ポジションを更新できませんでした"
     },
     "employmentType": {

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "O orçamento de headcount deve ser de no mínimo 1.",
       "saving": "Salvando...",
       "saveChanges": "Salvar alterações",
+      "updateSuccess": "Cargo \"{{title}}\" atualizado com sucesso.",
       "updateFailedInline": "Falha ao atualizar a posição"
     },
     "employmentType": {

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -4781,6 +4781,7 @@
       "headcountMinError": "编制人数至少为 1。",
       "saving": "保存中...",
       "saveChanges": "保存更改",
+      "updateSuccess": "已成功更新职位\"{{title}}\"。",
       "updateFailedInline": "更新职位失败"
     },
     "employmentType": {

--- a/packages/client/src/pages/positions/PositionDetailPage.tsx
+++ b/packages/client/src/pages/positions/PositionDetailPage.tsx
@@ -120,10 +120,12 @@ export default function PositionDetailPage() {
   const updateMutation = useMutation({
     mutationFn: (data: object) =>
       api.put(`/positions/${id}`, data).then((r) => r.data.data),
-    onSuccess: () => {
+    onSuccess: (updated: any) => {
       queryClient.invalidateQueries({ queryKey: ["position", id] });
       queryClient.invalidateQueries({ queryKey: ["positions"] });
+      queryClient.invalidateQueries({ queryKey: ["position-dashboard"] });
       setShowEdit(false);
+      showToast("success", t("positionDetail.editForm.updateSuccess", { title: updated?.title ?? "" }));
     },
     onError: (err: any) => {
       const msg =


### PR DESCRIPTION
## Summary
Saving position edits ("Save Changes" on the position detail page) closed the form silently. The update mutation toasted only on **error** — there was no confirmation on success.

## Change
- Show a **success toast** (naming the position) after a successful edit, using the app's standard `showToast`.
- Also invalidate the `position-dashboard` query so dashboard counts reflect the edit.

Error handling is unchanged (already toasts the server error).

Adds i18n key `positionDetail.editForm.updateSuccess` across all 9 locales.

## Test
Positions → open a position → Edit → change a field → **Save Changes**: a success toast appears and the form closes.
