### PR TITLE
feat(theme): themed dark-mode scrollbars (replace bright default with subtle gray)

### DIFF
--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -42,6 +42,36 @@
 }
 
 @layer base {
+  /* Dark-mode scrollbars. The browser's default scrollbar stays light in
+     dark mode (it's chrome, not page CSS), which reads as a jarring bright
+     bar against the dark sidebar / panels. Theme it to the token palette in
+     dark mode only; light mode keeps the native scrollbar. Covers Webkit
+     (Chrome/Edge/Safari) and Firefox (scrollbar-color/width). */
+  .dark {
+    scrollbar-color: hsl(var(--muted-foreground) / 0.35) transparent;
+    scrollbar-width: thin;
+  }
+  .dark ::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  .dark ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .dark ::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--muted-foreground) / 0.3);
+    border-radius: 9999px;
+    /* transparent border creates padding so the thumb reads as a thin pill */
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+  .dark ::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.55);
+  }
+  .dark ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
   body {
     @apply bg-background text-foreground antialiased;
   }


### PR DESCRIPTION
## Problem

In dark mode, scrollbars (e.g. the sidebar's) render as a bright **white/light-gray** bar. The browser's default scrollbar is chrome, not page CSS, so it doesn't follow the theme — it stays light and reads as jarring against the dark surfaces.

## Fix

Added themed scrollbar styling in `globals.css`, **scoped to `.dark` only**:

- **Thumb** — subtle gray pill using `--muted-foreground` at 30% opacity, brightening to 55% on hover
- **Track** — transparent (blends into the sidebar / panel)
- Thin, rounded, with a transparent border so it reads as a slim pill
- Covers **Webkit** (Chrome/Edge/Safari via `::-webkit-scrollbar`) and **Firefox** (`scrollbar-color` / `scrollbar-width`)

**Light mode is untouched** — it keeps the native scrollbar.

Because it's token-based and global, this fixes every scrollbar in dark mode — the sidebar, tables, dropdowns, and any scrollable panel.

## Verification

`tsc --noEmit` = 0 errors, `vite build` passes. **1 file changed.**
