### PR TITLE
fix(theme): dark-mode autofill background (login email box renders white on autofill)

### DIFF
--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -46,6 +46,27 @@
     @apply bg-background text-foreground antialiased;
   }
 
+  /* Browser autofill in dark mode. Chrome/Safari force their own light-yellow
+     `-webkit-autofill` background on autofilled fields, which overrides
+     `bg-card` and leaves a bright white/yellow box (e.g. the login email
+     field once the browser fills it) sitting on the dark card. You can't set
+     `background` on an autofilled input directly, so paint over it with a
+     large inset box-shadow tinted to --card and force the text color to
+     --foreground. Long transition-delay stops the brief flash of the native
+     colour on focus. Scoped to .dark so light mode keeps native autofill. */
+  .dark input:-webkit-autofill,
+  .dark input:-webkit-autofill:hover,
+  .dark input:-webkit-autofill:focus,
+  .dark input:-webkit-autofill:active,
+  .dark textarea:-webkit-autofill,
+  .dark select:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px hsl(var(--card)) inset !important;
+    box-shadow: 0 0 0 1000px hsl(var(--card)) inset !important;
+    -webkit-text-fill-color: hsl(var(--foreground)) !important;
+    caret-color: hsl(var(--foreground));
+    transition: background-color 9999s ease-in-out 0s;
+  }
+
   /* RTL (Arabic) layout support — flip directional properties */
   [dir="rtl"] {
     direction: rtl;


### PR DESCRIPTION
## Problem

On the login page in dark mode, the **email input renders with a light/white background** while the password field (right below it, identical classes) is correctly dark. See screenshot — the email box stands out as white-on-dark.

## Root cause

**Not a CSS class bug** — both inputs share `bg-card text-foreground`. The white box is Chrome/Safari's **`-webkit-autofill` styling**: once the browser autofills a field (the email was pre-filled), it forces its own light-yellow/white background that **overrides** `bg-card`. The password field wasn't autofilled the same way, so it stayed dark. There was no autofill handling in the stylesheet, so the native light autofill bled through in dark mode.

## Fix

Added a dark-mode autofill override in `globals.css` (`@layer base`, scoped to `.dark`):
- You can't set `background` on an autofilled input directly, so paint over it with a large **inset `box-shadow`** tinted to `--card`.
- `-webkit-text-fill-color: --foreground` for readable text, `caret-color: --foreground`.
- Long `transition-delay` suppresses the brief flash of the native colour on focus.
- Covers `input` / `textarea` / `select` in all autofill states (hover/focus/active).

**Light mode is untouched** — it keeps native autofill.

This fixes every autofilled input across the app in dark mode, not just login.

## Verification

`tsc --noEmit` = 0 errors, `vite build` passes. **1 file changed.**
