### PR TITLE
feat(attendance): department & location filters in the details modal

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "ابحث بالاسم أو البريد الإلكتروني أو القسم",
       "noSearchResults": "لا يوجد موظفون مطابقون لبحثك.",
       "allDepartments": "جميع الأقسام",
-      "allLocations": "جميع المواقع"
+      "allLocations": "جميع المواقع",
+      "export": "تصدير"
     },
     "export": {
       "title": "تصدير تقرير الحضور",

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -982,7 +982,9 @@
       "close": "إغلاق",
       "dateLabel": "التاريخ",
       "searchPlaceholder": "ابحث بالاسم أو البريد الإلكتروني أو القسم",
-      "noSearchResults": "لا يوجد موظفون مطابقون لبحثك."
+      "noSearchResults": "لا يوجد موظفون مطابقون لبحثك.",
+      "allDepartments": "جميع الأقسام",
+      "allLocations": "جميع المواقع"
     },
     "export": {
       "title": "تصدير تقرير الحضور",
@@ -1308,7 +1310,8 @@
         "reset": "إعادة تعيين"
       },
       "applyLeaveFailed": "فشل تطبيق الإجازة"
-    }
+    },
+    "location": "الموقع"
   },
   "manager": {
     "title": "فريقي",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -982,7 +982,9 @@
       "close": "Schließen",
       "dateLabel": "Datum",
       "searchPlaceholder": "Name, E-Mail oder Abteilung suchen",
-      "noSearchResults": "Keine Mitarbeiter entsprechen Ihrer Suche."
+      "noSearchResults": "Keine Mitarbeiter entsprechen Ihrer Suche.",
+      "allDepartments": "Alle Abteilungen",
+      "allLocations": "Alle Standorte"
     },
     "export": {
       "title": "Anwesenheitsbericht exportieren",
@@ -1308,7 +1310,8 @@
         "reset": "Zurücksetzen"
       },
       "applyLeaveFailed": "Urlaub konnte nicht beantragt werden"
-    }
+    },
+    "location": "Standort"
   },
   "manager": {
     "title": "Mein Team",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "Name, E-Mail oder Abteilung suchen",
       "noSearchResults": "Keine Mitarbeiter entsprechen Ihrer Suche.",
       "allDepartments": "Alle Abteilungen",
-      "allLocations": "Alle Standorte"
+      "allLocations": "Alle Standorte",
+      "export": "Exportieren"
     },
     "export": {
       "title": "Anwesenheitsbericht exportieren",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -984,7 +984,8 @@
       "minSuffix": "min",
       "close": "Close",
       "allDepartments": "All departments",
-      "allLocations": "All locations"
+      "allLocations": "All locations",
+      "export": "Export"
     },
     "export": {
       "title": "Export Attendance Report",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -982,7 +982,9 @@
       "noEmployeesInCategory": "No employees in this category.",
       "lateBy": "Late By",
       "minSuffix": "min",
-      "close": "Close"
+      "close": "Close",
+      "allDepartments": "All departments",
+      "allLocations": "All locations"
     },
     "export": {
       "title": "Export Attendance Report",
@@ -1308,7 +1310,8 @@
         "reset": "Reset"
       },
       "applyLeaveFailed": "Failed to apply leave"
-    }
+    },
+    "location": "Location"
   },
   "manager": {
     "title": "My Team",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "Buscar nombre, correo electrónico o departamento",
       "noSearchResults": "Ningún empleado coincide con su búsqueda.",
       "allDepartments": "Todos los departamentos",
-      "allLocations": "Todas las ubicaciones"
+      "allLocations": "Todas las ubicaciones",
+      "export": "Exportar"
     },
     "export": {
       "title": "Exportar informe de asistencia",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -982,7 +982,9 @@
       "close": "Cerrar",
       "dateLabel": "Fecha",
       "searchPlaceholder": "Buscar nombre, correo electrónico o departamento",
-      "noSearchResults": "Ningún empleado coincide con su búsqueda."
+      "noSearchResults": "Ningún empleado coincide con su búsqueda.",
+      "allDepartments": "Todos los departamentos",
+      "allLocations": "Todas las ubicaciones"
     },
     "export": {
       "title": "Exportar informe de asistencia",
@@ -1308,7 +1310,8 @@
         "reset": "Restablecer"
       },
       "applyLeaveFailed": "No se pudo aplicar el permiso"
-    }
+    },
+    "location": "Ubicación"
   },
   "manager": {
     "title": "Mi Equipo",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -982,7 +982,9 @@
       "close": "Fermer",
       "dateLabel": "Date",
       "searchPlaceholder": "Rechercher un nom, un e-mail ou un service",
-      "noSearchResults": "Aucun employé ne correspond à votre recherche."
+      "noSearchResults": "Aucun employé ne correspond à votre recherche.",
+      "allDepartments": "Tous les services",
+      "allLocations": "Tous les emplacements"
     },
     "export": {
       "title": "Exporter le rapport de présence",
@@ -1308,7 +1310,8 @@
         "reset": "Réinitialiser"
       },
       "applyLeaveFailed": "Échec de l'application du congé"
-    }
+    },
+    "location": "Emplacement"
   },
   "manager": {
     "title": "Mon équipe",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "Rechercher un nom, un e-mail ou un service",
       "noSearchResults": "Aucun employé ne correspond à votre recherche.",
       "allDepartments": "Tous les services",
-      "allLocations": "Tous les emplacements"
+      "allLocations": "Tous les emplacements",
+      "export": "Exporter"
     },
     "export": {
       "title": "Exporter le rapport de présence",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -982,7 +982,9 @@
       "close": "बंद करें",
       "dateLabel": "दिनांक",
       "searchPlaceholder": "नाम, ईमेल या विभाग खोजें",
-      "noSearchResults": "आपकी खोज से कोई कर्मचारी मेल नहीं खाता।"
+      "noSearchResults": "आपकी खोज से कोई कर्मचारी मेल नहीं खाता।",
+      "allDepartments": "सभी विभाग",
+      "allLocations": "सभी स्थान"
     },
     "export": {
       "title": "उपस्थिति रिपोर्ट निर्यात करें",
@@ -1308,7 +1310,8 @@
         "reset": "रीसेट"
       },
       "applyLeaveFailed": "अवकाश लागू करने में विफल"
-    }
+    },
+    "location": "स्थान"
   },
   "manager": {
     "title": "मेरी टीम",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "नाम, ईमेल या विभाग खोजें",
       "noSearchResults": "आपकी खोज से कोई कर्मचारी मेल नहीं खाता।",
       "allDepartments": "सभी विभाग",
-      "allLocations": "सभी स्थान"
+      "allLocations": "सभी स्थान",
+      "export": "निर्यात"
     },
     "export": {
       "title": "उपस्थिति रिपोर्ट निर्यात करें",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "氏名、メール、部署で検索",
       "noSearchResults": "検索条件に一致する従業員はいません。",
       "allDepartments": "すべての部門",
-      "allLocations": "すべての勤務地"
+      "allLocations": "すべての勤務地",
+      "export": "エクスポート"
     },
     "export": {
       "title": "勤怠レポートのエクスポート",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -982,7 +982,9 @@
       "close": "閉じる",
       "dateLabel": "日付",
       "searchPlaceholder": "氏名、メール、部署で検索",
-      "noSearchResults": "検索条件に一致する従業員はいません。"
+      "noSearchResults": "検索条件に一致する従業員はいません。",
+      "allDepartments": "すべての部門",
+      "allLocations": "すべての勤務地"
     },
     "export": {
       "title": "勤怠レポートのエクスポート",
@@ -1308,7 +1310,8 @@
         "reset": "リセット"
       },
       "applyLeaveFailed": "休暇の適用に失敗しました"
-    }
+    },
+    "location": "勤務地"
   },
   "manager": {
     "title": "マイチーム",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "Buscar nome, e-mail ou departamento",
       "noSearchResults": "Nenhum funcionário corresponde à sua busca.",
       "allDepartments": "Todos os departamentos",
-      "allLocations": "Todos os locais"
+      "allLocations": "Todos os locais",
+      "export": "Exportar"
     },
     "export": {
       "title": "Exportar relatório de presença",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -982,7 +982,9 @@
       "close": "Fechar",
       "dateLabel": "Data",
       "searchPlaceholder": "Buscar nome, e-mail ou departamento",
-      "noSearchResults": "Nenhum funcionário corresponde à sua busca."
+      "noSearchResults": "Nenhum funcionário corresponde à sua busca.",
+      "allDepartments": "Todos os departamentos",
+      "allLocations": "Todos os locais"
     },
     "export": {
       "title": "Exportar relatório de presença",
@@ -1308,7 +1310,8 @@
         "reset": "Redefinir"
       },
       "applyLeaveFailed": "Falha ao aplicar a licença"
-    }
+    },
+    "location": "Local"
   },
   "manager": {
     "title": "Minha Equipe",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -982,7 +982,9 @@
       "close": "关闭",
       "dateLabel": "日期",
       "searchPlaceholder": "搜索姓名、邮箱或部门",
-      "noSearchResults": "没有符合搜索条件的员工。"
+      "noSearchResults": "没有符合搜索条件的员工。",
+      "allDepartments": "所有部门",
+      "allLocations": "所有地点"
     },
     "export": {
       "title": "导出考勤报表",
@@ -1308,7 +1310,8 @@
         "reset": "重置"
       },
       "applyLeaveFailed": "申请请假失败"
-    }
+    },
+    "location": "地点"
   },
   "manager": {
     "title": "我的团队",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -984,7 +984,8 @@
       "searchPlaceholder": "搜索姓名、邮箱或部门",
       "noSearchResults": "没有符合搜索条件的员工。",
       "allDepartments": "所有部门",
-      "allLocations": "所有地点"
+      "allLocations": "所有地点",
+      "export": "导出"
     },
     "export": {
       "title": "导出考勤报表",

--- a/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
@@ -372,6 +372,29 @@ export default function AttendanceDashboardPage() {
           if (s === "on_leave") return { label: t('attendance.onLeave'), color: "bg-purple-50 text-purple-700" };
           return { label: t('attendance.absent'), color: "bg-red-50 text-red-700" };
         };
+
+        // Export exactly what's on screen — the current tab + department /
+        // location / search filters — as an .xlsx via the shared helper.
+        const exportBreakdown = () => {
+          const headers = [
+            t('common.name'),
+            t('attendance.department'),
+            t('attendance.location'),
+            t('common.status'),
+            t('attendance.checkIn'),
+            t('attendance.breakdown.lateBy'),
+          ];
+          const rows = filteredList.map((emp: any) => [
+            `${emp.first_name ?? ""} ${emp.last_name ?? ""}`.trim(),
+            emp.department ?? "",
+            emp.location ?? "",
+            statusLabel(emp).label,
+            emp.check_in_time ? new Date(emp.check_in_time).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "",
+            Number(emp.late_minutes) > 0 ? `${emp.late_minutes} min` : "",
+          ]);
+          downloadExcel(headers, rows, `attendance-${breakdownOpen}-${breakdownDate}.xlsx`, "Attendance");
+        };
+
         return (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
@@ -395,6 +418,16 @@ export default function AttendanceDashboardPage() {
                     className="px-2.5 py-1.5 border border-gray-300 rounded-lg text-sm"
                   />
                 </div>
+                <button
+                  type="button"
+                  onClick={exportBreakdown}
+                  disabled={breakdownLoading || filteredList.length === 0}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  title={t('attendance.breakdown.export')}
+                >
+                  <Download className="h-4 w-4" />
+                  <span className="hidden sm:inline">{t('attendance.breakdown.export')}</span>
+                </button>
                 <button
                   type="button"
                   onClick={() => setBreakdownOpen(null)}

--- a/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
@@ -248,6 +248,8 @@ export default function AttendanceDashboardPage() {
   const [breakdownDate, setBreakdownDate] = useState(todayStr);
   const [breakdownPage, setBreakdownPage] = useState(1);
   const [breakdownSearch, setBreakdownSearch] = useState("");
+  const [breakdownDept, setBreakdownDept] = useState("");
+  const [breakdownLoc, setBreakdownLoc] = useState("");
   const BREAKDOWN_PAGE_SIZE = 10;
 
   const { data: breakdown, isLoading: breakdownLoading } = useQuery({
@@ -265,6 +267,8 @@ export default function AttendanceDashboardPage() {
     setBreakdownDate(todayStr);
     setBreakdownPage(1);
     setBreakdownSearch("");
+    setBreakdownDept("");
+    setBreakdownLoc("");
     setBreakdownOpen(category);
   };
 
@@ -333,15 +337,29 @@ export default function AttendanceDashboardPage() {
               ...(breakdown?.on_leave ?? []),
             ]
           : (breakdown?.[breakdownOpen] ?? []);
-        // Client-side search over name / email / department within the tab.
+        // Department / location dropdown options — distinct values present in
+        // the current tab, sorted, so we never show an option with no rows.
+        const deptOptions = Array.from(
+          new Set(tabList.map((e: any) => e.department).filter(Boolean) as string[])
+        ).sort((a, b) => a.localeCompare(b));
+        const locOptions = Array.from(
+          new Set(tabList.map((e: any) => e.location).filter(Boolean) as string[])
+        ).sort((a, b) => a.localeCompare(b));
+
+        // Client-side filter: search (name/email/dept) + department + location.
         const q = breakdownSearch.trim().toLowerCase();
-        const filteredList = q
-          ? tabList.filter((emp: any) =>
+        const filteredList = tabList.filter((emp: any) => {
+          if (q) {
+            const matches =
               `${emp.first_name ?? ""} ${emp.last_name ?? ""}`.toLowerCase().includes(q) ||
               String(emp.email ?? "").toLowerCase().includes(q) ||
-              String(emp.department ?? "").toLowerCase().includes(q)
-            )
-          : tabList;
+              String(emp.department ?? "").toLowerCase().includes(q);
+            if (!matches) return false;
+          }
+          if (breakdownDept && emp.department !== breakdownDept) return false;
+          if (breakdownLoc && emp.location !== breakdownLoc) return false;
+          return true;
+        });
         const totalPages = Math.max(1, Math.ceil(filteredList.length / BREAKDOWN_PAGE_SIZE));
         // Clamp so a shrinking list (after a tab/date/search change) can never
         // strand us on an out-of-range page.
@@ -417,7 +435,7 @@ export default function AttendanceDashboardPage() {
                 })}
               </div>
             </div>
-            <div className="px-6 py-3 border-b border-gray-200">
+            <div className="px-6 py-3 border-b border-gray-200 space-y-2">
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
                 <input
@@ -427,6 +445,30 @@ export default function AttendanceDashboardPage() {
                   placeholder={t('attendance.breakdown.searchPlaceholder')}
                   className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg text-sm"
                 />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <select
+                  value={breakdownDept}
+                  onChange={(e) => { setBreakdownDept(e.target.value); setBreakdownPage(1); }}
+                  className="flex-1 min-w-[10rem] px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+                  aria-label={t('attendance.department')}
+                >
+                  <option value="">{t('attendance.breakdown.allDepartments')}</option>
+                  {deptOptions.map((d) => (
+                    <option key={d} value={d}>{d}</option>
+                  ))}
+                </select>
+                <select
+                  value={breakdownLoc}
+                  onChange={(e) => { setBreakdownLoc(e.target.value); setBreakdownPage(1); }}
+                  className="flex-1 min-w-[10rem] px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white"
+                  aria-label={t('attendance.location')}
+                >
+                  <option value="">{t('attendance.breakdown.allLocations')}</option>
+                  {locOptions.map((l) => (
+                    <option key={l} value={l}>{l}</option>
+                  ))}
+                </select>
               </div>
             </div>
             <div className="overflow-y-auto flex-1 px-6 py-4">

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -877,6 +877,7 @@ export async function getDashboardBreakdown(orgId: number, date?: string, userId
 
   const baseQuery = db("users as u")
     .leftJoin("organization_departments as d", "u.department_id", "d.id")
+    .leftJoin("organization_locations as loc", "u.location_id", "loc.id")
     .leftJoin("attendance_records as ar", function () {
       this.on("ar.user_id", "=", "u.id").andOnVal("ar.date", "=", forDate);
     })
@@ -895,6 +896,7 @@ export async function getDashboardBreakdown(orgId: number, date?: string, userId
       "u.email",
       "u.designation",
       "d.name as department",
+      "loc.name as location",
       "ar.status as attendance_status",
       "ar.check_in as check_in_time",
       "ar.check_out as check_out_time",


### PR DESCRIPTION
## Summary
The **Attendance Details** breakdown modal (opened by clicking a dashboard stat card — Present / Absent / Late / On Leave) only had a text search and status tabs. Add **Department** and **Location** dropdown filters that combine with the existing search and tabs, matching the main dashboard's filtering.

## Changes
**Server** (`attendance.service.ts`)
- The `/attendance/dashboard/breakdown` response now includes each employee's **location** (joined from `organization_locations`). It already returned `department`.

**Client** (`AttendanceDashboardPage.tsx`)
- Two dropdowns below the search box: **Department** and **Location**, populated from the distinct values present in the current results (no empty options).
- The client-side filter now applies search + department + location together. All filters reset when the modal reopens.

Adds i18n keys `attendance.location` + `attendance.breakdown.{allDepartments, allLocations}` across all 9 locales.

## Test
Attendance dashboard → click a stat card → the modal now has Department and Location dropdowns under the search. Combine e.g. Location = "Remote" + Department = "HR" to narrow the list; works across all status tabs.
