### PR TITLE
fix(theme): service-health status banner washed out in dark mode

### DIFF
--- a/packages/client/src/pages/admin/HealthDashboardPage.tsx
+++ b/packages/client/src/pages/admin/HealthDashboardPage.tsx
@@ -145,21 +145,21 @@ function OverallStatusBanner({ status, lastCheck }: { status: string; lastCheck:
   const { t } = useTranslation();
   const bannerConfig = {
     operational: {
-      bg: "bg-gradient-to-r from-green-50 to-emerald-50 border-green-200",
+      bg: "bg-gradient-to-r from-green-50 to-emerald-50 border-green-200 dark:from-green-950/40 dark:to-emerald-950/40 dark:border-green-900",
       icon: <CheckCircle2 className="h-8 w-8 text-green-500" />,
       title: t("healthDashboard.overall.operational.title"),
       subtitle: t("healthDashboard.overall.operational.subtitle"),
       dotColor: "bg-green-500",
     },
     degraded: {
-      bg: "bg-gradient-to-r from-amber-50 to-yellow-50 border-amber-200",
+      bg: "bg-gradient-to-r from-amber-50 to-yellow-50 border-amber-200 dark:from-amber-950/40 dark:to-yellow-950/40 dark:border-amber-900",
       icon: <AlertTriangle className="h-8 w-8 text-amber-500" />,
       title: t("healthDashboard.overall.degraded.title"),
       subtitle: t("healthDashboard.overall.degraded.subtitle"),
       dotColor: "bg-amber-500",
     },
     major_outage: {
-      bg: "bg-gradient-to-r from-red-50 to-rose-50 border-red-200",
+      bg: "bg-gradient-to-r from-red-50 to-rose-50 border-red-200 dark:from-red-950/40 dark:to-rose-950/40 dark:border-red-900",
       icon: <XCircle className="h-8 w-8 text-red-500" />,
       title: t("healthDashboard.overall.majorOutage.title"),
       subtitle: t("healthDashboard.overall.majorOutage.subtitle"),


### PR DESCRIPTION
## Problem

On the super-admin **Service Health** page in dark mode, the overall-status banner ("Partial System Degradation") is **washed out / barely readable** — the title and subtitle are near-invisible (see screenshot).

## Root cause

`OverallStatusBanner`'s config sets each state's background to a **light gradient with no dark variant**, e.g.:
```
degraded:  "bg-gradient-to-r from-amber-50 to-yellow-50 border-amber-200"
```
In dark mode the banner background stays **light amber/yellow**, but the text uses the theme tokens `text-foreground` (near-white) and `text-muted-foreground` (light gray). So it's **light text on a light background** → unreadable. Same for the operational (green) and major_outage (red) states.

## Fix

Added dark gradient stops + dark borders to all three banner states so the background goes dark and the token text reads correctly:
```
dark:from-amber-950/40 dark:to-yellow-950/40 dark:border-amber-900
```
(operational → green, degraded → amber, major_outage → red). The status icons (`text-*-500`) are mid-tone and read on both themes, left as-is.

## Verification

Swept the page — no other light banners missing dark variants (the `from-*-500 to-*-600` module icon-chip gradients are saturated data-viz colours, correct in both themes). `tsc --noEmit` = 0 errors; `vite build` passes.

**1 file changed.**
