### PR TITLE
ui: enterprise-density uplift for Attendance Grid

### DIFF
--- a/packages/client/src/pages/attendance/AttendanceGridPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceGridPage.tsx
@@ -425,12 +425,12 @@ export default function AttendanceGridPage() {
   ];
 
   return (
-    <div className="space-y-4 p-6">
+    <div className="space-y-4">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">
           {t("nav.attendanceGrid", "Attendance Grid")}
         </h1>
-        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        <p className="mt-0.5 text-[13px] text-muted-foreground">
           {t("attendance.grid.subtitle")}
         </p>
       </div>
@@ -451,7 +451,7 @@ export default function AttendanceGridPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => shiftMonth(-1)}
-            className="inline-flex h-8 w-8 items-center justify-center rounded border border-gray-300 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-800"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-gray-300 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-800"
           >
             <ChevronLeft className="h-4 w-4" />
           </button>
@@ -460,7 +460,7 @@ export default function AttendanceGridPage() {
           </span>
           <button
             onClick={() => shiftMonth(1)}
-            className="inline-flex h-8 w-8 items-center justify-center rounded border border-gray-300 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-800"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-gray-300 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-800"
           >
             <ChevronRight className="h-4 w-4" />
           </button>
@@ -508,7 +508,7 @@ export default function AttendanceGridPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={t("attendance.grid.searchPlaceholder")}
-              className="w-full rounded-md border border-gray-300 bg-white pl-8 pr-3 py-2 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+              className="w-full rounded-md border border-gray-300 bg-white pl-8 pr-3 py-2 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
             />
           </div>
         </div>
@@ -519,7 +519,7 @@ export default function AttendanceGridPage() {
           <select
             value={department}
             onChange={(e) => setDepartment(e.target.value)}
-            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
           >
             <option value="">{t("attendance.grid.allDepartments")}</option>
             {departmentOptions.map((d) => (
@@ -534,7 +534,7 @@ export default function AttendanceGridPage() {
           <select
             value={location}
             onChange={(e) => setLocation(e.target.value)}
-            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+            className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
           >
             <option value="">{t("attendance.grid.allLocations")}</option>
             {locationOptions.map((l) => (
@@ -550,7 +550,7 @@ export default function AttendanceGridPage() {
             <button
               type="button"
               onClick={clearFilters}
-              className="inline-flex items-center gap-1 rounded-full border border-gray-300 bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+              className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
             >
               <X className="h-3 w-3" />
               {t("attendance.grid.clearFilters")}
@@ -683,7 +683,7 @@ export default function AttendanceGridPage() {
                               <div
                                 onDoubleClick={() => setEditing({ uid: emp.user_id, date: d.date })}
                                 title={cellTitle}
-                                className={`flex h-full w-full cursor-pointer items-center justify-center rounded text-[11px] font-semibold transition hover:ring-2 hover:ring-blue-300 ${codeStyle(displayCode)}`}
+                                className={`flex h-full w-full cursor-pointer items-center justify-center rounded-md text-[11px] font-semibold transition hover:ring-2 hover:ring-brand-400 ${codeStyle(displayCode)}`}
                               >
                                 {displayCode || "—"}
                               </div>
@@ -774,7 +774,7 @@ export default function AttendanceGridPage() {
 function LegendDot({ label, cls, desc }: { label: string; cls: string; desc: string }) {
   return (
     <span className="inline-flex items-center gap-1">
-      <span className={`inline-flex h-5 w-6 items-center justify-center rounded text-[10px] font-semibold ${cls}`}>
+      <span className={`inline-flex h-5 w-6 items-center justify-center rounded-md text-[10px] font-semibold ${cls}`}>
         {label}
       </span>
       <span>{desc}</span>
@@ -946,7 +946,7 @@ function CellEditor({
               key={b.code || "reset"}
               type="button"
               onClick={() => onPickStatus(b.code)}
-              className={`rounded px-2.5 py-1 text-xs font-semibold transition ${b.cls} ${currentCode === b.code ? "ring-2 ring-blue-400" : ""}`}
+              className={`rounded-md px-2.5 py-1 text-xs font-semibold transition ${b.cls} ${currentCode === b.code ? "ring-2 ring-brand-400" : ""}`}
             >
               {b.label}
             </button>


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) to the Attendance Grid — an already-dense month grid, so this is a lighter, surface-only pass:

- Header → `text-xl font-semibold tracking-tight` with `text-[13px]` subtitle; dropped the extra `p-6` page padding
- Tightened control radii: month-nav, clear-filter, attendance cell, and legend swatch → `rounded-md`
- Replaced hardcoded `focus:ring-blue` / `hover:ring-blue` / selected-ring-blue with the **brand ring** so the accent matches the rest of the app

Attendance status codes (P/A/H/L/HPL/WO/HO/WOT/HOT/M) keep their semantic color palette with correct dark pairs. Surface-only — no data, query, or logic changes. tsc clean, build passes.

---

This is the **last of the 7 Attendance module pages**. Together with the 3 Positions pages, this completes two full modules of the enterprise UI uplift.