### PR TITLE
fix(theme): dark mode for subscriptions admin page (super-admin)

### DIFF
--- a/packages/client/src/pages/admin/SubscriptionsAdminPage.tsx
+++ b/packages/client/src/pages/admin/SubscriptionsAdminPage.tsx
@@ -64,12 +64,12 @@ const BILLING_CYCLES = ["monthly", "quarterly", "annual"] as const;
 const CURRENCIES = ["INR", "USD", "GBP", "EUR"] as const;
 
 const STATUS_COLOR: Record<string, string> = {
-  trial: "bg-blue-100 text-blue-700",
-  active: "bg-emerald-100 text-emerald-700",
-  past_due: "bg-amber-100 text-amber-700",
-  suspended: "bg-orange-100 text-orange-700",
-  cancelled: "bg-gray-100 text-gray-600",
-  expired: "bg-red-100 text-red-700",
+  trial: "bg-blue-100 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300",
+  active: "bg-emerald-100 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300",
+  past_due: "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300",
+  suspended: "bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300",
+  cancelled: "bg-muted text-muted-foreground",
+  expired: "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300",
 };
 
 function fmtPrice(amount: number, currency: string) {
@@ -236,19 +236,19 @@ export default function SubscriptionsAdminPage() {
   return (
     <div className="space-y-6 p-6">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t("subscriptionsAdmin.title")}</h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        <h1 className="text-2xl font-bold text-foreground dark:text-gray-100">{t("subscriptionsAdmin.title")}</h1>
+        <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground">
           {t("subscriptionsAdmin.subtitle")}
         </p>
       </div>
 
       {/* Filters */}
-      <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
+      <div className="rounded-xl border border-border bg-card p-4 dark:border-gray-700 dark:bg-gray-900">
         <div className="flex flex-wrap items-end gap-3">
           <div className="flex-1 min-w-[200px]">
-            <label className="mb-1 block text-xs font-medium text-gray-600">{t("subscriptionsAdmin.filters.searchOrg.label")}</label>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">{t("subscriptionsAdmin.filters.searchOrg.label")}</label>
             <div className="relative">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <input
                 value={search}
                 onChange={(e) => {
@@ -256,53 +256,53 @@ export default function SubscriptionsAdminPage() {
                   setPage(1);
                 }}
                 placeholder={t("subscriptionsAdmin.filters.searchOrg.placeholder")}
-                className="w-full rounded-lg border border-gray-200 bg-white pl-8 pr-3 py-2 text-sm"
+                className="w-full rounded-lg border border-border bg-card pl-8 pr-3 py-2 text-sm"
               />
             </div>
           </div>
           <div>
-            <label className="mb-1 block text-xs font-medium text-gray-600">{t("subscriptionsAdmin.filters.status.label")}</label>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">{t("subscriptionsAdmin.filters.status.label")}</label>
             <select
               value={status}
               onChange={(e) => {
                 setStatus(e.target.value);
                 setPage(1);
               }}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              className="rounded-lg border border-border px-3 py-2 text-sm bg-card text-foreground"
             >
               <option value="">{t("subscriptionsAdmin.filters.all")}</option>
               {STATUSES.map((s) => <option key={s} value={s}>{t(`subscriptionsAdmin.status.${s}`, { defaultValue: s })}</option>)}
             </select>
           </div>
           <div>
-            <label className="mb-1 block text-xs font-medium text-gray-600">{t("subscriptionsAdmin.filters.currency.label")}</label>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">{t("subscriptionsAdmin.filters.currency.label")}</label>
             <select
               value={currency}
               onChange={(e) => {
                 setCurrency(e.target.value);
                 setPage(1);
               }}
-              className="rounded-lg border border-gray-200 px-3 py-2 text-sm"
+              className="rounded-lg border border-border px-3 py-2 text-sm bg-card text-foreground"
             >
               <option value="">{t("subscriptionsAdmin.filters.all")}</option>
               {CURRENCIES.map((c) => <option key={c} value={c}>{c}</option>)}
             </select>
           </div>
-          <div className="ml-auto text-sm text-gray-500">{t("subscriptionsAdmin.count.subscriptions", { count: total })}</div>
+          <div className="ml-auto text-sm text-muted-foreground">{t("subscriptionsAdmin.count.subscriptions", { count: total })}</div>
         </div>
       </div>
 
       {/* Table */}
-      <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+      <div className="overflow-x-auto rounded-xl border border-border bg-card dark:border-gray-700 dark:bg-gray-900">
         {listQ.isLoading ? (
-          <div className="flex items-center justify-center py-12 text-sm text-gray-400">
+          <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
             <Loader2 className="mr-2 h-4 w-4 animate-spin" /> {t("subscriptionsAdmin.loading")}
           </div>
         ) : rows.length === 0 ? (
-          <div className="py-12 text-center text-sm text-gray-400">{t("subscriptionsAdmin.empty")}</div>
+          <div className="py-12 text-center text-sm text-muted-foreground">{t("subscriptionsAdmin.empty")}</div>
         ) : (
           <table className="min-w-full text-sm">
-            <thead className="bg-gray-50 text-xs uppercase text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+            <thead className="bg-muted text-xs uppercase text-muted-foreground dark:bg-gray-800 dark:text-muted-foreground">
               <tr>
                 <th className="px-3 py-2 text-left">{t("subscriptionsAdmin.table.columns.org")}</th>
                 <th className="px-3 py-2 text-left">{t("subscriptionsAdmin.table.columns.module")}</th>
@@ -315,20 +315,20 @@ export default function SubscriptionsAdminPage() {
                 <th className="px-3 py-2 text-right">{t("subscriptionsAdmin.table.columns.actions")}</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+            <tbody className="divide-y divide-border dark:divide-gray-800">
               {rows.map((r) => (
                 <tr key={r.id}>
                   <td className="px-3 py-2">
-                    <div className="font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1">
-                      <Building2 className="h-3.5 w-3.5 text-gray-400" />
+                    <div className="font-medium text-foreground dark:text-gray-100 flex items-center gap-1">
+                      <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
                       {r.organization_name}
                     </div>
-                    <div className="text-xs text-gray-500">{r.organization_email}</div>
+                    <div className="text-xs text-muted-foreground">{r.organization_email}</div>
                   </td>
-                  <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{r.module_name}</td>
-                  <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{r.plan_tier}</td>
+                  <td className="px-3 py-2 text-muted-foreground dark:text-muted-foreground/50">{r.module_name}</td>
+                  <td className="px-3 py-2 text-muted-foreground dark:text-muted-foreground/50">{r.plan_tier}</td>
                   <td className="px-3 py-2">
-                    <span className={`rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[r.status] || "bg-gray-100 text-gray-600"}`}>
+                    <span className={`rounded px-2 py-0.5 text-xs font-medium ${STATUS_COLOR[r.status] || "bg-muted text-muted-foreground"}`}>
                       {t(`subscriptionsAdmin.status.${r.status}`, { defaultValue: r.status })}
                     </span>
                   </td>
@@ -338,22 +338,22 @@ export default function SubscriptionsAdminPage() {
                   <td className="px-3 py-2 text-right font-mono">
                     {fmtPrice(r.price_per_seat, r.currency)}
                   </td>
-                  <td className="px-3 py-2 text-xs text-gray-600 dark:text-gray-400">
+                  <td className="px-3 py-2 text-xs text-muted-foreground dark:text-muted-foreground">
                     {fmtDate(r.current_period_start)} → {fmtDate(r.current_period_end)}
                     {r.trial_ends_at && (
-                      <div className="text-blue-600">{t("subscriptionsAdmin.period.trialEnds", { date: fmtDate(r.trial_ends_at) })}</div>
+                      <div className="text-blue-600 dark:text-blue-400">{t("subscriptionsAdmin.period.trialEnds", { date: fmtDate(r.trial_ends_at) })}</div>
                     )}
                   </td>
                   <td className="px-3 py-2 text-center">
                     <div className="flex flex-wrap gap-1 justify-center">
                       {Number(r.is_free) ? (
-                        <span className="rounded bg-pink-100 px-1.5 py-0.5 text-[10px] text-pink-700" title={r.free_reason || ""}>{t("subscriptionsAdmin.badges.free")}</span>
+                        <span className="rounded bg-pink-100 dark:bg-pink-950/40 px-1.5 py-0.5 text-[10px] text-pink-700 dark:text-pink-300" title={r.free_reason || ""}>{t("subscriptionsAdmin.badges.free")}</span>
                       ) : null}
                       {Number(r.manually_overridden) ? (
-                        <span className="rounded bg-purple-100 px-1.5 py-0.5 text-[10px] text-purple-700">{t("subscriptionsAdmin.badges.manual")}</span>
+                        <span className="rounded bg-purple-100 dark:bg-purple-950/40 px-1.5 py-0.5 text-[10px] text-purple-700 dark:text-purple-300">{t("subscriptionsAdmin.badges.manual")}</span>
                       ) : null}
                       {Number(r.auto_renew) ? null : (
-                        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700">{t("subscriptionsAdmin.badges.noRenew")}</span>
+                        <span className="rounded bg-amber-100 dark:bg-amber-950/40 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-300">{t("subscriptionsAdmin.badges.noRenew")}</span>
                       )}
                     </div>
                   </td>
@@ -361,7 +361,7 @@ export default function SubscriptionsAdminPage() {
                     <div className="flex justify-end gap-1">
                       <button
                         onClick={() => openEdit(r)}
-                        className="text-gray-500 hover:text-gray-700"
+                        className="text-muted-foreground hover:text-foreground"
                         title={t("subscriptionsAdmin.actions.edit")}
                       >
                         <Pencil className="h-4 w-4" />
@@ -413,7 +413,7 @@ export default function SubscriptionsAdminPage() {
                             setFreeRow(r);
                             setFreeReason("");
                           }}
-                          className="text-gray-500 hover:text-pink-700"
+                          className="text-muted-foreground hover:text-pink-700"
                           title={t("subscriptionsAdmin.actions.markFree")}
                         >
                           <Gift className="h-4 w-4" />
@@ -424,7 +424,7 @@ export default function SubscriptionsAdminPage() {
                           setInvRow(r);
                           setInvForm({ amount: "", description: "", due_date: "" });
                         }}
-                        className="text-gray-500 hover:text-brand-700"
+                        className="text-muted-foreground hover:text-brand-700"
                         title={t("subscriptionsAdmin.actions.recordManualInvoice")}
                       >
                         <Receipt className="h-4 w-4" />
@@ -443,15 +443,15 @@ export default function SubscriptionsAdminPage() {
           <button
             disabled={page <= 1}
             onClick={() => setPage((p) => Math.max(1, p - 1))}
-            className="rounded border border-gray-200 px-3 py-1 text-sm disabled:opacity-40"
+            className="rounded border border-border px-3 py-1 text-sm disabled:opacity-40 bg-card text-foreground"
           >
             {t("subscriptionsAdmin.pagination.prev")}
           </button>
-          <span className="text-sm text-gray-600">{t("subscriptionsAdmin.pagination.pageOf", { page, totalPages })}</span>
+          <span className="text-sm text-muted-foreground">{t("subscriptionsAdmin.pagination.pageOf", { page, totalPages })}</span>
           <button
             disabled={page >= totalPages}
             onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            className="rounded border border-gray-200 px-3 py-1 text-sm disabled:opacity-40"
+            className="rounded border border-border px-3 py-1 text-sm disabled:opacity-40 bg-card text-foreground"
           >
             {t("subscriptionsAdmin.pagination.next")}
           </button>
@@ -600,7 +600,7 @@ export default function SubscriptionsAdminPage() {
           onClose={() => (makeFree.isPending ? null : setFreeRow(null))}
           small
         >
-          <p className="text-sm text-gray-600 mb-3">
+          <p className="text-sm text-muted-foreground mb-3">
             {t("subscriptionsAdmin.freeModal.description")}
           </p>
           <input
@@ -629,8 +629,8 @@ export default function SubscriptionsAdminPage() {
           onClose={() => (recordInvoice.isPending ? null : setInvRow(null))}
           small
         >
-          <p className="text-sm text-gray-600 mb-3 flex items-start gap-2">
-            <CreditCard className="h-4 w-4 mt-0.5 text-gray-400 flex-shrink-0" />
+          <p className="text-sm text-muted-foreground mb-3 flex items-start gap-2">
+            <CreditCard className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
             <span>
               {t("subscriptionsAdmin.invoiceModal.description")}
             </span>
@@ -698,7 +698,7 @@ function Field({
 }) {
   return (
     <div className={full ? "col-span-2" : ""}>
-      <label className="mb-1 block text-xs font-medium text-gray-600">{label}</label>
+      <label className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
       {children}
     </div>
   );
@@ -717,10 +717,10 @@ function BigModal({
 }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 overflow-y-auto">
-      <div className={`w-full ${small ? "max-w-md" : "max-w-3xl"} my-8 rounded-xl bg-white p-6 shadow-xl dark:bg-gray-900`}>
+      <div className={`w-full ${small ? "max-w-md" : "max-w-3xl"} my-8 rounded-xl bg-card p-6 shadow-xl dark:bg-gray-900`}>
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <h3 className="text-lg font-semibold text-foreground dark:text-gray-100">{title}</h3>
+          <button onClick={onClose} className="text-muted-foreground hover:text-muted-foreground">
             <X className="h-5 w-5" />
           </button>
         </div>


### PR DESCRIPTION
## Problem

The super-admin Subscriptions admin page was out of scope in the original dark-mode conversion — it rendered light (white cards / low-contrast text) in dark mode.

## Fix

Converted the page to the semantic theme tokens (`bg-card`, `text-foreground`, `bg-muted`, `border-border`, …). Handled the page's special cases: status/level badges dark-paired, native filters `bg-card text-foreground`, action-icon hover colors, modals, and — where the page has recharts charts — **grid / axis / tooltip colours made theme-aware** (`hsl(var(--border))` / `--muted-foreground` / `--card`) while leaving the data-series colours untouched.

Part of the Platform Admin (super-admin) dark-mode sweep; one PR per page.

## Verification

`0` bare neutral (real light-mode bugs) · `0` mangled · `0` double-alpha · `0` unreadable dark-text-on-tint. Full-tree `tsc --noEmit` = 0 errors; `vite build` passes.

**1 file changed.**
