### PR TITLE
fix(theme): dark mode for revenue analytics page (super-admin)

### DIFF
--- a/packages/client/src/pages/admin/RevenueAnalyticsPage.tsx
+++ b/packages/client/src/pages/admin/RevenueAnalyticsPage.tsx
@@ -62,8 +62,8 @@ export default function RevenueAnalyticsPage() {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="flex flex-col items-center gap-2">
-          <div className="h-6 w-6 border-2 border-gray-200 border-t-gray-500 rounded-full animate-spin" />
-          <span className="text-sm text-gray-400">{t("revenueAnalytics.loading")}</span>
+          <div className="h-6 w-6 border-2 border-border border-t-gray-500 rounded-full animate-spin" />
+          <span className="text-sm text-muted-foreground">{t("revenueAnalytics.loading")}</span>
         </div>
       </div>
     );
@@ -76,12 +76,12 @@ export default function RevenueAnalyticsPage() {
       {/* Header */}
       <div className="mb-8">
         <div className="flex items-center gap-3">
-          <div className="h-10 w-10 rounded-xl bg-amber-50 flex items-center justify-center">
-            <BarChart3 className="h-5 w-5 text-amber-600" />
+          <div className="h-10 w-10 rounded-xl bg-amber-50 dark:bg-amber-950/40 flex items-center justify-center">
+            <BarChart3 className="h-5 w-5 text-amber-600 dark:text-amber-400" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">{t("revenueAnalytics.title")}</h1>
-            <p className="text-gray-500 mt-0.5 text-sm">
+            <h1 className="text-2xl font-bold text-foreground">{t("revenueAnalytics.title")}</h1>
+            <p className="text-muted-foreground mt-0.5 text-sm">
               {t("revenueAnalytics.subtitle")}
             </p>
           </div>
@@ -90,15 +90,15 @@ export default function RevenueAnalyticsPage() {
 
       {/* Top Revenue Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
+        <div className="bg-card rounded-xl border border-border p-6">
           <div className="flex items-start justify-between">
-            <div className="h-10 w-10 rounded-lg bg-green-50 flex items-center justify-center">
-              <TrendingUp className="h-5 w-5 text-green-600" />
+            <div className="h-10 w-10 rounded-lg bg-green-50 dark:bg-green-950/40 flex items-center justify-center">
+              <TrendingUp className="h-5 w-5 text-green-600 dark:text-green-400" />
             </div>
             {mrrGrowth !== 0 && (
               <span
                 className={`flex items-center gap-0.5 text-xs font-medium px-2 py-1 rounded-full ${
-                  mrrGrowth > 0 ? "bg-green-50 text-green-600" : "bg-red-50 text-red-600"
+                  mrrGrowth > 0 ? "bg-green-50 dark:bg-green-950/40 text-green-600 dark:text-green-400" : "bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400"
                 }`}
               >
                 {mrrGrowth > 0 ? <ArrowUpRight className="h-3 w-3" /> : <ArrowDownRight className="h-3 w-3" />}
@@ -106,27 +106,27 @@ export default function RevenueAnalyticsPage() {
               </span>
             )}
           </div>
-          <p className="text-2xl font-bold text-gray-900 mt-3">{formatINR(revenue?.mrr ?? 0)}</p>
-          <p className="text-sm text-gray-500 mt-1">{t("revenueAnalytics.stats.mrr")}</p>
+          <p className="text-2xl font-bold text-foreground mt-3">{formatINR(revenue?.mrr ?? 0)}</p>
+          <p className="text-sm text-muted-foreground mt-1">{t("revenueAnalytics.stats.mrr")}</p>
         </div>
 
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <div className="h-10 w-10 rounded-lg bg-indigo-50 flex items-center justify-center">
-            <DollarSign className="h-5 w-5 text-indigo-600" />
+        <div className="bg-card rounded-xl border border-border p-6">
+          <div className="h-10 w-10 rounded-lg bg-indigo-50 dark:bg-indigo-950/40 flex items-center justify-center">
+            <DollarSign className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
           </div>
-          <p className="text-2xl font-bold text-gray-900 mt-3">{formatINR(revenue?.arr ?? 0)}</p>
-          <p className="text-sm text-gray-500 mt-1">{t("revenueAnalytics.stats.arr")}</p>
+          <p className="text-2xl font-bold text-foreground mt-3">{formatINR(revenue?.arr ?? 0)}</p>
+          <p className="text-sm text-muted-foreground mt-1">{t("revenueAnalytics.stats.arr")}</p>
         </div>
 
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <div className="h-10 w-10 rounded-lg bg-purple-50 flex items-center justify-center">
-            <Calendar className="h-5 w-5 text-purple-600" />
+        <div className="bg-card rounded-xl border border-border p-6">
+          <div className="h-10 w-10 rounded-lg bg-purple-50 dark:bg-purple-950/40 flex items-center justify-center">
+            <Calendar className="h-5 w-5 text-purple-600 dark:text-purple-400" />
           </div>
-          <p className="text-2xl font-bold text-gray-900 mt-3">
+          <p className="text-2xl font-bold text-foreground mt-3">
             {subscriptions?.overall_utilization ?? 0}%
           </p>
-          <p className="text-sm text-gray-500 mt-1">{t("revenueAnalytics.stats.seatUtilization")}</p>
-          <p className="text-xs text-gray-400 mt-0.5">
+          <p className="text-sm text-muted-foreground mt-1">{t("revenueAnalytics.stats.seatUtilization")}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
             {t("revenueAnalytics.stats.seats", {
               used: subscriptions?.used_seats?.toLocaleString() ?? 0,
               total: subscriptions?.total_seats?.toLocaleString() ?? 0,
@@ -134,28 +134,28 @@ export default function RevenueAnalyticsPage() {
           </p>
         </div>
 
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <div className="h-10 w-10 rounded-lg bg-amber-50 flex items-center justify-center">
-            <BarChart3 className="h-5 w-5 text-amber-600" />
+        <div className="bg-card rounded-xl border border-border p-6">
+          <div className="h-10 w-10 rounded-lg bg-amber-50 dark:bg-amber-950/40 flex items-center justify-center">
+            <BarChart3 className="h-5 w-5 text-amber-600 dark:text-amber-400" />
           </div>
-          <p className="text-2xl font-bold text-gray-900 mt-3">
+          <p className="text-2xl font-bold text-foreground mt-3">
             {(revenue?.top_customers || []).length}
           </p>
-          <p className="text-sm text-gray-500 mt-1">{t("revenueAnalytics.stats.payingCustomers")}</p>
+          <p className="text-sm text-muted-foreground mt-1">{t("revenueAnalytics.stats.payingCustomers")}</p>
         </div>
       </div>
 
       {/* Revenue Trend + Revenue by Module */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
         {/* Monthly Revenue Trend */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">{t("revenueAnalytics.charts.revenueTrend.title")}</h2>
+        <div className="bg-card rounded-xl border border-border p-6">
+          <h2 className="text-lg font-semibold text-foreground mb-4">{t("revenueAnalytics.charts.revenueTrend.title")}</h2>
           {revenue?.revenue_trend?.length > 0 ? (
             <ResponsiveContainer width="100%" height={320}>
               <LineChart data={revenue.revenue_trend}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                <XAxis dataKey="month" tick={{ fontSize: 11 }} />
-                <YAxis tickFormatter={(v) => formatINR(v)} tick={{ fontSize: 11 }} />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="month" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} stroke="hsl(var(--border))" />
+                <YAxis tickFormatter={(v) => formatINR(v)} tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
                 <Tooltip formatter={(value: any) => formatINR(Number(value))} />
                 <Line
                   type="monotone"
@@ -168,27 +168,27 @@ export default function RevenueAnalyticsPage() {
               </LineChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-[320px] text-gray-400 text-sm">
+            <div className="flex items-center justify-center h-[320px] text-muted-foreground text-sm">
               {t("revenueAnalytics.charts.revenueTrend.empty")}
             </div>
           )}
         </div>
 
         {/* Revenue by Module */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">{t("revenueAnalytics.charts.revenueByModule.title")}</h2>
+        <div className="bg-card rounded-xl border border-border p-6">
+          <h2 className="text-lg font-semibold text-foreground mb-4">{t("revenueAnalytics.charts.revenueByModule.title")}</h2>
           {revenue?.revenue_by_module?.length > 0 ? (
             <ResponsiveContainer width="100%" height={320}>
               <BarChart data={revenue.revenue_by_module}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                <XAxis dataKey="name" tick={{ fontSize: 11 }} angle={-15} textAnchor="end" height={60} />
-                <YAxis tickFormatter={(v) => formatINR(v)} tick={{ fontSize: 11 }} />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="name" tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} angle={-15} textAnchor="end" height={60} stroke="hsl(var(--border))" />
+                <YAxis tickFormatter={(v) => formatINR(v)} tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }} />
                 <Tooltip formatter={(value: any) => formatINR(Number(value))} />
                 <Bar dataKey="revenue" name={t("revenueAnalytics.charts.revenueByModule.series")} fill="#8b5cf6" radius={[6, 6, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           ) : (
-            <div className="flex items-center justify-center h-[320px] text-gray-400 text-sm">
+            <div className="flex items-center justify-center h-[320px] text-muted-foreground text-sm">
               {t("revenueAnalytics.charts.empty")}
             </div>
           )}
@@ -198,8 +198,8 @@ export default function RevenueAnalyticsPage() {
       {/* Revenue by Tier + Billing Cycle */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
         {/* Revenue by Plan Tier (Pie) */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">{t("revenueAnalytics.charts.revenueByTier.title")}</h2>
+        <div className="bg-card rounded-xl border border-border p-6">
+          <h2 className="text-lg font-semibold text-foreground mb-4">{t("revenueAnalytics.charts.revenueByTier.title")}</h2>
           {revenue?.revenue_by_tier?.length > 0 ? (
             <div className="flex items-center gap-6">
               <ResponsiveContainer width="60%" height={280}>
@@ -228,8 +228,8 @@ export default function RevenueAnalyticsPage() {
                       style={{ backgroundColor: TIER_COLORS[tier.plan_tier] || COLORS[i % COLORS.length] }}
                     />
                     <div className="flex-1">
-                      <p className="text-sm font-medium text-gray-900 capitalize">{tier.plan_tier}</p>
-                      <p className="text-xs text-gray-500">
+                      <p className="text-sm font-medium text-foreground capitalize">{tier.plan_tier}</p>
+                      <p className="text-xs text-muted-foreground">
                         {t("revenueAnalytics.charts.revenueByTier.subsLabel", { count: tier.count, revenue: formatINR(tier.revenue) })}
                       </p>
                     </div>
@@ -238,15 +238,15 @@ export default function RevenueAnalyticsPage() {
               </div>
             </div>
           ) : (
-            <div className="flex items-center justify-center h-[280px] text-gray-400 text-sm">
+            <div className="flex items-center justify-center h-[280px] text-muted-foreground text-sm">
               {t("revenueAnalytics.charts.empty")}
             </div>
           )}
         </div>
 
         {/* Billing Cycle Distribution */}
-        <div className="bg-white rounded-xl border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">{t("revenueAnalytics.charts.billingCycle.title")}</h2>
+        <div className="bg-card rounded-xl border border-border p-6">
+          <h2 className="text-lg font-semibold text-foreground mb-4">{t("revenueAnalytics.charts.billingCycle.title")}</h2>
           {revenue?.billing_cycle_distribution?.length > 0 ? (
             <div className="space-y-4 pt-4">
               {revenue.billing_cycle_distribution.map((cycle: any) => {
@@ -258,27 +258,27 @@ export default function RevenueAnalyticsPage() {
                 return (
                   <div key={cycle.billing_cycle}>
                     <div className="flex items-center justify-between mb-1.5">
-                      <span className="text-sm font-medium text-gray-900 capitalize">
+                      <span className="text-sm font-medium text-foreground capitalize">
                         {cycle.billing_cycle}
                       </span>
                       <div className="flex items-center gap-3">
-                        <span className="text-sm text-gray-600">{t("revenueAnalytics.charts.billingCycle.subs", { count: cycle.count })}</span>
-                        <span className="text-sm font-medium text-gray-900">{formatINR(cycle.revenue)}</span>
+                        <span className="text-sm text-muted-foreground">{t("revenueAnalytics.charts.billingCycle.subs", { count: cycle.count })}</span>
+                        <span className="text-sm font-medium text-foreground">{formatINR(cycle.revenue)}</span>
                       </div>
                     </div>
-                    <div className="h-3 rounded-full bg-gray-100 overflow-hidden">
+                    <div className="h-3 rounded-full bg-muted overflow-hidden">
                       <div
                         className="h-full rounded-full bg-indigo-500 transition-all"
                         style={{ width: `${pct}%` }}
                       />
                     </div>
-                    <p className="text-xs text-gray-400 mt-0.5">{t("revenueAnalytics.charts.billingCycle.percentOfSubscriptions", { percent: pct })}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{t("revenueAnalytics.charts.billingCycle.percentOfSubscriptions", { percent: pct })}</p>
                   </div>
                 );
               })}
             </div>
           ) : (
-            <div className="flex items-center justify-center h-[280px] text-gray-400 text-sm">
+            <div className="flex items-center justify-center h-[280px] text-muted-foreground text-sm">
               {t("revenueAnalytics.charts.empty")}
             </div>
           )}
@@ -286,32 +286,32 @@ export default function RevenueAnalyticsPage() {
       </div>
 
       {/* Top 10 Customers */}
-      <div className="bg-white rounded-xl border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">{t("revenueAnalytics.topCustomers.title")}</h2>
+      <div className="bg-card rounded-xl border border-border p-6">
+        <h2 className="text-lg font-semibold text-foreground mb-4">{t("revenueAnalytics.topCustomers.title")}</h2>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-gray-200 bg-gray-50">
-                <th className="text-left py-3 px-4 font-medium text-gray-500">{t("revenueAnalytics.topCustomers.columns.rank")}</th>
-                <th className="text-left py-3 px-4 font-medium text-gray-500">{t("revenueAnalytics.topCustomers.columns.organization")}</th>
-                <th className="text-left py-3 px-4 font-medium text-gray-500">{t("revenueAnalytics.topCustomers.columns.email")}</th>
-                <th className="text-right py-3 px-4 font-medium text-gray-500">{t("revenueAnalytics.topCustomers.columns.subscriptions")}</th>
-                <th className="text-right py-3 px-4 font-medium text-gray-500">{t("revenueAnalytics.topCustomers.columns.monthlySpend")}</th>
+              <tr className="border-b border-border bg-muted">
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">{t("revenueAnalytics.topCustomers.columns.rank")}</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">{t("revenueAnalytics.topCustomers.columns.organization")}</th>
+                <th className="text-left py-3 px-4 font-medium text-muted-foreground">{t("revenueAnalytics.topCustomers.columns.email")}</th>
+                <th className="text-right py-3 px-4 font-medium text-muted-foreground">{t("revenueAnalytics.topCustomers.columns.subscriptions")}</th>
+                <th className="text-right py-3 px-4 font-medium text-muted-foreground">{t("revenueAnalytics.topCustomers.columns.monthlySpend")}</th>
               </tr>
             </thead>
             <tbody>
               {(revenue?.top_customers || []).map((customer: any, index: number) => (
-                <tr key={customer.id} className="border-b border-gray-100 hover:bg-gray-50/50">
+                <tr key={customer.id} className="border-b border-border hover:bg-muted/50">
                   <td className="py-3 px-4">
                     <span
                       className={`inline-flex items-center justify-center h-7 w-7 rounded-full text-xs font-bold ${
                         index === 0
-                          ? "bg-amber-100 text-amber-700"
+                          ? "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300"
                           : index === 1
-                            ? "bg-gray-200 text-gray-700"
+                            ? "bg-muted text-muted-foreground"
                             : index === 2
-                              ? "bg-orange-100 text-orange-700"
-                              : "bg-gray-100 text-gray-600"
+                              ? "bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300"
+                              : "bg-muted text-muted-foreground"
                       }`}
                     >
                       {index + 1}
@@ -320,21 +320,21 @@ export default function RevenueAnalyticsPage() {
                   <td className="py-3 px-4">
                     <Link
                       to={`/admin/organizations/${customer.id}`}
-                      className="font-medium text-gray-900 hover:text-brand-600"
+                      className="font-medium text-foreground hover:text-brand-600"
                     >
                       {customer.name}
                     </Link>
                   </td>
-                  <td className="py-3 px-4 text-gray-600">{customer.email}</td>
-                  <td className="py-3 px-4 text-right text-gray-700">{customer.subscription_count}</td>
-                  <td className="py-3 px-4 text-right font-bold text-gray-900">
+                  <td className="py-3 px-4 text-muted-foreground">{customer.email}</td>
+                  <td className="py-3 px-4 text-right text-muted-foreground">{customer.subscription_count}</td>
+                  <td className="py-3 px-4 text-right font-bold text-foreground">
                     {formatINR(customer.total_spend)}
                   </td>
                 </tr>
               ))}
               {(!revenue?.top_customers || revenue.top_customers.length === 0) && (
                 <tr>
-                  <td colSpan={5} className="py-8 text-center text-gray-400">
+                  <td colSpan={5} className="py-8 text-center text-muted-foreground">
                     {t("revenueAnalytics.topCustomers.empty")}
                   </td>
                 </tr>


### PR DESCRIPTION
## Problem

The super-admin Revenue Analytics page (MRR/ARR trend + revenue-by-module charts) was out of scope in the original dark-mode conversion — it rendered light (white cards / low-contrast text) in dark mode.

## Fix

Converted the page to the semantic theme tokens (`bg-card`, `text-foreground`, `bg-muted`, `border-border`, …). Handled the page's special cases: status/level badges dark-paired, native filters `bg-card text-foreground`, action-icon hover colors, modals, and — where the page has recharts charts — **grid / axis / tooltip colours made theme-aware** (`hsl(var(--border))` / `--muted-foreground` / `--card`) while leaving the data-series colours untouched.

Part of the Platform Admin (super-admin) dark-mode sweep; one PR per page.

## Verification

`0` bare neutral (real light-mode bugs) · `0` mangled · `0` double-alpha · `0` unreadable dark-text-on-tint. Full-tree `tsc --noEmit` = 0 errors; `vite build` passes.

**1 file changed.**
