### PR TITLE
fix(theme): super-admin dashboard System Health rows washed out in dark mode

### DIFF
--- a/packages/client/src/pages/admin/SuperAdminDashboard.tsx
+++ b/packages/client/src/pages/admin/SuperAdminDashboard.tsx
@@ -489,8 +489,8 @@ export default function SuperAdminDashboard() {
                 key={mod.slug}
                 className={`flex items-center justify-between rounded-lg border p-3 ${
                   mod.status === "healthy"
-                    ? "border-green-200 bg-green-50/50"
-                    : "border-red-200 bg-red-50/50"
+                    ? "border-green-200 dark:border-green-900 bg-green-50/50 dark:bg-green-950/30"
+                    : "border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30"
                 }`}
               >
                 <div className="flex items-center gap-3">


### PR DESCRIPTION
## Problem

On the super-admin **Overview Dashboard** (`/admin`), the **System Health** widget's per-service rows (EMP Cloud, EMP Recruit, …) show a washed-out / muddy **light band** in dark mode — each row's status-tinted background stays light against the dark card.

## Root cause

The row background/border are conditional light tints with **no dark variant**:
```
mod.status === "healthy" ? "border-green-200 bg-green-50/50" : "border-red-200 bg-red-50/50"
```
In dark mode `bg-green-50/50` / `bg-red-50/50` stay light and the light `border-*-200` sits on the dark card, so the rows read as pale bands.

(The SuperAdminDashboard was converted in #2216, but this ternary-branch row tint was a special case the pipeline didn't reach.)

## Fix

Added dark variants to both branches:
```
"border-green-200 dark:border-green-900 bg-green-50/50 dark:bg-green-950/30"
"border-red-200   dark:border-red-900   bg-red-50/50   dark:bg-red-950/30"
```
The status dots (`bg-*-500`) and badges were already correct and are left as-is.

## Verification

Swept the page — no other light tints missing dark variants (the `bg-*-500` matches are saturated status dots, correct in both themes). `tsc --noEmit` = 0 errors; `vite build` passes.

**1 file changed.**
