### PR TITLE
feat(leave): hide personal leave sections in Admin view

### DIFF
--- a/packages/client/src/pages/leave/CompOffPage.tsx
+++ b/packages/client/src/pages/leave/CompOffPage.tsx
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import api from "@/api/client";
 import { useAuthStore } from "@/lib/auth-store";
+import { usePermissions } from "@/lib/use-permissions";
+import { useViewModeStore, hasAnyAdminPermission } from "@/lib/use-view-mode";
 import { PlusCircle, Clock, CheckCircle2, XCircle, CalendarDays, Plus } from "lucide-react";
 
 interface CompOffRequest {
@@ -34,8 +36,20 @@ export default function CompOffPage() {
   const qc = useQueryClient();
   const user = useAuthStore((s) => s.user);
   const isHR = user && HR_ROLES.includes(user.role);
+  // Personal sections (own balance, own request form, "My Requests") belong to
+  // the self experience. Mirror the DashboardLayout view-toggle rule so that a
+  // non-HR user with admin permissions who flips to Admin view sees only the HR
+  // management sections (Credit Balance, Pending Approvals), not their own
+  // comp-off. HR users have no toggle → isSelfView stays true (unchanged).
+  const { permissions } = usePermissions();
+  const viewMode = useViewModeStore((s) => s.viewMode);
+  const showViewToggle = !isHR && hasAnyAdminPermission(permissions);
+  const isSelfView = !(showViewToggle && viewMode === "admin");
   const [showForm, setShowForm] = useState(false);
   const [tab, setTab] = useState<"my" | "pending">("my");
+  // In Admin view the "My Requests" tab is hidden, so force the Pending
+  // Approvals table regardless of the persisted tab state.
+  const effectiveTab = isSelfView ? tab : "pending";
   const [rejectReason, setRejectReason] = useState("");
   const [actionId, setActionId] = useState<number | null>(null);
 
@@ -192,12 +206,14 @@ export default function CompOffPage() {
               <Plus className="h-4 w-4" /> Credit Balance
             </button>
           )}
-          <button
-            onClick={() => setShowForm(!showForm)}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
-          >
-            <PlusCircle className="h-4 w-4" /> {t('leave.compOff.request')}
-          </button>
+          {isSelfView && (
+            <button
+              onClick={() => setShowForm(!showForm)}
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            >
+              <PlusCircle className="h-4 w-4" /> {t('leave.compOff.request')}
+            </button>
+          )}
         </div>
       </div>
 
@@ -282,7 +298,8 @@ export default function CompOffPage() {
         </form>
       )}
 
-      {/* Balance Card */}
+      {/* Balance Cards — own comp-off balance & counts; self view only. */}
+      {isSelfView && (
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
         <div className="bg-white rounded-xl border border-gray-200 p-5">
           <div className="flex items-center gap-3 mb-2">
@@ -327,9 +344,10 @@ export default function CompOffPage() {
           </div>
         </div>
       </div>
+      )}
 
-      {/* Request Form */}
-      {showForm && (
+      {/* Request Form — own comp-off request; self view only. */}
+      {isSelfView && showForm && (
         <form
           onSubmit={handleSubmit}
           className="bg-white rounded-xl border border-gray-200 p-6 mb-8"
@@ -409,21 +427,23 @@ export default function CompOffPage() {
 
       {/* Tabs */}
       <div className="flex gap-2 mb-4">
-        <button
-          onClick={() => setTab("my")}
-          className={`px-4 py-2 text-sm font-medium rounded-lg ${
-            tab === "my"
-              ? "bg-brand-50 text-brand-700"
-              : "text-gray-600 hover:bg-gray-100"
-          }`}
-        >
-          {t('leave.compOff.myRequests')}
-        </button>
+        {isSelfView && (
+          <button
+            onClick={() => setTab("my")}
+            className={`px-4 py-2 text-sm font-medium rounded-lg ${
+              effectiveTab === "my"
+                ? "bg-brand-50 text-brand-700"
+                : "text-gray-600 hover:bg-gray-100"
+            }`}
+          >
+            {t('leave.compOff.myRequests')}
+          </button>
+        )}
         {isHR && (
           <button
             onClick={() => setTab("pending")}
             className={`px-4 py-2 text-sm font-medium rounded-lg ${
-              tab === "pending"
+              effectiveTab === "pending"
                 ? "bg-brand-50 text-brand-700"
                 : "text-gray-600 hover:bg-gray-100"
             }`}
@@ -438,8 +458,8 @@ export default function CompOffPage() {
         )}
       </div>
 
-      {/* My Requests Table */}
-      {tab === "my" && (
+      {/* My Requests Table — own comp-off history; self view only. */}
+      {isSelfView && effectiveTab === "my" && (
         <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto">
           <table className="min-w-full">
             <thead className="bg-gray-50 border-b border-gray-200">
@@ -494,7 +514,7 @@ export default function CompOffPage() {
       )}
 
       {/* Pending Approvals Table (HR View) */}
-      {tab === "pending" && isHR && (
+      {effectiveTab === "pending" && isHR && (
         <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto">
           <table className="min-w-full">
             <thead className="bg-gray-50 border-b border-gray-200">

--- a/packages/client/src/pages/leave/LeaveDashboardPage.tsx
+++ b/packages/client/src/pages/leave/LeaveDashboardPage.tsx
@@ -9,6 +9,7 @@ import { CalendarDays, PlusCircle, Clock, CheckCircle2, XCircle, Ban, AlertCircl
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { leaveTypeLabel } from "@/lib/leave-type-label";
 import { useStickyLocationFilter } from "@/lib/use-sticky-location";
+import { useViewModeStore, hasAnyAdminPermission } from "@/lib/use-view-mode";
 
 // Kept for any legacy callers — page now uses permission-based gates below.
 const HR_ROLES = ["hr_admin", "org_admin", "super_admin", "manager"];
@@ -46,7 +47,7 @@ export default function LeaveDashboardPage() {
   // shows for users with the corresponding leave permissions, regardless of
   // primary role. A custom role granting leave:approve / view_all /
   // manage_policies / override_balance unlocks the admin sections.
-  const { has: hasPerm } = usePermissions();
+  const { has: hasPerm, permissions } = usePermissions();
   const isAdmin = hasPerm(
     "leave:view_all",
     "leave:view_team",
@@ -54,6 +55,18 @@ export default function LeaveDashboardPage() {
     "leave:manage_policies",
     "leave:override_balance",
   ) || (user ? HR_ROLES.includes(user.role) : false);
+
+  // Personal sections (own balances, Apply Leave, own applications) belong to
+  // the employee/self experience. Mirror the DashboardLayout view-toggle rule:
+  // a non-HR user with admin permissions gets the "My view / Admin view"
+  // toggle, and when they're in Admin view we hide their personal leave.
+  // Everyone else (HR users without a toggle, plain employees) is treated as
+  // self view — their behaviour is unchanged.
+  const isHRUser = user ? HR_ROLES.includes(user.role) : false;
+  const viewMode = useViewModeStore((s) => s.viewMode);
+  const hasAdminPerms = hasAnyAdminPermission(permissions);
+  const showViewToggle = !isHRUser && hasAdminPerms;
+  const isSelfView = !(showViewToggle && viewMode === "admin");
   const [showApply, setShowApply] = useState(false);
   // When set, the apply form is in edit-mode and submits PATCH instead of POST.
   // Cleared whenever the form closes or completes successfully.
@@ -280,19 +293,23 @@ export default function LeaveDashboardPage() {
               <Settings2 className="h-4 w-4" /> {t('leave.dashboard.leaveSettings')}
             </Link>
           )}
-          <button
-            type="button"
-            onClick={() => setShowApply(true)}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 cursor-pointer"
-          >
-            <PlusCircle className="h-4 w-4" /> {t('leave.applyLeave')}
-          </button>
+          {isSelfView && (
+            <button
+              type="button"
+              onClick={() => setShowApply(true)}
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 cursor-pointer"
+            >
+              <PlusCircle className="h-4 w-4" /> {t('leave.applyLeave')}
+            </button>
+          )}
         </div>
       </div>
 
       {/* Balance Cards — #1409: render one card per active leave type so
           employees see all configured types even when a balance row has not
-          yet been initialized (missing rows render as zero). */}
+          yet been initialized (missing rows render as zero).
+          Hidden in Admin view — own leave balance is personal/self-only. */}
+      {isSelfView && (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {loadingBalances ? (
           <>
@@ -447,9 +464,10 @@ export default function LeaveDashboardPage() {
             })
         )}
       </div>
+      )}
 
-      {/* Quick Apply Form */}
-      {showApply && (
+      {/* Quick Apply Form — self view only (own leave application). */}
+      {isSelfView && showApply && (
         <form
           ref={applyFormRef}
           onSubmit={handleSubmit}
@@ -605,21 +623,26 @@ export default function LeaveDashboardPage() {
       {/* Pending Approvals — Admin/Manager View */}
       {isAdmin && <PendingApprovals leaveTypes={leaveTypes} />}
 
-      {/* Recent Applications */}
-      <RecentApplications
-        leaveTypes={leaveTypes}
-        locale={i18n.language}
-        onEdit={startEdit}
-        onCancel={(id: number) => setCancelTargetId(id)}
-        cancelPending={cancelLeave.isPending}
-      />
+      {/* Recent Applications — the current user's OWN leave applications, so
+          only shown in self view (hidden in Admin view). */}
+      {isSelfView && (
+        <>
+          <RecentApplications
+            leaveTypes={leaveTypes}
+            locale={i18n.language}
+            onEdit={startEdit}
+            onCancel={(id: number) => setCancelTargetId(id)}
+            cancelPending={cancelLeave.isPending}
+          />
 
-      {/* Legend */}
-      <div className="flex items-center gap-6 text-xs text-gray-500 mt-6">
-        <span className="flex items-center gap-1"><Clock className="h-3.5 w-3.5 text-amber-500" /> {t('common.pending')}</span>
-        <span className="flex items-center gap-1"><CheckCircle2 className="h-3.5 w-3.5 text-green-500" /> {t('common.approved')}</span>
-        <span className="flex items-center gap-1"><XCircle className="h-3.5 w-3.5 text-red-500" /> {t('common.rejected')}</span>
-      </div>
+          {/* Legend */}
+          <div className="flex items-center gap-6 text-xs text-gray-500 mt-6">
+            <span className="flex items-center gap-1"><Clock className="h-3.5 w-3.5 text-amber-500" /> {t('common.pending')}</span>
+            <span className="flex items-center gap-1"><CheckCircle2 className="h-3.5 w-3.5 text-green-500" /> {t('common.approved')}</span>
+            <span className="flex items-center gap-1"><XCircle className="h-3.5 w-3.5 text-red-500" /> {t('common.rejected')}</span>
+          </div>
+        </>
+      )}
 
       <ConfirmDialog
         open={cancelTargetId !== null}


### PR DESCRIPTION
## Summary
When a non-HR user with admin permissions (granted via a custom role) switches to **Admin view**, they should see only management content — not their **own** personal leave. Previously the Leave Dashboard and Comp-Off pages still showed the user's own balances, "apply for myself" buttons, and own request history in Admin view.

## Change
Gate the personal sections on an `isSelfView` flag that mirrors the DashboardLayout view-toggle rule:
```
const showViewToggle = !isHRUser && hasAnyAdminPermission(permissions);
const isSelfView = !(showViewToggle && viewMode === "admin");
```

**Leave Dashboard** (`/leave`): in Admin view, hide own balance cards, Apply Leave button + form, and own Recent Applications. Keep **Pending Approvals** + **Leave Settings**.

**Comp-Off** (`/leave/comp-off`): in Admin view, hide own balance cards, Request Comp-Off button + form, and the **My Requests** tab/table. Keep the HR **Credit Balance** + **Pending Approvals** (forces the pending tab in admin view).

**HR users are unaffected** — they have no toggle, so `isSelfView` stays true and their pages render exactly as before.

## Scope — audited
A page audit (Dashboard, Leave Applications, Attendance, Self-Service, My-Profile, Leave Types, etc.) confirmed only these two pages mix personal + admin content on a shared route. The others are correctly designed:
- **Dashboard** `/` — self/admin split is a *routing* decision (RootRedirect sends toggle-users to SelfServiceDashboardPage in self view); DashboardPage is admin-only content.
- **Leave Applications** — server-scoped admin queue, no personal-only sections.
- **My Profile / employee detail** — own-vs-other driven by route param, already correct.

## Test
As `priya@technova.in` (custom-role admin perms), toggle **My view / Admin view** on `/leave` and `/leave/comp-off`:
- Admin view → only approval/management sections
- My view → full personal leave/comp-off page
