### PR TITLE
fix(i18n): localize sidebar section headers (PEOPLE & HR, COMMUNICATION, etc.)

### DIFF
--- a/packages/client/src/components/layout/NavSection.tsx
+++ b/packages/client/src/components/layout/NavSection.tsx
@@ -9,7 +9,7 @@ interface NavSectionProps {
   label: string;
   items: NavItem[];
   location: { pathname: string };
-  t: (key: string) => string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
   activeClass?: string;
   /** Live unread counts keyed by nav path (e.g. { "/messages": 3 }). */
   unreadByPath?: Record<string, number>;
@@ -37,7 +37,21 @@ function isItemActive(item: NavItem, pathname: string, allItems: NavItem[]): boo
     : isExact || (isPrefix && !hasMoreSpecificMatch);
 }
 
-export function NavSection({ label, items, location, activeClass = "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300", unreadByPath }: NavSectionProps) {
+// Section headers are stored as English strings in navigation.config.ts
+// (e.g. "People & HR"). Localise them via `nav.section.<slug>` keys, falling
+// back to the raw English string so an unmapped section still renders.
+function sectionLabel(section: string, t: (key: string, opts?: Record<string, unknown>) => string): string {
+  const slug = section
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  const key = `nav.section.${slug}`;
+  const translated = t(key, { defaultValue: section });
+  return translated;
+}
+
+export function NavSection({ label, items, location, t, activeClass = "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300", unreadByPath }: NavSectionProps) {
   // Track the running section so a divider+label renders before the first
   // surviving item of each new group (resilient to permission-filtered items).
   let currentSection: string | undefined;
@@ -56,7 +70,7 @@ export function NavSection({ label, items, location, activeClass = "bg-brand-50 
           <Fragment key={item.path}>
             {header && (
               <div className="mx-3 mt-4 mb-1 border-t border-border pt-3 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                {header}
+                {sectionLabel(header, t)}
               </div>
             )}
             {item.children ? (

--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -377,7 +377,15 @@
     "changePassword": "تغيير كلمة المرور",
     "viewAttendance": "عرض الحضور",
     "attendanceGrid": "شبكة الحضور",
-    "attendanceSettings": "إعدادات الحضور"
+    "attendanceSettings": "إعدادات الحضور",
+    "section": {
+      "account": "الحساب",
+      "administration": "الإدارة",
+      "attendance_and_leave": "الحضور والإجازات",
+      "communication": "التواصل",
+      "people_and_hr": "الأفراد والموارد البشرية",
+      "workplace_and_community": "مكان العمل والمجتمع"
+    }
   },
   "common": {
     "save": "حفظ",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -377,7 +377,15 @@
     "changePassword": "Passwort ändern",
     "viewAttendance": "Anwesenheit ansehen",
     "attendanceGrid": "Anwesenheitsraster",
-    "attendanceSettings": "Anwesenheitseinstellungen"
+    "attendanceSettings": "Anwesenheitseinstellungen",
+    "section": {
+      "account": "Konto",
+      "administration": "Verwaltung",
+      "attendance_and_leave": "Anwesenheit & Urlaub",
+      "communication": "Kommunikation",
+      "people_and_hr": "Personen & HR",
+      "workplace_and_community": "Arbeitsplatz & Community"
+    }
   },
   "common": {
     "save": "Speichern",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -377,7 +377,15 @@
     "changePassword": "Change Password",
     "viewAttendance": "View Attendance",
     "attendanceGrid": "Attendance Grid",
-    "attendanceSettings": "Attendance Settings"
+    "attendanceSettings": "Attendance Settings",
+    "section": {
+      "account": "Account",
+      "administration": "Administration",
+      "attendance_and_leave": "Attendance & Leave",
+      "communication": "Communication",
+      "people_and_hr": "People & HR",
+      "workplace_and_community": "Workplace & Community"
+    }
   },
   "common": {
     "save": "Save",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -377,7 +377,15 @@
     "changePassword": "Cambiar Contraseña",
     "viewAttendance": "Ver Asistencia",
     "attendanceGrid": "Cuadrícula de Asistencia",
-    "attendanceSettings": "Configuración de Asistencia"
+    "attendanceSettings": "Configuración de Asistencia",
+    "section": {
+      "account": "Cuenta",
+      "administration": "Administración",
+      "attendance_and_leave": "Asistencia y permisos",
+      "communication": "Comunicación",
+      "people_and_hr": "Personas y RR. HH.",
+      "workplace_and_community": "Lugar de trabajo y comunidad"
+    }
   },
   "common": {
     "save": "Guardar",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -377,7 +377,15 @@
     "changePassword": "Changer le mot de passe",
     "viewAttendance": "Voir la présence",
     "attendanceGrid": "Grille de présence",
-    "attendanceSettings": "Paramètres de présence"
+    "attendanceSettings": "Paramètres de présence",
+    "section": {
+      "account": "Compte",
+      "administration": "Administration",
+      "attendance_and_leave": "Présence et congés",
+      "communication": "Communication",
+      "people_and_hr": "Personnel et RH",
+      "workplace_and_community": "Espace de travail et communauté"
+    }
   },
   "common": {
     "save": "Enregistrer",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -377,7 +377,15 @@
     "changePassword": "पासवर्ड बदलें",
     "viewAttendance": "उपस्थिति देखें",
     "attendanceGrid": "उपस्थिति ग्रिड",
-    "attendanceSettings": "उपस्थिति सेटिंग्स"
+    "attendanceSettings": "उपस्थिति सेटिंग्स",
+    "section": {
+      "account": "खाता",
+      "administration": "प्रशासन",
+      "attendance_and_leave": "उपस्थिति और अवकाश",
+      "communication": "संचार",
+      "people_and_hr": "लोग और HR",
+      "workplace_and_community": "कार्यस्थल और समुदाय"
+    }
   },
   "common": {
     "save": "सहेजें",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -377,7 +377,15 @@
     "changePassword": "パスワードの変更",
     "viewAttendance": "勤怠を表示",
     "attendanceGrid": "勤怠グリッド",
-    "attendanceSettings": "勤怠設定"
+    "attendanceSettings": "勤怠設定",
+    "section": {
+      "account": "アカウント",
+      "administration": "管理",
+      "attendance_and_leave": "勤怠・休暇",
+      "communication": "コミュニケーション",
+      "people_and_hr": "人材・人事",
+      "workplace_and_community": "ワークプレイス・コミュニティ"
+    }
   },
   "common": {
     "save": "保存",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -377,7 +377,15 @@
     "changePassword": "Alterar Senha",
     "viewAttendance": "Ver Presença",
     "attendanceGrid": "Grade de Presença",
-    "attendanceSettings": "Configurações de Presença"
+    "attendanceSettings": "Configurações de Presença",
+    "section": {
+      "account": "Conta",
+      "administration": "Administração",
+      "attendance_and_leave": "Presença e licenças",
+      "communication": "Comunicação",
+      "people_and_hr": "Pessoas e RH",
+      "workplace_and_community": "Local de trabalho e comunidade"
+    }
   },
   "common": {
     "save": "Salvar",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -377,7 +377,15 @@
     "changePassword": "修改密码",
     "viewAttendance": "查看考勤",
     "attendanceGrid": "考勤网格",
-    "attendanceSettings": "考勤设置"
+    "attendanceSettings": "考勤设置",
+    "section": {
+      "account": "账户",
+      "administration": "管理",
+      "attendance_and_leave": "考勤与休假",
+      "communication": "沟通",
+      "people_and_hr": "人员与人力资源",
+      "workplace_and_community": "工作场所与社区"
+    }
   },
   "common": {
     "save": "保存",


### PR DESCRIPTION
## Problem

The sidebar **section headers** — `PEOPLE & HR`, `COMMUNICATION`, `WORKPLACE & COMMUNITY`, `ADMINISTRATION` (and Attendance & Leave, Account) — stay in **English** when the app is switched to Arabic (or any non-English locale). See screenshot: the nav items themselves are translated, but the group headers above them are not.

## Root cause

In `navigation.config.ts`, nav items carry both a `label` (English) **and** an `i18nKey` (translated) — but the `section` field is a **hardcoded English string** (`"People & HR"`, …) with no i18n key. `NavSection.tsx` rendered `{header}` directly, so the raw English string showed regardless of locale.

## Fix

- **`NavSection.tsx`**: added a `sectionLabel()` helper that slugifies the section string (`"People & HR"` → `people_and_hr`) and translates it via `nav.section.<slug>`, falling back to the raw English string if a key is missing.
- **i18n**: added a `nav.section` block (6 keys) to **all 9 locales** (en/hi/es/fr/de/pt/ar/ja/zh) with proper translations.

## Verification

Simulated the helper's lookup against `ar.json` — all sections resolve to their Arabic values. All 9 locale JSONs valid; `tsc --noEmit` = 0 errors; `vite build` passes.

*(Note: "HRMS" and the "AI" assistant badge in the screenshot are intentional acronyms kept as-is, not part of this fix.)*

**10 files changed** (NavSection + 9 locales).
