### PR TITLE
fix(theme): dark mode for AI configuration page (super-admin)

### DIFF
--- a/packages/client/src/pages/admin/AIConfigPage.tsx
+++ b/packages/client/src/pages/admin/AIConfigPage.tsx
@@ -70,8 +70,8 @@ const PROVIDERS: ProviderDef[] = [
     id: "anthropic",
     name: "Claude (Anthropic)",
     description: "Advanced reasoning and analysis with Claude models",
-    color: "text-amber-700",
-    bgColor: "bg-amber-50",
+    color: "text-amber-700 dark:text-amber-300",
+    bgColor: "bg-amber-50 dark:bg-amber-950/40",
     borderColor: "border-amber-200",
     keyField: "anthropic_api_key",
     models: [
@@ -84,8 +84,8 @@ const PROVIDERS: ProviderDef[] = [
     id: "openai",
     name: "OpenAI",
     description: "GPT-4o and GPT-4 Turbo models from OpenAI",
-    color: "text-green-700",
-    bgColor: "bg-green-50",
+    color: "text-green-700 dark:text-green-300",
+    bgColor: "bg-green-50 dark:bg-green-950/40",
     borderColor: "border-green-200",
     keyField: "openai_api_key",
     models: [
@@ -99,8 +99,8 @@ const PROVIDERS: ProviderDef[] = [
     id: "gemini",
     name: "Google Gemini",
     description: "Gemini Pro and Flash models from Google",
-    color: "text-blue-700",
-    bgColor: "bg-blue-50",
+    color: "text-blue-700 dark:text-blue-300",
+    bgColor: "bg-blue-50 dark:bg-blue-950/40",
     borderColor: "border-blue-200",
     keyField: "gemini_api_key",
     models: [
@@ -114,8 +114,8 @@ const PROVIDERS: ProviderDef[] = [
     id: "deepseek",
     name: "DeepSeek",
     description: "Cost-effective reasoning models from DeepSeek",
-    color: "text-indigo-700",
-    bgColor: "bg-indigo-50",
+    color: "text-indigo-700 dark:text-indigo-300",
+    bgColor: "bg-indigo-50 dark:bg-indigo-950/40",
     borderColor: "border-indigo-200",
     keyField: "openai_api_key",
     baseUrlField: "openai_base_url",
@@ -130,8 +130,8 @@ const PROVIDERS: ProviderDef[] = [
     id: "groq",
     name: "Groq",
     description: "Ultra-fast inference with Groq LPU hardware",
-    color: "text-orange-700",
-    bgColor: "bg-orange-50",
+    color: "text-orange-700 dark:text-orange-300",
+    bgColor: "bg-orange-50 dark:bg-orange-950/40",
     borderColor: "border-orange-200",
     keyField: "openai_api_key",
     baseUrlField: "openai_base_url",
@@ -146,9 +146,9 @@ const PROVIDERS: ProviderDef[] = [
     id: "ollama",
     name: "Ollama (Local)",
     description: "Run models locally with Ollama — no API key needed",
-    color: "text-gray-700",
-    bgColor: "bg-gray-50",
-    borderColor: "border-gray-200",
+    color: "text-muted-foreground",
+    bgColor: "bg-muted",
+    borderColor: "border-border",
     keyField: "",
     baseUrlField: "openai_base_url",
     defaultBaseUrl: "http://localhost:11434",
@@ -163,8 +163,8 @@ const PROVIDERS: ProviderDef[] = [
     id: "openai-compatible",
     name: "Custom OpenAI-Compatible",
     description: "Any provider with an OpenAI-compatible API endpoint",
-    color: "text-purple-700",
-    bgColor: "bg-purple-50",
+    color: "text-purple-700 dark:text-purple-300",
+    bgColor: "bg-purple-50 dark:bg-purple-950/40",
     borderColor: "border-purple-200",
     keyField: "openai_api_key",
     baseUrlField: "openai_base_url",
@@ -185,7 +185,7 @@ function StatusBadge({
   const { t } = useTranslation();
   if (status === "active") {
     return (
-      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 dark:bg-green-950/40 text-green-800 dark:text-green-200">
         <CheckCircle2 className="w-3 h-3" />
         {t("aiConfig.status.active")}
       </span>
@@ -193,14 +193,14 @@ function StatusBadge({
   }
   if (status === "configured") {
     return (
-      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+      <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-950/40 text-yellow-800 dark:text-yellow-200">
         <Circle className="w-3 h-3" />
         {t("aiConfig.status.configured")}
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">
+    <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
       <XCircle className="w-3 h-3" />
       {t("aiConfig.status.notConfigured")}
     </span>
@@ -315,7 +315,7 @@ function ProviderCard({
       className={`border rounded-xl transition-all ${
         isActive
           ? `${provider.borderColor} ring-2 ring-offset-1 ring-${provider.id === "anthropic" ? "amber" : provider.id === "openai" ? "green" : provider.id === "gemini" ? "blue" : "indigo"}-300`
-          : "border-gray-200 hover:border-gray-300"
+          : "border-border hover:border-border"
       }`}
     >
       {/* Card header */}
@@ -331,14 +331,14 @@ function ProviderCard({
           </div>
           <div>
             <div className="flex items-center gap-2">
-              <h3 className="font-semibold text-gray-900">{provider.name}</h3>
+              <h3 className="font-semibold text-foreground">{provider.name}</h3>
               <StatusBadge status={cardStatus} />
             </div>
-            <p className="text-sm text-gray-500">{provider.description}</p>
+            <p className="text-sm text-muted-foreground">{provider.description}</p>
           </div>
         </div>
         <ChevronDown
-          className={`w-5 h-5 text-gray-400 transition-transform ${
+          className={`w-5 h-5 text-muted-foreground transition-transform ${
             expanded ? "rotate-180" : ""
           }`}
         />
@@ -346,11 +346,11 @@ function ProviderCard({
 
       {/* Expanded content */}
       {expanded && (
-        <div className="px-4 pb-4 space-y-4 border-t border-gray-100 pt-4">
+        <div className="px-4 pb-4 space-y-4 border-t border-border pt-4">
           {/* API Key */}
           {provider.needsApiKey && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
                 {t("aiConfig.field.apiKey")}
               </label>
               <div className="relative">
@@ -365,12 +365,12 @@ function ProviderCard({
                         })
                       : t("aiConfig.placeholder.apiKeyEnter")
                   }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 pr-10"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 pr-10"
                 />
                 <button
                   type="button"
                   onClick={() => setShowKey(!showKey)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-muted-foreground"
                 >
                   {showKey ? (
                     <EyeOff className="w-4 h-4" />
@@ -385,7 +385,7 @@ function ProviderCard({
           {/* Base URL */}
           {provider.baseUrlField && (
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
                 {t("aiConfig.field.baseUrl")}
               </label>
               <input
@@ -395,21 +395,21 @@ function ProviderCard({
                 placeholder={
                   provider.defaultBaseUrl || t("aiConfig.placeholder.baseUrl")
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>
           )}
 
           {/* Model selector */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-muted-foreground mb-1">
               {t("aiConfig.field.model")}
             </label>
             {provider.models.length > 0 ? (
               <select
                 value={selectedModel}
                 onChange={(e) => setSelectedModel(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-white"
+                className="w-full px-3 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 bg-card"
               >
                 {provider.models.map((m) => (
                   <option key={m.value} value={m.value}>
@@ -423,7 +423,7 @@ function ProviderCard({
                 value={customModel}
                 onChange={(e) => setCustomModel(e.target.value)}
                 placeholder={t("aiConfig.placeholder.customModel")}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               />
             )}
           </div>
@@ -433,8 +433,8 @@ function ProviderCard({
             <div
               className={`flex items-start gap-2 p-3 rounded-lg text-sm ${
                 testResult.success
-                  ? "bg-green-50 text-green-800"
-                  : "bg-red-50 text-red-800"
+                  ? "bg-green-50 dark:bg-green-950/40 text-green-800 dark:text-green-200"
+                  : "bg-red-50 dark:bg-red-950/40 text-red-800 dark:text-red-200"
               }`}
             >
               {testResult.success ? (
@@ -461,7 +461,7 @@ function ProviderCard({
                 testing ||
                 (provider.needsApiKey && !apiKey && !configMap[provider.keyField])
               }
-              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground bg-card border border-border rounded-lg hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {testing ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
@@ -479,7 +479,7 @@ function ProviderCard({
               }
               className={`inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed ${
                 isActive
-                  ? "text-green-700 bg-green-100 border border-green-300"
+                  ? "text-green-700 dark:text-green-300 bg-green-100 dark:bg-green-950/40 border border-green-300"
                   : "text-white bg-indigo-600 hover:bg-indigo-700"
               }`}
             >
@@ -498,7 +498,7 @@ function ProviderCard({
             {isActive && (
               <button
                 onClick={() => onActivate("none", "", "")}
-                className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-red-700 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100"
+                className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 border border-red-200 rounded-lg hover:bg-red-100 dark:hover:bg-red-950/40"
               >
                 <X className="w-4 h-4" />
                 {t("aiConfig.button.deactivate")}
@@ -635,7 +635,7 @@ export default function AIConfigPage() {
   if (configLoading || statusLoading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <Loader2 className="w-8 h-8 animate-spin text-indigo-600" />
+        <Loader2 className="w-8 h-8 animate-spin text-indigo-600 dark:text-indigo-400" />
       </div>
     );
   }
@@ -644,11 +644,11 @@ export default function AIConfigPage() {
     <div className="max-w-4xl mx-auto px-4 py-6 space-y-6">
       {/* Page header */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
-          <Sparkles className="w-7 h-7 text-indigo-600" />
+        <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+          <Sparkles className="w-7 h-7 text-indigo-600 dark:text-indigo-400" />
           {t("aiConfig.title")}
         </h1>
-        <p className="mt-1 text-sm text-gray-500">
+        <p className="mt-1 text-sm text-muted-foreground">
           {t("aiConfig.subtitle")}
         </p>
       </div>
@@ -658,7 +658,7 @@ export default function AIConfigPage() {
         className={`rounded-xl p-4 ${
           activeProvider !== "none"
             ? "bg-gradient-to-r from-indigo-50 to-purple-50 border border-indigo-200"
-            : "bg-gray-50 border border-gray-200"
+            : "bg-muted border border-border"
         }`}
       >
         <div className="flex items-center justify-between">
@@ -666,22 +666,22 @@ export default function AIConfigPage() {
             <div
               className={`w-10 h-10 rounded-full flex items-center justify-center ${
                 activeProvider !== "none"
-                  ? "bg-indigo-100"
-                  : "bg-gray-200"
+                  ? "bg-indigo-100 dark:bg-indigo-950/40"
+                  : "bg-muted"
               }`}
             >
               {activeProvider !== "none" ? (
-                <Sparkles className="w-5 h-5 text-indigo-600" />
+                <Sparkles className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
               ) : (
-                <AlertCircle className="w-5 h-5 text-gray-400" />
+                <AlertCircle className="w-5 h-5 text-muted-foreground" />
               )}
             </div>
             <div>
-              <h2 className="font-semibold text-gray-900">
+              <h2 className="font-semibold text-foreground">
                 {activeProvider !== "none" ? (
                   <>
                     {t("aiConfig.banner.aiPoweredMode")}{" "}
-                    <span className="text-indigo-600 capitalize">
+                    <span className="text-indigo-600 dark:text-indigo-400 capitalize">
                       ({PROVIDERS.find((p) => p.id === activeProvider)?.name ||
                         activeProvider})
                     </span>
@@ -690,7 +690,7 @@ export default function AIConfigPage() {
                   t("aiConfig.banner.basicMode")
                 )}
               </h2>
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-muted-foreground">
                 {activeProvider !== "none" ? (
                   <>
                     {t("aiConfig.banner.modelStatus", {
@@ -709,7 +709,7 @@ export default function AIConfigPage() {
 
       {/* Provider cards */}
       <div className="space-y-3">
-        <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+        <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
           <Settings className="w-5 h-5" />
           {t("aiConfig.section.providers")}
         </h2>
@@ -730,15 +730,15 @@ export default function AIConfigPage() {
       </div>
 
       {/* General settings */}
-      <div className="border border-gray-200 rounded-xl p-4 space-y-4">
-        <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+      <div className="border border-border rounded-xl p-4 space-y-4">
+        <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
           <Settings className="w-5 h-5" />
           {t("aiConfig.section.generalSettings")}
         </h2>
 
         {/* Max tokens */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+          <label className="block text-sm font-medium text-muted-foreground mb-2">
             {t("aiConfig.field.maxTokens", { count: maxTokens })}
           </label>
           <input
@@ -748,9 +748,9 @@ export default function AIConfigPage() {
             step={256}
             value={maxTokens}
             onChange={(e) => setMaxTokens(parseInt(e.target.value, 10))}
-            className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-indigo-600"
+            className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-indigo-600"
           />
-          <div className="flex justify-between text-xs text-gray-400 mt-1">
+          <div className="flex justify-between text-xs text-muted-foreground mt-1">
             <span>1024</span>
             <span>4096</span>
             <span>8192</span>
@@ -758,7 +758,7 @@ export default function AIConfigPage() {
           <button
             onClick={handleMaxTokensSave}
             disabled={updateMutation.isPending}
-            className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-lg hover:bg-indigo-100 disabled:opacity-50"
+            className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-950/40 disabled:opacity-50"
           >
             {updateMutation.isPending ? (
               <Loader2 className="w-3 h-3 animate-spin" />
@@ -771,12 +771,12 @@ export default function AIConfigPage() {
       </div>
 
       {/* Info box */}
-      <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-800">
+      <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 rounded-xl p-4 text-sm text-amber-800 dark:text-amber-200">
         <div className="flex items-start gap-2">
           <AlertCircle className="w-5 h-5 mt-0.5 flex-shrink-0" />
           <div>
             <p className="font-medium">{t("aiConfig.info.title")}</p>
-            <ul className="mt-1 list-disc list-inside space-y-1 text-amber-700">
+            <ul className="mt-1 list-disc list-inside space-y-1 text-amber-700 dark:text-amber-300">
               <li>{t("aiConfig.info.encryption")}</li>
               <li>{t("aiConfig.info.overrideEnv")}</li>
               <li>{t("aiConfig.info.singleActive")}</li>


### PR DESCRIPTION
## Problem

The super-admin AI Configuration page was out of scope in the original dark-mode conversion — it rendered light (white cards / low-contrast text) in dark mode.

## Fix

Converted the page to the semantic theme tokens (`bg-card`, `text-foreground`, `bg-muted`, `border-border`, …). Handled the page's special cases: status/level badges dark-paired, native filters `bg-card text-foreground`, action-icon hover colors, modals, and — where the page has recharts charts — **grid / axis / tooltip colours made theme-aware** (`hsl(var(--border))` / `--muted-foreground` / `--card`) while leaving the data-series colours untouched.

Part of the Platform Admin (super-admin) dark-mode sweep; one PR per page.

## Verification

`0` bare neutral (real light-mode bugs) · `0` mangled · `0` double-alpha · `0` unreadable dark-text-on-tint. Full-tree `tsc --noEmit` = 0 errors; `vite build` passes.

**1 file changed.**
