### PR TITLE
fix(celebrations): relabel 'This Month' as 'Upcoming · Next 30 days'

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -6839,6 +6839,8 @@
     "filterAll": "الكل",
     "todaysCelebrations": "احتفالات اليوم",
     "thisMonth": "هذا الشهر",
+    "upcoming": "القادمة",
+    "upcomingRange": "الـ 30 يومًا القادمة",
     "happyBirthday": "عيد ميلاد سعيد! 🎂",
     "yearsToday": "{{count}} سنوات اليوم 🏆",
     "birthday": "عيد ميلاد",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -6467,6 +6467,8 @@
     "filterAll": "Alle",
     "todaysCelebrations": "Heutige Feiern",
     "thisMonth": "Diesen Monat",
+    "upcoming": "Bevorstehend",
+    "upcomingRange": "Nächste 30 Tage",
     "happyBirthday": "Alles Gute zum Geburtstag! 🎂",
     "yearsToday": "heute {{count}} Jahre 🏆",
     "birthday": "Geburtstag",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -6467,6 +6467,8 @@
     "filterAll": "All",
     "todaysCelebrations": "Today's Celebrations",
     "thisMonth": "This Month",
+    "upcoming": "Upcoming",
+    "upcomingRange": "Next 30 days",
     "happyBirthday": "Happy Birthday! 🎂",
     "yearsToday": "{{count}} years today 🏆",
     "birthday": "Birthday",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -6467,6 +6467,8 @@
     "filterAll": "Todos",
     "todaysCelebrations": "Celebraciones de hoy",
     "thisMonth": "Este mes",
+    "upcoming": "Próximos",
+    "upcomingRange": "Próximos 30 días",
     "happyBirthday": "¡Feliz cumpleaños! 🎂",
     "yearsToday": "{{count}} años hoy 🏆",
     "birthday": "Cumpleaños",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -6467,6 +6467,8 @@
     "filterAll": "Tous",
     "todaysCelebrations": "Célébrations du jour",
     "thisMonth": "Ce mois-ci",
+    "upcoming": "À venir",
+    "upcomingRange": "30 prochains jours",
     "happyBirthday": "Joyeux anniversaire ! 🎂",
     "yearsToday": "{{count}} ans aujourd'hui 🏆",
     "birthday": "Anniversaire",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -6467,6 +6467,8 @@
     "filterAll": "सभी",
     "todaysCelebrations": "आज के उत्सव",
     "thisMonth": "इस माह",
+    "upcoming": "आगामी",
+    "upcomingRange": "अगले 30 दिन",
     "happyBirthday": "जन्मदिन मुबारक! 🎂",
     "yearsToday": "आज {{count}} वर्ष 🏆",
     "birthday": "जन्मदिन",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -6467,6 +6467,8 @@
     "filterAll": "すべて",
     "todaysCelebrations": "今日のお祝い",
     "thisMonth": "今月",
+    "upcoming": "今後の予定",
+    "upcomingRange": "今後30日間",
     "happyBirthday": "お誕生日おめでとう！🎂",
     "yearsToday": "本日で{{count}}年 🏆",
     "birthday": "誕生日",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -6467,6 +6467,8 @@
     "filterAll": "Todos",
     "todaysCelebrations": "Celebrações de hoje",
     "thisMonth": "Este mês",
+    "upcoming": "Próximos",
+    "upcomingRange": "Próximos 30 dias",
     "happyBirthday": "Feliz aniversário! 🎂",
     "yearsToday": "{{count}} anos hoje 🏆",
     "birthday": "Aniversário",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -6467,6 +6467,8 @@
     "filterAll": "全部",
     "todaysCelebrations": "今日庆祝",
     "thisMonth": "本月",
+    "upcoming": "即将到来",
+    "upcomingRange": "未来 30 天",
     "happyBirthday": "生日快乐！🎂",
     "yearsToday": "今天{{count}}周年 🏆",
     "birthday": "生日",

--- a/packages/client/src/pages/celebrations/CelebrationsPage.tsx
+++ b/packages/client/src/pages/celebrations/CelebrationsPage.tsx
@@ -280,9 +280,19 @@ export default function CelebrationsPage() {
             </div>
           )}
 
-          {/* ── This month ────────────────────────────────────────────── */}
+          {/* ── Upcoming (next 30 days) ──────────────────────────────────
+              This is a rolling 30-day lookahead from the server, so it
+              deliberately spills into the next calendar month (e.g. an early-
+              August birthday shows in mid-July). Labelled "Upcoming" with a
+              "Next 30 days" caption rather than "This Month" so those
+              next-month entries don't read as a bug. */}
           <section>
-            <SectionHeading emoji="🗓️" title={t("celebrations.thisMonth")} count={upcoming.length} />
+            <SectionHeading
+              emoji="🗓️"
+              title={t("celebrations.upcoming")}
+              hint={t("celebrations.upcomingRange")}
+              count={upcoming.length}
+            />
             {upcoming.length === 0 ? (
               <EmptyState
                 title={t("celebrations.noUpcomingTitle")}
@@ -350,7 +360,17 @@ function FilterTab({
   );
 }
 
-function SectionHeading({ emoji, title, count }: { emoji: string; title: string; count: number }) {
+function SectionHeading({
+  emoji,
+  title,
+  count,
+  hint,
+}: {
+  emoji: string;
+  title: string;
+  count: number;
+  hint?: string;
+}) {
   return (
     <div className="mb-4 flex items-center gap-2">
       <span className="text-lg" aria-hidden>
@@ -360,6 +380,7 @@ function SectionHeading({ emoji, title, count }: { emoji: string; title: string;
       <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-600 tabular-nums">
         {count}
       </span>
+      {hint ? <span className="ml-1 text-xs font-medium text-gray-400">{hint}</span> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Fix: Celebrations "This Month" section shows next-month birthdays

**Reported:** on the Celebrations page, an early-August birthday (e.g. "6 Aug · in 24 days") appears under a **"This Month"** heading in mid-July, which looks like a bug.

**Root cause — a mislabel, not bad data.** The Celebrations endpoints deliberately return a **rolling 30-day lookahead** so teams get a heads-up on next week's birthday even when it lands early next month. A 6 Aug birthday 24 days out is correctly inside that window — but under a "This Month" heading, an August date in July reads as wrong.

**Fix**
- Rename the section **"This Month" → "Upcoming"** and add a small **"Next 30 days"** caption next to the heading, so the lookahead window is self-explanatory.
- Keep the 30-day behavior itself (the useful HR lookahead).
- Add `celebrations.upcoming` / `celebrations.upcomingRange` to **all 9 locales** (en, hi, es, fr, de, pt, ar, ja, zh).
- Extend `SectionHeading` with an optional `hint` caption.

**Verification**
- Client-local `tsc --noEmit`: **0 errors**.
- Frontend-only; no server/migration changes.

Header now reads: **🗓️ Upcoming · [count] · Next 30 days**.
