### PR TITLE
fix(sidebar): add hover tooltips to icon-only controls (sign out, collapse toggle, notification bell)

### DIFF
--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -233,6 +233,11 @@ export default function DashboardLayout() {
         <button
           onClick={handleLogout}
           aria-label={t('nav.signOut')}
+          // #tooltip — hover title so the icon-only collapsed sidebar is
+          // discoverable (matches the NavLink pattern). Only set when
+          // collapsed so the expanded button, whose visible text already
+          // reads "Sign out", doesn't show a redundant native tooltip.
+          title={isCollapsed ? t('nav.signOut') : undefined}
           className={`flex items-center ${isCollapsed ? "justify-center" : "gap-2"} w-full px-3 py-2 text-sm text-muted-foreground hover:bg-muted rounded-lg transition-colors`}
         >
           <LogOut className="h-4 w-4 flex-shrink-0" />
@@ -261,6 +266,7 @@ export default function DashboardLayout() {
         <button
           onClick={() => setSidebarCollapsed((c) => !c)}
           aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           className="hidden md:flex absolute top-1/2 -right-3 -translate-y-1/2 z-30 h-6 w-6 rounded-full bg-card border border-border text-muted-foreground hover:text-brand-600 hover:border-brand-300 shadow-sm items-center justify-center transition-colors"
         >
           {sidebarCollapsed ? (

--- a/packages/client/src/components/layout/NotificationDropdown.tsx
+++ b/packages/client/src/components/layout/NotificationDropdown.tsx
@@ -86,6 +86,10 @@ export function NotificationDropdown() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setOpen(!open)}
+        // Icon-only control in the topbar: give it an accessible name + a
+        // hover tooltip so it's not an unlabelled bell.
+        title={t('common.notifications')}
+        aria-label={t('common.notifications')}
         className="relative p-2 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
       >
         <Bell className="h-5 w-5" />


### PR DESCRIPTION
## Problem

Icon-only controls in the sidebar/topbar have no **hover tooltip**, so when the sidebar is collapsed (or for the always-icon topbar bell) there's no way to tell what an icon does. The **Sign out** icon at the bottom of the collapsed rail (screenshot) is the clearest case.

## Fix

Added `title` (hover tooltip) to the icon-only controls that were missing one. The nav links already have `title={label}`; this brings the rest in line:

1. **Sign out button** — `title={isCollapsed ? t('nav.signOut') : undefined}` (only when collapsed, so the expanded button whose visible text already reads "Sign out" doesn't get a redundant native tooltip). Already had `aria-label`.
2. **Collapse / Expand toggle** — added `title` mirroring its existing `aria-label`.
3. **Notification bell** (topbar, always icon-only) — had **neither** `title` nor `aria-label`; added both via `t('common.notifications')` so it has an accessible name + tooltip.

## Verification

`tsc --noEmit` = 0 errors; `vite build` passes. Confirmed a completeness sweep: after these, every `aria-label`led button in the sidebar also has a `title`, and no icon-only control is left unlabelled. UX/a11y fix — not dark-mode related.

**2 files changed.**
