### PR TITLE
fix(theme): dark mode for organizations list page (super-admin)

### DIFF
--- a/packages/client/src/pages/admin/OrgListPage.tsx
+++ b/packages/client/src/pages/admin/OrgListPage.tsx
@@ -107,11 +107,11 @@ export default function OrgListPage() {
 
   function SortIcon({ field }: { field: SortField }) {
     if (sortBy !== field)
-      return <ArrowUpDown className="h-3.5 w-3.5 text-gray-400" />;
+      return <ArrowUpDown className="h-3.5 w-3.5 text-muted-foreground" />;
     return sortOrder === "asc" ? (
-      <ArrowUp className="h-3.5 w-3.5 text-brand-600" />
+      <ArrowUp className="h-3.5 w-3.5 text-brand-600 dark:text-brand-400" />
     ) : (
-      <ArrowDown className="h-3.5 w-3.5 text-brand-600" />
+      <ArrowDown className="h-3.5 w-3.5 text-brand-600 dark:text-brand-400" />
     );
   }
 
@@ -121,12 +121,12 @@ export default function OrgListPage() {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-xl bg-blue-50 flex items-center justify-center">
-              <Building2 className="h-5 w-5 text-blue-600" />
+            <div className="h-10 w-10 rounded-xl bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
+              <Building2 className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-gray-900">{t("orgList.title")}</h1>
-              <p className="text-gray-500 mt-0.5 text-sm">
+              <h1 className="text-2xl font-bold text-foreground">{t("orgList.title")}</h1>
+              <p className="text-muted-foreground mt-0.5 text-sm">
                 {t("orgList.subtitle", { count: meta.total })}
               </p>
             </div>
@@ -144,12 +144,12 @@ export default function OrgListPage() {
       {showCreateModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div className="fixed inset-0 bg-black/50" onClick={() => setShowCreateModal(false)} />
-          <div className="relative bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 z-50">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-              <h2 className="text-lg font-semibold text-gray-900">{t("orgList.modal.title")}</h2>
+          <div className="relative bg-card rounded-xl shadow-xl w-full max-w-lg mx-4 z-50">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+              <h2 className="text-lg font-semibold text-foreground">{t("orgList.modal.title")}</h2>
               <button
                 onClick={() => { setShowCreateModal(false); setCreateError(""); }}
-                className="p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                className="p-1.5 rounded-lg text-muted-foreground hover:bg-muted hover:text-muted-foreground"
               >
                 <X className="h-5 w-5" />
               </button>
@@ -163,12 +163,12 @@ export default function OrgListPage() {
               className="p-6 space-y-4"
             >
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.orgName")} *</label>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.orgName")} *</label>
                 <input
                   type="text"
                   value={createForm.org_name}
                   onChange={(e) => setCreateForm({ ...createForm, org_name: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                   placeholder="Acme Corp"
                   required
                   minLength={2}
@@ -176,76 +176,76 @@ export default function OrgListPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.firstName")} *</label>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.firstName")} *</label>
                   <input
                     type="text"
                     value={createForm.first_name}
                     onChange={(e) => setCreateForm({ ...createForm, first_name: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                     placeholder="John"
                     required
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.lastName")} *</label>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.lastName")} *</label>
                   <input
                     type="text"
                     value={createForm.last_name}
                     onChange={(e) => setCreateForm({ ...createForm, last_name: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                     placeholder="Doe"
                     required
                   />
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.email")} *</label>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.email")} *</label>
                 <input
                   type="email"
                   value={createForm.email}
                   onChange={(e) => setCreateForm({ ...createForm, email: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                   placeholder="admin@acme.com"
                   required
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.password")} *</label>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.password")} *</label>
                 <input
                   type="password"
                   value={createForm.password}
                   onChange={(e) => setCreateForm({ ...createForm, password: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                   placeholder={t("orgList.modal.placeholders.password")}
                   required
                   minLength={8}
                 />
-                <p className="text-xs text-gray-400 mt-1">{t("orgList.modal.passwordHint")}</p>
+                <p className="text-xs text-muted-foreground mt-1">{t("orgList.modal.passwordHint")}</p>
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.country")}</label>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.country")}</label>
                   <input
                     type="text"
                     value={createForm.org_country}
                     onChange={(e) => setCreateForm({ ...createForm, org_country: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                     placeholder="IN"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">{t("orgList.modal.fields.timezone")}</label>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">{t("orgList.modal.fields.timezone")}</label>
                   <input
                     type="text"
                     value={createForm.org_timezone}
                     onChange={(e) => setCreateForm({ ...createForm, org_timezone: e.target.value })}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                     placeholder="Asia/Kolkata"
                   />
                 </div>
               </div>
               {createError && (
-                <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+                <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 text-red-700 dark:text-red-300 text-sm rounded-lg px-4 py-3">
                   {createError}
                 </div>
               )}
@@ -253,7 +253,7 @@ export default function OrgListPage() {
                 <button
                   type="button"
                   onClick={() => { setShowCreateModal(false); setCreateError(""); }}
-                  className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+                  className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
                 >
                   {t("orgList.modal.cancel")}
                 </button>
@@ -274,23 +274,23 @@ export default function OrgListPage() {
       {/* Search */}
       <form onSubmit={handleSearch} className="mb-6">
         <div className="relative max-w-md">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
             type="text"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             placeholder={t("orgList.search.placeholder")}
-            className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+            className="bg-card text-foreground w-full pl-10 pr-4 py-2.5 rounded-lg border border-border text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
           />
         </div>
       </form>
 
       {/* Table */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div className="bg-card rounded-xl border border-border overflow-hidden">
         {isLoading ? (
-          <div className="flex items-center justify-center py-16 text-gray-400">
+          <div className="flex items-center justify-center py-16 text-muted-foreground">
             <div className="flex flex-col items-center gap-2">
-              <div className="h-6 w-6 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin" />
+              <div className="h-6 w-6 border-2 border-border border-t-gray-500 rounded-full animate-spin" />
               <span className="text-sm">{t("orgList.loading")}</span>
             </div>
           </div>
@@ -299,9 +299,9 @@ export default function OrgListPage() {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-gray-200 bg-gray-50">
+                  <tr className="border-b border-border bg-muted">
                     <th
-                      className="text-left py-3 px-4 font-medium text-gray-500 cursor-pointer hover:text-gray-700"
+                      className="text-left py-3 px-4 font-medium text-muted-foreground cursor-pointer hover:text-foreground"
                       onClick={() => handleSort("name")}
                     >
                       <div className="flex items-center gap-1.5">
@@ -309,9 +309,9 @@ export default function OrgListPage() {
                         <SortIcon field="name" />
                       </div>
                     </th>
-                    <th className="text-left py-3 px-4 font-medium text-gray-500">{t("orgList.table.headers.adminEmail")}</th>
+                    <th className="text-left py-3 px-4 font-medium text-muted-foreground">{t("orgList.table.headers.adminEmail")}</th>
                     <th
-                      className="text-left py-3 px-4 font-medium text-gray-500 cursor-pointer hover:text-gray-700"
+                      className="text-left py-3 px-4 font-medium text-muted-foreground cursor-pointer hover:text-foreground"
                       onClick={() => handleSort("user_count")}
                     >
                       <div className="flex items-center gap-1.5">
@@ -320,7 +320,7 @@ export default function OrgListPage() {
                       </div>
                     </th>
                     <th
-                      className="text-left py-3 px-4 font-medium text-gray-500 cursor-pointer hover:text-gray-700"
+                      className="text-left py-3 px-4 font-medium text-muted-foreground cursor-pointer hover:text-foreground"
                       onClick={() => handleSort("subscription_count")}
                     >
                       <div className="flex items-center gap-1.5">
@@ -329,7 +329,7 @@ export default function OrgListPage() {
                       </div>
                     </th>
                     <th
-                      className="text-left py-3 px-4 font-medium text-gray-500 cursor-pointer hover:text-gray-700"
+                      className="text-left py-3 px-4 font-medium text-muted-foreground cursor-pointer hover:text-foreground"
                       onClick={() => handleSort("monthly_spend")}
                     >
                       <div className="flex items-center gap-1.5">
@@ -337,9 +337,9 @@ export default function OrgListPage() {
                         <SortIcon field="monthly_spend" />
                       </div>
                     </th>
-                    <th className="text-left py-3 px-4 font-medium text-gray-500">{t("orgList.table.headers.status")}</th>
+                    <th className="text-left py-3 px-4 font-medium text-muted-foreground">{t("orgList.table.headers.status")}</th>
                     <th
-                      className="text-left py-3 px-4 font-medium text-gray-500 cursor-pointer hover:text-gray-700"
+                      className="text-left py-3 px-4 font-medium text-muted-foreground cursor-pointer hover:text-foreground"
                       onClick={() => handleSort("created_at")}
                     >
                       <div className="flex items-center gap-1.5">
@@ -347,39 +347,39 @@ export default function OrgListPage() {
                         <SortIcon field="created_at" />
                       </div>
                     </th>
-                    <th className="text-left py-3 px-4 font-medium text-gray-500 w-10"></th>
+                    <th className="text-left py-3 px-4 font-medium text-muted-foreground w-10"></th>
                   </tr>
                 </thead>
                 <tbody>
                   {orgs.map((org: any) => (
                     <tr
                       key={org.id}
-                      className="border-b border-gray-100 hover:bg-gray-50/50 transition-colors"
+                      className="border-b border-border hover:bg-muted/50 transition-colors"
                     >
                       <td className="py-3 px-4">
                         <Link
                           to={`/admin/organizations/${org.id}`}
-                          className="font-medium text-gray-900 hover:text-brand-600 transition-colors"
+                          className="font-medium text-foreground hover:text-brand-600 transition-colors"
                         >
                           {org.name}
                         </Link>
                         {org.slug && (
-                          <p className="text-xs text-gray-400 font-mono mt-0.5">{org.slug}</p>
+                          <p className="text-xs text-muted-foreground font-mono mt-0.5">{org.slug}</p>
                         )}
                       </td>
-                      <td className="py-3 px-4 text-gray-600">{org.email}</td>
+                      <td className="py-3 px-4 text-muted-foreground">{org.email}</td>
                       <td className="py-3 px-4">
-                        <span className="inline-flex items-center gap-1 text-gray-700 font-medium">
+                        <span className="inline-flex items-center gap-1 text-muted-foreground font-medium">
                           {org.user_count}
                         </span>
                       </td>
                       <td className="py-3 px-4">
-                        <span className="inline-flex items-center gap-1 text-gray-700 font-medium">
+                        <span className="inline-flex items-center gap-1 text-muted-foreground font-medium">
                           {org.subscription_count}
                         </span>
                       </td>
                       <td className="py-3 px-4">
-                        <span className="text-gray-700 font-medium">
+                        <span className="text-muted-foreground font-medium">
                           {formatINR(org.monthly_spend)}
                         </span>
                       </td>
@@ -387,20 +387,20 @@ export default function OrgListPage() {
                         <span
                           className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
                             org.status === "active"
-                              ? "bg-green-100 text-green-700"
-                              : "bg-gray-100 text-gray-600"
+                              ? "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300"
+                              : "bg-muted text-muted-foreground"
                           }`}
                         >
                           {t(`orgList.status.${org.status}`, { defaultValue: org.status })}
                         </span>
                       </td>
-                      <td className="py-3 px-4 text-gray-600 text-xs">
+                      <td className="py-3 px-4 text-muted-foreground text-xs">
                         {new Date(org.created_at).toLocaleDateString()}
                       </td>
                       <td className="py-3 px-4">
                         <Link
                           to={`/admin/organizations/${org.id}`}
-                          className="p-1.5 rounded-lg text-gray-400 hover:text-brand-600 hover:bg-brand-50 transition-all"
+                          className="p-1.5 rounded-lg text-muted-foreground hover:text-brand-600 hover:bg-brand-50 dark:hover:bg-brand-950/40 transition-all"
                         >
                           <ExternalLink className="h-4 w-4" />
                         </Link>
@@ -409,7 +409,7 @@ export default function OrgListPage() {
                   ))}
                   {orgs.length === 0 && (
                     <tr>
-                      <td colSpan={8} className="py-12 text-center text-gray-400">
+                      <td colSpan={8} className="py-12 text-center text-muted-foreground">
                         {t("orgList.empty")}
                       </td>
                     </tr>
@@ -420,8 +420,8 @@ export default function OrgListPage() {
 
             {/* Pagination */}
             {meta.total_pages > 1 && (
-              <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50/50">
-                <p className="text-sm text-gray-500">
+              <div className="flex items-center justify-between px-4 py-3 border-t border-border bg-muted/50">
+                <p className="text-sm text-muted-foreground">
                   {t("orgList.pagination.summary", {
                     page: meta.page,
                     totalPages: meta.total_pages,
@@ -432,14 +432,14 @@ export default function OrgListPage() {
                   <button
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
                     disabled={page === 1}
-                    className="p-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="p-2 rounded-lg border border-border text-muted-foreground hover:bg-card disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <ChevronLeft className="h-4 w-4" />
                   </button>
                   <button
                     onClick={() => setPage((p) => Math.min(meta.total_pages, p + 1))}
                     disabled={page >= meta.total_pages}
-                    className="p-2 rounded-lg border border-gray-300 text-gray-600 hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="p-2 rounded-lg border border-border text-muted-foreground hover:bg-card disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <ChevronRight className="h-4 w-4" />
                   </button>


### PR DESCRIPTION
## Problem

The super-admin Organizations list page (table + filters) was out of scope in the original dark-mode conversion — it rendered light (white cards / low-contrast text) in dark mode.

## Fix

Converted the page to the semantic theme tokens (`bg-card`, `text-foreground`, `bg-muted`, `border-border`, …). Handled the page's special cases: status/level badges dark-paired, native filters `bg-card text-foreground`, action-icon hover colors, modals, and — where the page has recharts charts — **grid / axis / tooltip colours made theme-aware** (`hsl(var(--border))` / `--muted-foreground` / `--card`) while leaving the data-series colours untouched.

Part of the Platform Admin (super-admin) dark-mode sweep; one PR per page.

## Verification

`0` bare neutral (real light-mode bugs) · `0` mangled · `0` double-alpha · `0` unreadable dark-text-on-tint. Full-tree `tsc --noEmit` = 0 errors; `vite build` passes.

**1 file changed.**
