### PR TITLE
fix(rtl): sidebar collapse toggle sticks out as stray wedge in Arabic layout

### DIFF
--- a/packages/client/src/components/layout/DashboardLayout.tsx
+++ b/packages/client/src/components/layout/DashboardLayout.tsx
@@ -267,7 +267,7 @@ export default function DashboardLayout() {
           onClick={() => setSidebarCollapsed((c) => !c)}
           aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
           title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-          className="hidden md:flex absolute top-1/2 -right-3 -translate-y-1/2 z-30 h-6 w-6 rounded-full bg-card border border-border text-muted-foreground hover:text-brand-600 hover:border-brand-300 shadow-sm items-center justify-center transition-colors"
+          className="sidebar-collapse-toggle hidden md:flex absolute top-1/2 -right-3 -translate-y-1/2 z-30 h-6 w-6 rounded-full bg-card border border-border text-muted-foreground hover:text-brand-600 hover:border-brand-300 shadow-sm items-center justify-center transition-colors"
         >
           {sidebarCollapsed ? (
             <ChevronRight className="h-3.5 w-3.5" />

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -136,6 +136,25 @@
     right: 0;
   }
 
+  /* Sidebar collapse toggle in RTL. The button is anchored to the sidebar's
+     inner edge via `-right-3` (Tailwind), which is correct for LTR (sidebar
+     on the left). In RTL the sidebar flips to the right of the viewport, so
+     `-right-3` pushes the circular toggle onto the OUTER edge where it sticks
+     out as a stray wedge. Re-anchor it to the (now-inner) left edge and mirror
+     the chevron so it points the right way. */
+  /* !important is load-bearing here for the same reason as the collapsed-nav
+     rules below: this sits in @layer base while Tailwind's `-right-3` sits in
+     @layer utilities, which is emitted later in the prod build and would win
+     the cascade on source order. Without !important the override "works" in
+     dev (source-order coincidence) and silently regresses in prod. */
+  [dir="rtl"] .sidebar-collapse-toggle {
+    right: auto !important;
+    left: -0.75rem !important; /* mirror of Tailwind -right-3 */
+  }
+  [dir="rtl"] .sidebar-collapse-toggle svg {
+    transform: scaleX(-1);
+  }
+
   /* #1415 — Collapsed sidebar: hide text labels, section headers, badges, and
      chevrons so only nav icons remain visible. We rely on a class toggle on
      the sidebar root (.sidebar-collapsed) so every NavLink/NestedNavItem


### PR DESCRIPTION
## Problem

In the **Arabic / RTL** layout, the sidebar collapse toggle (the small circular chevron button) renders as a **stray red wedge sticking out** of the sidebar's outer edge (see screenshot), instead of sitting neatly on the sidebar's inner edge.

## Root cause

The toggle is anchored with Tailwind's `-right-3` (`right: -0.75rem`). That's correct in **LTR** — the sidebar is on the left, so `-right-3` puts the toggle on its right (inner) edge. But in **RTL** the sidebar flips to the right of the viewport, so `-right-3` pushes the toggle onto the **outer** edge, where it overflows and reads as a broken wedge. The chevron also points the wrong direction.

There was no RTL override for this element in `globals.css` (which already flips `.border-r`, `.ml-auto`, `.fixed.left-0`, etc.).

## Fix

- Gave the button a stable `sidebar-collapse-toggle` class.
- Added `[dir="rtl"]` overrides in `globals.css`: re-anchor to the (now-inner) left edge (`right: auto; left: -0.75rem`) and mirror the chevron (`transform: scaleX(-1)`).

**`!important` is load-bearing** here — same documented gotcha as the collapsed-nav rules: this rule sits in `@layer base` while `-right-3` sits in `@layer utilities`, which is emitted later in the prod build and would win on source order. Verified the compiled CSS emits `right:auto!important;left:-.75rem!important`.

## Verification

`tsc --noEmit` = 0 errors; `vite build` passes; confirmed the `!important` override is present in the compiled stylesheet so it wins in prod. RTL/layout fix.

**2 files changed.**
