### PR TITLE
fix(org-chart): PNG/PDF export failing with 'Export failed'

### DIFF
--- a/packages/client/src/pages/employees/OrgChartPage.tsx
+++ b/packages/client/src/pages/employees/OrgChartPage.tsx
@@ -563,9 +563,19 @@ export default function OrgChartPage() {
         await new Promise<void>((r) => requestAnimationFrame(() => r()));
 
         const dataUrl = await toPng(node, {
-          cacheBust: true,
+          // NOTE: cacheBust is deliberately OFF. It appends a query string to
+          // every image URL, which (a) breaks the `blob:` object-URLs that
+          // EmployeeAvatar uses for manually-uploaded photos and (b) forces a
+          // re-fetch of the authenticated biometric-face API images — either of
+          // which made toPng throw and surfaced as "Export failed" (#1651).
           backgroundColor: "#f8fafc", // matches the slate-50 viewport bg
           pixelRatio: 2,
+          // Don't let a single un-inlinable avatar/font kill the whole export:
+          // fall back to a transparent pixel for images that can't be captured,
+          // and skip webfont inlining (not needed for the chart's visual).
+          imagePlaceholder:
+            "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+          skipFonts: true,
         });
 
         const stamp = new Date().toISOString().split("T")[0];


### PR DESCRIPTION
## Summary
The Org Chart **PNG / PDF export** always failed with a "Export failed. Please try again." toast.

## Root cause
The export rasterizes the chart DOM with `html-to-image`'s `toPng`, which was called with **`cacheBust: true`**. `cacheBust` appends a query string to every image URL, which:
- **breaks the `blob:` object-URLs** `EmployeeAvatar` uses for manually-uploaded photos (a `blob:` URL with an appended `?...` is invalid), and
- **forces a re-fetch of the authenticated biometric-face API images** (`/api/v3/biometric/face/:id.jpg`).

Either broken image made `toPng` throw → the whole export failed.

## Fix
- **Remove `cacheBust`** — the root cause.
- **Add `imagePlaceholder`** (a transparent 1×1 pixel) so if any single avatar still can't be inlined, it degrades to blank instead of killing the export.
- **Add `skipFonts: true`** to avoid cross-origin webfont fetch failures (not needed for the chart's visual).

The export is now resilient and succeeds even when an avatar can't be captured.

## Test
Org Chart → click **PNG** (downloads .png) and **PDF** (downloads .pdf) → both succeed with a success toast. Verified working in the running app.
