### PR TITLE
fix(sidebar): section headers clipped (ATTEN/COMM/WOR/ACCOU) in collapsed rail

### DIFF
--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -171,7 +171,14 @@
   .sidebar-collapsed nav a > span,
   .sidebar-collapsed nav button > span,
   .sidebar-collapsed nav a > .inline-block,
+  /* Section labels: the top-level `label` prop renders as `.text-xs.uppercase`,
+     but the per-group section HEADERS (ATTENDANCE & LEAVE, COMMUNICATION, …)
+     render as `text-[10px] … uppercase` divs — a different size class the old
+     selector missed, so they leaked into the 64px collapsed rail and clipped
+     to "ATTEN / COMM / WOR / ACCOU". Match any uppercase label div in the
+     collapsed nav so every section header hides regardless of its size class. */
   .sidebar-collapsed nav .text-xs.uppercase,
+  .sidebar-collapsed nav > .uppercase,
   .sidebar-collapsed nav button > svg.lucide-chevron-down {
     display: none;
   }


### PR DESCRIPTION
## Problem

When the sidebar is **collapsed** to the icon-only rail (64px), the section HEADERS leak into the rail and get clipped: **ATTEN**, **COMM**, **WOR**, **ACCOU** (see screenshot) instead of being hidden. Only the nav icons should show when collapsed.

## Root cause

`globals.css` has a rule that hides sidebar text when collapsed:
```css
.sidebar-collapsed nav .text-xs.uppercase { display: none; }
```
But the per-group section headers (ATTENDANCE & LEAVE, COMMUNICATION, WORKPLACE & COMMUNITY, ACCOUNT) render in `NavSection.tsx` as **`text-[10px] … uppercase`** divs — a *different* size class the selector never matched. So they stayed visible and clipped to the 64px width.

(They render as **direct children of `<nav>`** — React `Fragment`/`<>` wrappers are transparent in the DOM.)

## Fix

Broaden the collapsed hide-rule to also match section headers regardless of their size class:
```css
.sidebar-collapsed nav > .uppercase { display: none; }
```
This targets any uppercase label div that's a direct child of the collapsed `nav`. Audited both `uppercase` usages in the nav — both are section labels that *should* hide when collapsed, so nothing is over-hidden.

## Verification

`vite build` passes; confirmed the compiled CSS contains `.sidebar-collapsed nav>.uppercase{…display:none}`. This is a layout/CSS fix — not dark-mode related.

**1 file changed.**
