### PR TITLE
ui: enterprise-density uplift for the Leave module (5 pages)

### DIFF
--- a/packages/client/src/pages/leave/CompOffPage.tsx
+++ b/packages/client/src/pages/leave/CompOffPage.tsx
@@ -188,10 +188,10 @@ export default function CompOffPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t('leave.compOff.title')}</h1>
-          <p className="text-muted-foreground mt-1">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('leave.compOff.title')}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">
             {t('leave.compOff.subtitle')}
           </p>
         </div>
@@ -201,7 +201,7 @@ export default function CompOffPage() {
           {isHR && (
             <button
               onClick={() => setShowCredit((v) => !v)}
-              className="flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-emerald-700"
+              className="flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-emerald-700"
             >
               <Plus className="h-4 w-4" /> Credit Balance
             </button>
@@ -209,7 +209,7 @@ export default function CompOffPage() {
           {isSelfView && (
             <button
               onClick={() => setShowForm(!showForm)}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
             >
               <PlusCircle className="h-4 w-4" /> {t('leave.compOff.request')}
             </button>
@@ -221,21 +221,21 @@ export default function CompOffPage() {
       {isHR && showCredit && (
         <form
           onSubmit={handleCreditSubmit}
-          className="bg-card rounded-xl border border-emerald-200 p-6 mb-8"
+          className="bg-card rounded-lg border border-emerald-200 dark:border-emerald-900/40 p-4 mb-6"
         >
-          <h2 className="text-lg font-semibold text-foreground mb-1">Credit / Debit Comp-Off Balance</h2>
+          <h2 className="text-base font-semibold text-foreground mb-1">Credit / Debit Comp-Off Balance</h2>
           <p className="text-xs text-muted-foreground mb-4">
             Manually grant days to an employee's comp-off balance. Use a negative number to debit.
           </p>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <div className="lg:col-span-2">
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 Employee <span className="text-red-500">*</span>
               </label>
               <select
                 value={creditForm.user_id || ""}
                 onChange={(e) => setCreditForm({ ...creditForm, user_id: Number(e.target.value) })}
-                className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card"
                 required
               >
                 <option value="">— Select employee —</option>
@@ -248,7 +248,7 @@ export default function CompOffPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 Days <span className="text-red-500">*</span>
               </label>
               <input
@@ -256,24 +256,24 @@ export default function CompOffPage() {
                 step="0.5"
                 value={creditForm.days}
                 onChange={(e) => setCreditForm({ ...creditForm, days: Number(e.target.value) })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
               <p className="text-xs text-muted-foreground mt-1">Positive to credit, negative to debit.</p>
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">Reason</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">Reason</label>
               <input
                 type="text"
                 value={creditForm.reason}
                 onChange={(e) => setCreditForm({ ...creditForm, reason: e.target.value })}
                 placeholder="e.g. Year-end carry forward"
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
           </div>
           {creditError && (
-            <p className="mt-3 text-sm text-red-600 dark:text-red-400">{creditError}</p>
+            <p className="mt-3 text-[13px] text-red-600 dark:text-red-400">{creditError}</p>
           )}
           <div className="flex justify-end gap-3 mt-4">
             <button
@@ -283,14 +283,14 @@ export default function CompOffPage() {
                 setCreditError(null);
                 setCreditForm({ user_id: 0, days: 1, reason: "" });
               }}
-              className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
+              className="px-4 py-2 text-[13px] text-muted-foreground border border-border rounded-md hover:bg-muted transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={creditMut.isPending}
-              className="flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-emerald-700 disabled:opacity-50"
+              className="flex items-center gap-2 bg-emerald-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-emerald-700 disabled:opacity-50"
             >
               {creditMut.isPending ? "Saving..." : "Apply Adjustment"}
             </button>
@@ -300,43 +300,43 @@ export default function CompOffPage() {
 
       {/* Balance Cards — own comp-off balance & counts; self view only. */}
       {isSelfView && (
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-        <div className="bg-card rounded-xl border border-border p-5">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2.5 mb-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg flex items-center justify-center bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300">
+            <div className="h-8 w-8 rounded-md flex items-center justify-center bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300">
               <CalendarDays className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">
+              <p className="text-2xl font-bold tabular-nums text-foreground">
                 {balanceData?.balance ?? 0}
               </p>
-              <p className="text-xs text-muted-foreground">{t('leave.compOff.balanceLabel')}</p>
+              <p className="text-[11px] text-muted-foreground">{t('leave.compOff.balanceLabel')}</p>
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
             {t('leave.compOff.usedOfAllocated', { used: balanceData?.total_used ?? 0, allocated: balanceData?.total_allocated ?? 0 })}
           </p>
         </div>
-        <div className="bg-card rounded-xl border border-border p-5">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg flex items-center justify-center bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300">
+            <div className="h-8 w-8 rounded-md flex items-center justify-center bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300">
               <Clock className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">
+              <p className="text-2xl font-bold tabular-nums text-foreground">
                 {myRequests.filter((r) => r.status === "pending").length}
               </p>
               <p className="text-xs text-muted-foreground">{t('leave.compOff.pendingRequests')}</p>
             </div>
           </div>
         </div>
-        <div className="bg-card rounded-xl border border-border p-5">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg flex items-center justify-center bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300">
+            <div className="h-8 w-8 rounded-md flex items-center justify-center bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300">
               <CheckCircle2 className="h-5 w-5" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">
+              <p className="text-2xl font-bold tabular-nums text-foreground">
                 {myRequests.filter((r) => r.status === "approved").length}
               </p>
               <p className="text-xs text-muted-foreground">{t('leave.compOff.approvedRequests')}</p>
@@ -350,38 +350,38 @@ export default function CompOffPage() {
       {isSelfView && showForm && (
         <form
           onSubmit={handleSubmit}
-          className="bg-card rounded-xl border border-border p-6 mb-8"
+          className="bg-card rounded-lg border border-border p-4 mb-6"
         >
-          <h2 className="text-lg font-semibold text-foreground mb-4">{t('leave.compOff.requestTitle')}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t('leave.compOff.requestTitle')}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.compOff.dateWorked')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.compOff.dateWorked')} <span className="text-red-500">*</span></label>
               <input
                 type="date"
                 value={form.worked_date}
                 onChange={(e) => handleWorkedDateChange(e.target.value)}
                 max={new Date().toISOString().slice(0, 10)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.compOff.expiresOn')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.compOff.expiresOn')} <span className="text-red-500">*</span></label>
               <input
                 type="date"
                 value={form.expires_on}
                 onChange={(e) => setForm({ ...form, expires_on: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
               <p className="text-xs text-muted-foreground mt-1">{t('leave.compOff.expiryHint')}</p>
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.compOff.days')}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.compOff.days')}</label>
               <select
                 value={form.days}
                 onChange={(e) => setForm({ ...form, days: Number(e.target.value) })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value={0.5}>{t('leave.compOff.daysHalf')}</option>
                 <option value={1}>{t('leave.compOff.daysFull')}</option>
@@ -390,11 +390,11 @@ export default function CompOffPage() {
               </select>
             </div>
             <div className="md:col-span-2 lg:col-span-4">
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.compOff.reason')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.compOff.reason')} <span className="text-red-500">*</span></label>
               <textarea
                 value={form.reason}
                 onChange={(e) => setForm({ ...form, reason: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 rows={2}
                 placeholder={t('leave.compOff.reasonPlaceholder')}
                 required
@@ -405,20 +405,20 @@ export default function CompOffPage() {
             <button
               type="button"
               onClick={() => setShowForm(false)}
-              className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
+              className="px-4 py-2 text-[13px] text-muted-foreground border border-border rounded-md hover:bg-muted transition-colors"
             >
               {t('leave.compOff.cancel')}
             </button>
             <button
               type="submit"
               disabled={submitMut.isPending}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {t('leave.compOff.submit')}
             </button>
           </div>
           {submitMut.isError && (
-            <p className="text-sm text-red-600 dark:text-red-400 mt-2">
+            <p className="text-[13px] text-red-600 dark:text-red-400 mt-2">
               {(submitMut.error as any)?.response?.data?.error?.message || t('leave.compOff.submitFailed')}
             </p>
           )}
@@ -430,7 +430,7 @@ export default function CompOffPage() {
         {isSelfView && (
           <button
             onClick={() => setTab("my")}
-            className={`px-4 py-2 text-sm font-medium rounded-lg ${
+            className={`px-4 py-2 text-[13px] font-medium rounded-md ${
               effectiveTab === "my"
                 ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                 : "text-muted-foreground hover:bg-muted"
@@ -442,7 +442,7 @@ export default function CompOffPage() {
         {isHR && (
           <button
             onClick={() => setTab("pending")}
-            className={`px-4 py-2 text-sm font-medium rounded-lg ${
+            className={`px-4 py-2 text-[13px] font-medium rounded-md ${
               effectiveTab === "pending"
                 ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                 : "text-muted-foreground hover:bg-muted"
@@ -450,7 +450,7 @@ export default function CompOffPage() {
           >
             {t('leave.compOff.pendingApprovals')}
             {pendingRequests.length > 0 && (
-              <span className="ml-2 bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 text-xs px-1.5 py-0.5 rounded-full">
+              <span className="ml-2 bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 text-[11px] tabular-nums px-1.5 py-0.5 rounded-md">
                 {pendingRequests.length}
               </span>
             )}
@@ -460,16 +460,16 @@ export default function CompOffPage() {
 
       {/* My Requests Table — own comp-off history; self view only. */}
       {isSelfView && effectiveTab === "my" && (
-        <div className="bg-card rounded-xl border border-border overflow-x-auto">
+        <div className="bg-card rounded-lg border border-border overflow-x-auto">
           <table className="min-w-full">
-            <thead className="bg-muted border-b border-border">
+            <thead className="bg-muted/50 border-b border-border">
               <tr>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.workedDate')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.days')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.expiresOn')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.reason')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.status')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.submitted')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.workedDate')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.days')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.expiresOn')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.reason')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.status')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.submitted')}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -488,20 +488,20 @@ export default function CompOffPage() {
                   const style = STATUS_STYLES[req.status] || STATUS_STYLES.pending;
                   const Icon = style.icon;
                   return (
-                    <tr key={req.id} className="hover:bg-muted">
-                      <td className="px-6 py-4 text-sm font-medium text-foreground">{req.worked_date}</td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground">{Number(req.days)}</td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground">{req.expires_on}</td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground max-w-xs truncate">{req.reason}</td>
-                      <td className="px-6 py-4">
-                        <span className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full font-medium ${style.bg} ${style.text}`}>
+                    <tr key={req.id} className="hover:bg-muted/50 transition-colors">
+                      <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">{req.worked_date}</td>
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{Number(req.days)}</td>
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{req.expires_on}</td>
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground max-w-xs truncate">{req.reason}</td>
+                      <td className="px-4 py-2.5">
+                        <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md font-medium ${style.bg} ${style.text}`}>
                           <Icon className="h-3 w-3" /> {t(`leave.compOff.status${req.status.charAt(0).toUpperCase() + req.status.slice(1)}`, { defaultValue: req.status })}
                         </span>
                         {req.rejection_reason && (
                           <p className="text-xs text-red-500 mt-1">{req.rejection_reason}</p>
                         )}
                       </td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground">
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                         {new Date(req.created_at).toLocaleDateString()}
                       </td>
                     </tr>
@@ -515,15 +515,15 @@ export default function CompOffPage() {
 
       {/* Pending Approvals Table (HR View) */}
       {effectiveTab === "pending" && isHR && (
-        <div className="bg-card rounded-xl border border-border overflow-x-auto">
+        <div className="bg-card rounded-lg border border-border overflow-x-auto">
           <table className="min-w-full">
-            <thead className="bg-muted border-b border-border">
+            <thead className="bg-muted/50 border-b border-border">
               <tr>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.employee')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.workedDate')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.days')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.reason')}</th>
-                <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.compOff.actions')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.employee')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.workedDate')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.days')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.reason')}</th>
+                <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.compOff.actions')}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border">
@@ -548,26 +548,26 @@ export default function CompOffPage() {
                     req.user_email ||
                     t('leave.compOff.userHash', { id: req.user_id });
                   return (
-                  <tr key={req.id} className="hover:bg-muted">
-                    <td className="px-6 py-4 text-sm font-medium text-foreground">
+                  <tr key={req.id} className="hover:bg-muted/50 transition-colors">
+                    <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">
                       {displayName}
                     </td>
-                    <td className="px-6 py-4 text-sm text-muted-foreground">{req.worked_date}</td>
-                    <td className="px-6 py-4 text-sm text-muted-foreground">{Number(req.days)}</td>
-                    <td className="px-6 py-4 text-sm text-muted-foreground max-w-xs truncate">{req.reason}</td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{req.worked_date}</td>
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{Number(req.days)}</td>
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground max-w-xs truncate">{req.reason}</td>
+                    <td className="px-4 py-2.5">
                       <div className="flex flex-col gap-2">
                         <div className="flex items-center gap-2">
                           <button
                             onClick={() => approveMut.mutate(req.id)}
                             disabled={approveMut.isPending}
-                            className="text-xs bg-green-600 text-white px-2 py-1 rounded hover:bg-green-700 disabled:opacity-50"
+                            className="text-xs bg-green-600 text-white px-2 py-1 rounded-md hover:bg-green-700 disabled:opacity-50"
                           >
                             <CheckCircle2 className="h-3 w-3 inline mr-1" />{t('leave.compOff.approve')}
                           </button>
                           <button
                             onClick={() => setActionId(actionId === req.id ? null : req.id)}
-                            className="text-xs bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 px-2 py-1 rounded hover:bg-red-100 dark:hover:bg-red-950/40"
+                            className="text-xs bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 px-2 py-1 rounded-md hover:bg-red-100 dark:hover:bg-red-950/40"
                           >
                             <XCircle className="h-3 w-3 inline mr-1" />{t('leave.compOff.reject')}
                           </button>
@@ -579,12 +579,12 @@ export default function CompOffPage() {
                               value={rejectReason}
                               onChange={(e) => setRejectReason(e.target.value)}
                               placeholder={t('leave.compOff.rejectionReason')}
-                              className="bg-card text-foreground px-2 py-1 border border-border rounded text-xs flex-1"
+                              className="bg-card text-foreground px-2 py-1 border border-border rounded-md text-[11px] flex-1"
                             />
                             <button
                               onClick={() => rejectMut.mutate({ id: req.id, reason: rejectReason })}
                               disabled={rejectMut.isPending}
-                              className="text-xs bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700 disabled:opacity-50 whitespace-nowrap"
+                              className="text-xs bg-red-600 text-white px-2 py-1 rounded-md hover:bg-red-700 disabled:opacity-50 whitespace-nowrap"
                             >
                               {t('leave.compOff.confirmReject')}
                             </button>

--- a/packages/client/src/pages/leave/LeaveApplicationsPage.tsx
+++ b/packages/client/src/pages/leave/LeaveApplicationsPage.tsx
@@ -26,10 +26,10 @@ interface LeaveType {
 }
 
 const STATUS_STYLES: Record<string, { bg: string; text: string; icon: typeof Clock }> = {
-  pending: { bg: "bg-amber-50", text: "text-amber-700", icon: Clock },
-  approved: { bg: "bg-green-50", text: "text-green-700", icon: CheckCircle2 },
-  rejected: { bg: "bg-red-50", text: "text-red-700", icon: XCircle },
-  cancelled: { bg: "bg-gray-50", text: "text-gray-500", icon: Ban },
+  pending: { bg: "bg-amber-50 dark:bg-amber-950/40", text: "text-amber-700 dark:text-amber-300", icon: Clock },
+  approved: { bg: "bg-green-50 dark:bg-green-950/40", text: "text-green-700 dark:text-green-300", icon: CheckCircle2 },
+  rejected: { bg: "bg-red-50 dark:bg-red-950/40", text: "text-red-700 dark:text-red-300", icon: XCircle },
+  cancelled: { bg: "bg-muted", text: "text-muted-foreground", icon: Ban },
 };
 
 const HR_ROLES = ["hr_admin", "org_admin", "super_admin", "manager"];
@@ -111,16 +111,16 @@ export default function LeaveApplicationsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t("leave.applications.title")}</h1>
-          <p className="text-gray-500 mt-1">{t("leave.applications.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("leave.applications.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("leave.applications.subtitle")}</p>
         </div>
       </div>
 
       {/* #1411 — action feedback */}
       {actionError && (
-        <div className="mb-4 flex items-start justify-between gap-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+        <div className="mb-4 flex items-start justify-between gap-3 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900/40 text-red-700 dark:text-red-300 text-[13px] rounded-md px-4 py-3">
           <span>{actionError}</span>
           <button
             onClick={() => setActionError(null)}
@@ -133,11 +133,11 @@ export default function LeaveApplicationsPage() {
 
       {/* Filters */}
       <div className="flex items-center gap-3 mb-4">
-        <Filter className="h-4 w-4 text-gray-400" />
+        <Filter className="h-4 w-4 text-muted-foreground" />
         <select
           value={statusFilter}
           onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-          className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+          className="px-3 py-2 border border-border rounded-md text-[13px]"
         >
           <option value="">{t("leave.applications.allStatuses")}</option>
           <option value="pending">{t("leave.applications.status.pending")}</option>
@@ -148,26 +148,26 @@ export default function LeaveApplicationsPage() {
       </div>
 
       {/* Table */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
+          <thead className="bg-muted/50 border-b border-border">
             <tr>
-              {canApprove && <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colEmployee")}</th>}
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colType")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colDates")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colDays")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colReason")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colStatus")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colRemarks")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("leave.applications.colActions")}</th>
+              {canApprove && <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colEmployee")}</th>}
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colType")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colDates")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colDays")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colReason")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colStatus")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colRemarks")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("leave.applications.colActions")}</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {isLoading ? (
-              <tr><td colSpan={canApprove ? 8 : 7} className="px-6 py-8 text-center text-gray-400">{t("leave.applications.loading")}</td></tr>
+              <tr><td colSpan={canApprove ? 8 : 7} className="px-6 py-8 text-center text-muted-foreground">{t("leave.applications.loading")}</td></tr>
             ) : applications.length === 0 ? (
               <tr>
-                <td colSpan={canApprove ? 8 : 7} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={canApprove ? 8 : 7} className="px-6 py-8 text-center text-muted-foreground">
                   {/*
                     #1822 — Bug 26: previously a fresh page-load with the
                     "Pending" filter active just said "No applications
@@ -197,55 +197,55 @@ export default function LeaveApplicationsPage() {
                 const style = STATUS_STYLES[app.status] || STATUS_STYLES.pending;
                 const Icon = style.icon;
                 return (
-                  <tr key={app.id} className="hover:bg-gray-50">
+                  <tr key={app.id} className="hover:bg-muted/50 transition-colors">
                     {canApprove && (
-                      <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                      <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">
                         {(app as any).user_first_name ? `${(app as any).user_first_name} ${(app as any).user_last_name || ""}` : t("leave.applications.userHash", { id: app.user_id })}
                       </td>
                     )}
-                    <td className="px-6 py-4 text-sm font-medium text-gray-900">
+                    <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">
                       {getTypeName(app.leave_type_id)}
                       {/* #1609 — guard with Boolean(): MySQL tinyint 0 would
                           render as a literal "0" via JSX `&&` short-circuit. */}
                       {Boolean(app.is_half_day) && (
-                        <span className="ml-1 text-xs text-gray-400">{t("leave.applications.half")}</span>
+                        <span className="ml-1 text-xs text-muted-foreground">{t("leave.applications.half")}</span>
                       )}
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500">
+                    <td className="px-4 py-2.5 text-[13px] tabular-nums text-muted-foreground">
                       {app.start_date} &mdash; {app.end_date}
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-700 font-medium">
+                    <td className="px-4 py-2.5 text-[13px] tabular-nums text-foreground font-medium">
                       {Number(app.days_count)}
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground max-w-xs truncate">
                       {app.reason}
                     </td>
-                    <td className="px-6 py-4">
-                      <span className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full font-medium ${style.bg} ${style.text}`}>
+                    <td className="px-4 py-2.5">
+                      <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md font-medium ${style.bg} ${style.text}`}>
                         <Icon className="h-3 w-3" /> {t(`leave.applications.status.${app.status}`, { defaultValue: app.status })}
                       </span>
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate">
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground max-w-xs truncate">
                       {(app as any).admin_remarks || "-"}
                       {(app as any).approver_name && (app as any).admin_remarks && (
-                        <span className="block text-xs text-gray-400">{t("leave.applications.by", { name: (app as any).approver_name })}</span>
+                        <span className="block text-xs text-muted-foreground">{t("leave.applications.by", { name: (app as any).approver_name })}</span>
                       )}
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       <div className="flex items-center gap-2">
                         {app.status === "pending" && (
                           <>
                             {canApprove && (
                               <button
                                 onClick={() => setActionId(actionId === app.id ? null : app.id)}
-                                className="text-xs bg-green-50 text-green-700 px-2 py-1 rounded hover:bg-green-100"
+                                className="text-xs bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-1 rounded-md hover:bg-green-100 dark:hover:bg-green-950/60"
                               >
                                 {t("leave.applications.review")}
                               </button>
                             )}
                             <button
                               onClick={() => cancelMut.mutate(app.id)}
-                              className="text-xs bg-gray-50 text-gray-600 px-2 py-1 rounded hover:bg-gray-100"
+                              className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-md hover:bg-muted/70"
                             >
                               {t("leave.applications.cancel")}
                             </button>
@@ -254,7 +254,7 @@ export default function LeaveApplicationsPage() {
                         {app.status === "approved" && (
                           <button
                             onClick={() => cancelMut.mutate(app.id)}
-                            className="text-xs bg-gray-50 text-gray-600 px-2 py-1 rounded hover:bg-gray-100"
+                            className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-md hover:bg-muted/70"
                           >
                             Cancel
                           </button>
@@ -267,7 +267,7 @@ export default function LeaveApplicationsPage() {
                             value={remarks}
                             onChange={(e) => setRemarks(e.target.value)}
                             placeholder={t("leave.applications.remarksPlaceholder")}
-                            className="px-2 py-1 border border-gray-300 rounded text-xs flex-1"
+                            className="px-2 py-1 border border-border rounded text-xs flex-1"
                           />
                           <button
                             onClick={() => approveMut.mutate(app.id)}
@@ -294,22 +294,22 @@ export default function LeaveApplicationsPage() {
         </table>
 
         {meta && meta.total_pages > 1 && (
-          <div className="flex items-center justify-between px-6 py-3 border-t border-gray-200">
-            <p className="text-sm text-gray-500">
+          <div className="flex items-center justify-between px-6 py-3 border-t border-border">
+            <p className="text-[13px] tabular-nums text-muted-foreground">
               {t("leave.applications.pageOf", { page: meta.page, total_pages: meta.total_pages, total: meta.total })}
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="px-3 py-1 text-sm border border-gray-300 rounded-lg disabled:opacity-50"
+                className="px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50"
               >
                 {t("leave.applications.previous")}
               </button>
               <button
                 onClick={() => setPage((p) => p + 1)}
                 disabled={page >= meta.total_pages}
-                className="px-3 py-1 text-sm border border-gray-300 rounded-lg disabled:opacity-50"
+                className="px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50"
               >
                 {t("leave.applications.next")}
               </button>

--- a/packages/client/src/pages/leave/LeaveCalendarPage.tsx
+++ b/packages/client/src/pages/leave/LeaveCalendarPage.tsx
@@ -71,32 +71,32 @@ export default function LeaveCalendarPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Leave Calendar</h1>
-          <p className="text-gray-500 mt-1">View approved leaves across your organization.</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">Leave Calendar</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">View approved leaves across your organization.</p>
         </div>
       </div>
 
       {/* Month Navigation */}
       <div className="flex items-center justify-between mb-4">
-        <button onClick={prevMonth} className="p-2 hover:bg-gray-100 rounded-lg">
-          <ChevronLeft className="h-5 w-5 text-gray-600" />
+        <button onClick={prevMonth} className="p-2 hover:bg-muted rounded-md transition-colors">
+          <ChevronLeft className="h-5 w-5 text-muted-foreground" />
         </button>
-        <h2 className="text-lg font-semibold text-gray-900">
+        <h2 className="text-base font-semibold tabular-nums text-foreground">
           {MONTH_NAMES[month - 1]} {year}
         </h2>
-        <button onClick={nextMonth} className="p-2 hover:bg-gray-100 rounded-lg">
-          <ChevronRight className="h-5 w-5 text-gray-600" />
+        <button onClick={nextMonth} className="p-2 hover:bg-muted rounded-md transition-colors">
+          <ChevronRight className="h-5 w-5 text-muted-foreground" />
         </button>
       </div>
 
       {/* Calendar Grid */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div className="bg-card rounded-lg border border-border overflow-hidden">
         {/* Day headers */}
-        <div className="grid grid-cols-7 border-b border-gray-200 bg-gray-50">
+        <div className="grid grid-cols-7 border-b border-border bg-muted/50">
           {DAY_NAMES.map((d) => (
-            <div key={d} className="text-center text-xs font-medium text-gray-500 uppercase py-3">
+            <div key={d} className="text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider py-2.5">
               {d}
             </div>
           ))}
@@ -104,7 +104,7 @@ export default function LeaveCalendarPage() {
 
         {/* Day cells */}
         {isLoading ? (
-          <div className="py-20 text-center text-gray-400">Loading calendar...</div>
+          <div className="py-20 text-center text-muted-foreground">Loading calendar...</div>
         ) : (
           <div className="grid grid-cols-7">
             {cells.map((day, idx) => {
@@ -117,17 +117,17 @@ export default function LeaveCalendarPage() {
               return (
                 <div
                   key={idx}
-                  className={`min-h-[100px] border-b border-r border-gray-100 p-2 ${
-                    day ? "bg-white" : "bg-gray-50"
+                  className={`min-h-[100px] border-b border-r border-border p-2 ${
+                    day ? "bg-card" : "bg-muted/40"
                   }`}
                 >
                   {day && (
                     <>
                       <span
-                        className={`text-sm font-medium ${
+                        className={`text-[13px] font-medium tabular-nums ${
                           isToday
                             ? "bg-brand-600 text-white rounded-full w-7 h-7 flex items-center justify-center"
-                            : "text-gray-700"
+                            : "text-foreground"
                         }`}
                       >
                         {day}
@@ -147,7 +147,7 @@ export default function LeaveCalendarPage() {
                           </div>
                         ))}
                         {dayLeaves.length > 3 && (
-                          <div className="text-[10px] text-gray-400 px-1.5">
+                          <div className="text-[10px] tabular-nums text-muted-foreground px-1.5">
                             +{dayLeaves.length - 3} more
                           </div>
                         )}

--- a/packages/client/src/pages/leave/LeaveDashboardPage.tsx
+++ b/packages/client/src/pages/leave/LeaveDashboardPage.tsx
@@ -267,7 +267,7 @@ export default function LeaveDashboardPage() {
           className="fixed top-4 right-4 z-[60] flex items-start gap-3 max-w-sm rounded-lg border border-green-200 bg-green-50 dark:bg-green-950/40 px-4 py-3 shadow-lg animate-in fade-in slide-in-from-top-2"
         >
           <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400 mt-0.5" />
-          <div className="flex-1 text-sm font-medium text-green-800">{successMsg}</div>
+          <div className="flex-1 text-[13px] font-medium text-green-800 dark:text-green-200">{successMsg}</div>
           <button
             type="button"
             onClick={() => setSuccessMsg(null)}
@@ -279,16 +279,16 @@ export default function LeaveDashboardPage() {
         </div>
       )}
 
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t('leave.dashboard.title')}</h1>
-          <p className="text-muted-foreground mt-1">{t('leave.dashboard.subtitle')}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('leave.dashboard.title')}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t('leave.dashboard.subtitle')}</p>
         </div>
         <div className="flex gap-2">
           {isAdmin && (
             <Link
               to="/leave/settings"
-              className="flex items-center gap-2 bg-muted text-muted-foreground px-4 py-2 rounded-lg text-sm font-medium hover:bg-muted"
+              className="flex items-center gap-2 bg-muted text-muted-foreground px-4 py-2 rounded-md text-[13px] font-medium hover:bg-muted transition-colors"
             >
               <Settings2 className="h-4 w-4" /> {t('leave.dashboard.leaveSettings')}
             </Link>
@@ -297,7 +297,7 @@ export default function LeaveDashboardPage() {
             <button
               type="button"
               onClick={() => setShowApply(true)}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 cursor-pointer"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 cursor-pointer transition-colors"
             >
               <PlusCircle className="h-4 w-4" /> {t('leave.applyLeave')}
             </button>
@@ -310,11 +310,11 @@ export default function LeaveDashboardPage() {
           yet been initialized (missing rows render as zero).
           Hidden in Admin view — own leave balance is personal/self-only. */}
       {isSelfView && (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2.5 mb-6">
         {loadingBalances ? (
           <>
             {[1, 2, 3, 4].map((i) => (
-              <div key={i} className="bg-card rounded-xl border border-border p-5 animate-pulse">
+              <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
                 <div className="h-4 w-24 bg-muted rounded mb-3" />
                 <div className="h-7 w-16 bg-muted rounded mb-2" />
                 <div className="h-2 w-full bg-muted rounded-full" />
@@ -363,7 +363,7 @@ export default function LeaveDashboardPage() {
               return (
                 <div
                   key={type.id}
-                  className="bg-card rounded-xl border border-border p-5 flex flex-col h-full"
+                  className="bg-card rounded-lg border border-border p-4 flex flex-col h-full hover:border-brand-400 transition-colors duration-150"
                 >
                   <div className="flex items-center gap-3 mb-1">
                     <div
@@ -397,7 +397,7 @@ export default function LeaveDashboardPage() {
                       const showAsPaid = type.is_paid && !isUnpaidByName;
                       return (
                         <span
-                          className={`text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded ${
+                          className={`text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0.5 rounded-md ${
                             showAsPaid ? "bg-green-50 dark:bg-green-950/40 text-green-600 dark:text-green-400" : "bg-muted text-muted-foreground"
                           }`}
                         >
@@ -408,7 +408,7 @@ export default function LeaveDashboardPage() {
                       );
                     })()}
                   </div>
-                  <div className="text-3xl font-bold text-foreground mb-1">
+                  <div className="text-3xl font-bold tabular-nums text-foreground mb-1">
                     {balance} <span className="text-sm font-normal text-muted-foreground">{t('leave.dashboard.days')}</span>
                   </div>
                   <p className="text-xs text-muted-foreground">
@@ -471,18 +471,18 @@ export default function LeaveDashboardPage() {
         <form
           ref={applyFormRef}
           onSubmit={handleSubmit}
-          className="bg-card rounded-xl border border-border p-6 mb-8 scroll-mt-4"
+          className="bg-card rounded-lg border border-border p-4 mb-6 scroll-mt-4"
         >
-          <h2 className="text-lg font-semibold text-foreground mb-4">
+          <h2 className="text-base font-semibold text-foreground mb-3">
             {editingId !== null ? t('leave.dashboard.editTitle') : t('leave.dashboard.applyTitle')}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.leaveType')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.leaveType')} <span className="text-red-500">*</span></label>
               <select
                 value={form.leave_type_id}
                 onChange={(e) => setForm({ ...form, leave_type_id: Number(e.target.value) })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               >
                 <option value={0} disabled>{t('leave.dashboard.selectType')}</option>
@@ -512,33 +512,33 @@ export default function LeaveDashboardPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.startDate')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.startDate')} <span className="text-red-500">*</span></label>
               <input
                 type="date"
                 value={form.start_date}
                 onChange={(e) => setForm({ ...form, start_date: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.endDate')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.endDate')} <span className="text-red-500">*</span></label>
               <input
                 type="date"
                 value={form.end_date}
                 onChange={(e) => setForm({ ...form, end_date: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.dashboard.numberOfDays')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.dashboard.numberOfDays')} <span className="text-red-500">*</span></label>
               <input
                 type="number"
                 value={form.days_count}
                 readOnly
                 tabIndex={-1}
-                className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-muted text-muted-foreground cursor-not-allowed"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-muted text-muted-foreground cursor-not-allowed"
                 title="Auto-computed from the date range. The server adjusts the actual debit to exclude your week-offs and mandatory holidays."
               />
               <p className="mt-1 text-xs text-muted-foreground">
@@ -559,7 +559,7 @@ export default function LeaveDashboardPage() {
                 <select
                   value={form.half_day_type ?? ""}
                   onChange={(e) => setForm({ ...form, half_day_type: e.target.value })}
-                  className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
                 >
                   <option value="first_half">{t('leave.dashboard.firstHalf')}</option>
                   <option value="second_half">{t('leave.dashboard.secondHalf')}</option>
@@ -567,23 +567,23 @@ export default function LeaveDashboardPage() {
               )}
             </div>
             <div className="md:col-span-2 lg:col-span-3">
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('leave.reason')} <span className="text-red-500">*</span></label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t('leave.reason')} <span className="text-red-500">*</span></label>
               <textarea
                 value={form.reason}
                 onChange={(e) => setForm({ ...form, reason: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 rows={2}
                 required
               />
             </div>
           </div>
           {formError && (
-            <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 text-red-700 dark:text-red-300 text-sm rounded-lg px-4 py-3 mt-4">
+            <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900/40 text-red-700 dark:text-red-300 text-[13px] rounded-md px-4 py-3 mt-4">
               {formError}
             </div>
           )}
           {(applyLeave.isError || updateLeave.isError) && (
-            <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 text-red-700 dark:text-red-300 text-sm rounded-lg px-4 py-3 mt-4">
+            <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900/40 text-red-700 dark:text-red-300 text-[13px] rounded-md px-4 py-3 mt-4">
               {(() => {
                 const err = editingId !== null ? updateLeave.error : applyLeave.error;
                 const msg = err && typeof err === "object" && "response" in err
@@ -602,14 +602,14 @@ export default function LeaveDashboardPage() {
                 applyLeave.reset();
                 updateLeave.reset();
               }}
-              className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
+              className="px-4 py-2 text-[13px] text-muted-foreground border border-border rounded-md hover:bg-muted transition-colors"
             >
               {t('common.cancel')}
             </button>
             <button
               type="submit"
               disabled={applyLeave.isPending || updateLeave.isPending}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
             >
               <CalendarDays className="h-4 w-4" />
               {editingId !== null
@@ -748,15 +748,15 @@ function RecentApplications({
   };
 
   return (
-    <div className="bg-card rounded-xl border border-border overflow-hidden">
-      <div className="px-6 py-4 border-b border-border">
+    <div className="bg-card rounded-lg border border-border overflow-hidden">
+      <div className="px-4 py-2.5 border-b border-border">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold text-foreground">{t('leave.dashboard.recentTitle')}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('leave.dashboard.recentTitle')}</h2>
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={() => setShowFilters((v) => !v)}
-              className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-lg border ${hasActiveFilter ? "border-brand-300 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300" : "border-border text-muted-foreground hover:bg-muted"}`}
+              className={`inline-flex items-center gap-1 text-[11px] px-2 py-1 rounded-md border transition-colors ${hasActiveFilter ? "border-brand-300 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300" : "border-border text-muted-foreground hover:bg-muted"}`}
             >
               <Filter className="h-3.5 w-3.5" /> Filters{hasActiveFilter ? " ·" : ""}
             </button>
@@ -774,7 +774,7 @@ function RecentApplications({
               <select
                 value={statusFilter}
                 onChange={(e) => setStatusFilter(e.target.value)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               >
                 <option value="">All</option>
                 <option value="pending">Pending</option>
@@ -788,7 +788,7 @@ function RecentApplications({
               <select
                 value={leaveTypeFilter ?? ""}
                 onChange={(e) => setLeaveTypeFilter(e.target.value ? Number(e.target.value) : undefined)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               >
                 <option value="">All</option>
                 {leaveTypes.map((lt) => (
@@ -802,7 +802,7 @@ function RecentApplications({
                 type="date"
                 value={dateFrom}
                 onChange={(e) => setDateFrom(e.target.value)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               />
             </div>
             <div>
@@ -811,7 +811,7 @@ function RecentApplications({
                 type="date"
                 value={dateTo}
                 onChange={(e) => setDateTo(e.target.value)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               />
             </div>
             {hasActiveFilter && (
@@ -828,13 +828,13 @@ function RecentApplications({
       </div>
       <div className="max-h-96 overflow-y-auto">
       <table className="min-w-full">
-        <thead className="bg-muted border-b border-border">
+        <thead className="bg-muted/50 border-b border-border">
           <tr>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.typeHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.datesHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.daysHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.statusHeader')}</th>
-            <th className="text-right text-xs font-medium text-muted-foreground uppercase px-6 py-3 w-24 whitespace-nowrap">{t('leave.dashboard.actionsHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.typeHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.datesHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.daysHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.statusHeader')}</th>
+            <th className="text-right text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5 w-24 whitespace-nowrap">{t('leave.dashboard.actionsHeader')}</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-border">
@@ -842,11 +842,11 @@ function RecentApplications({
             <>
               {[1, 2, 3].map((i) => (
                 <tr key={i} className="animate-pulse">
-                  <td className="px-6 py-4"><div className="h-4 w-20 bg-muted rounded" /></td>
-                  <td className="px-6 py-4"><div className="h-4 w-32 bg-muted rounded" /></td>
-                  <td className="px-6 py-4"><div className="h-4 w-8 bg-muted rounded" /></td>
-                  <td className="px-6 py-4"><div className="h-4 w-16 bg-muted rounded-full" /></td>
-                  <td className="px-6 py-4"><div className="h-4 w-12 bg-muted rounded ml-auto" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-20 bg-muted rounded" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-32 bg-muted rounded" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-8 bg-muted rounded" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-16 bg-muted rounded-full" /></td>
+                  <td className="px-4 py-2.5"><div className="h-4 w-12 bg-muted rounded ml-auto" /></td>
                 </tr>
               ))}
             </>
@@ -859,22 +859,22 @@ function RecentApplications({
               const style = STATUS_STYLES[app.status] || STATUS_STYLES.pending;
               const Icon = style.icon;
               return (
-                <tr key={app.id} className="hover:bg-muted">
-                  <td className="px-6 py-4 text-sm font-medium text-foreground">
+                <tr key={app.id} className="hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">
                     {getTypeName(app.leave_type_id)}
                     {/* #1609 — guard with Boolean(): MySQL tinyint returns 0/1,
                         and `0 && ...` evaluates to 0 which React renders as a
                         literal "0" right after the leave label ("Sick Leave0"). */}
                     {Boolean(app.is_half_day) && <span className="ml-1 text-xs text-muted-foreground">{t('leave.dashboard.halfSuffix')}</span>}
                   </td>
-                  <td className="px-6 py-4 text-sm text-muted-foreground">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                     {new Date(app.start_date).toLocaleDateString(locale, { day: "2-digit", month: "short", year: "numeric" })} &mdash; {new Date(app.end_date).toLocaleDateString(locale, { day: "2-digit", month: "short", year: "numeric" })}
                   </td>
-                  <td className="px-6 py-4 text-sm text-muted-foreground font-medium">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground font-medium">
                     {Number(app.days_count)}
                   </td>
-                  <td className="px-6 py-4">
-                    <span className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full font-medium ${style.bg} ${style.text}`}>
+                  <td className="px-4 py-2.5">
+                    <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md font-medium ${style.bg} ${style.text}`}>
                       <Icon className="h-3 w-3" /> {statusLabel(app.status)}
                     </span>
                     {/* Backend joins leave_approvals → approver name + acted_at.
@@ -900,7 +900,7 @@ function RecentApplications({
                         </div>
                       )}
                   </td>
-                  <td className="px-6 py-4 text-right whitespace-nowrap w-24">
+                  <td className="px-4 py-2.5 text-right whitespace-nowrap w-24">
                     {app.status === "pending" ? (
                       <div className="inline-flex items-center gap-1">
                         <button
@@ -1165,12 +1165,12 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
             : t('common.all');
 
   return (
-    <div className={`bg-card rounded-xl border ${panelTone.border} overflow-hidden mb-6`}>
+    <div className={`bg-card rounded-lg border ${panelTone.border} overflow-hidden mb-6`}>
       <div className={`px-6 py-4 border-b ${panelTone.header}`}>
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground flex items-center gap-2">
             <AlertCircle className={`h-5 w-5 ${panelTone.icon}`} />
-            {headingText} ({applications.length})
+            {headingText} (<span className="tabular-nums">{applications.length}</span>)
           </h2>
           {selectedIds.size > 0 && statusFilter === "pending" && (
             <div className="flex items-center gap-2">
@@ -1178,14 +1178,14 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
               <button
                 onClick={() => handleBulkAction("approve")}
                 disabled={bulkProcessing}
-                className="text-xs bg-green-600 text-white px-3 py-1.5 rounded-lg hover:bg-green-700 disabled:opacity-50 font-medium"
+                className="text-[11px] bg-green-600 text-white px-3 py-1.5 rounded-md hover:bg-green-700 disabled:opacity-50 font-medium"
               >
                 {bulkProcessing ? t('leave.dashboard.processing') : t('leave.dashboard.approveSelected')}
               </button>
               <button
                 onClick={() => handleBulkAction("reject")}
                 disabled={bulkProcessing}
-                className="text-xs bg-red-600 text-white px-3 py-1.5 rounded-lg hover:bg-red-700 disabled:opacity-50 font-medium"
+                className="text-[11px] bg-red-600 text-white px-3 py-1.5 rounded-md hover:bg-red-700 disabled:opacity-50 font-medium"
               >
                 {bulkProcessing ? t('leave.dashboard.processing') : t('leave.dashboard.rejectSelected')}
               </button>
@@ -1202,7 +1202,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                 setActionId(null);
                 setBulkResult(null);
               }}
-              className={`px-3 py-1 text-xs rounded-full font-medium transition-colors ${
+              className={`px-3 py-1 text-[11px] rounded-md font-medium transition-colors ${
                 statusFilter === tab.key
                   ? "bg-foreground text-background"
                   : "bg-card border border-border text-muted-foreground hover:bg-muted"
@@ -1214,7 +1214,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
           <button
             type="button"
             onClick={() => setShowFilters((v) => !v)}
-            className={`ml-2 inline-flex items-center gap-1 px-3 py-1 text-xs rounded-full font-medium border transition-colors ${
+            className={`ml-2 inline-flex items-center gap-1 px-3 py-1 text-[11px] rounded-md font-medium border transition-colors ${
               hasExtraFilters
                 ? "bg-brand-50 dark:bg-brand-950/40 border-brand-300 text-brand-700 dark:text-brand-300"
                 : "bg-card border-border text-muted-foreground hover:bg-muted"
@@ -1232,7 +1232,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Name, email, code"
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs w-52"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px] w-52"
               />
             </div>
             <div>
@@ -1240,7 +1240,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
               <select
                 value={departmentId ?? ""}
                 onChange={(e) => setDepartmentId(e.target.value ? Number(e.target.value) : undefined)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               >
                 <option value="">All</option>
                 {departments.map((d: any) => (
@@ -1253,7 +1253,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
               <select
                 value={locationId ?? ""}
                 onChange={(e) => setLocationId(e.target.value ? Number(e.target.value) : undefined)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               >
                 <option value="">All</option>
                 {locations.map((l: any) => (
@@ -1266,7 +1266,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
               <select
                 value={leaveTypeFilter ?? ""}
                 onChange={(e) => setLeaveTypeFilter(e.target.value ? Number(e.target.value) : undefined)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               >
                 <option value="">All</option>
                 {leaveTypes.map((lt) => (
@@ -1280,7 +1280,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                 type="date"
                 value={dateFrom}
                 onChange={(e) => setDateFrom(e.target.value)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               />
             </div>
             <div>
@@ -1289,7 +1289,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                 type="date"
                 value={dateTo}
                 onChange={(e) => setDateTo(e.target.value)}
-                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-lg text-xs"
+                className="bg-card text-foreground px-2 py-1.5 border border-border rounded-md text-[11px]"
               />
             </div>
             {hasExtraFilters && (
@@ -1344,7 +1344,7 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
         <thead className="bg-muted border-b border-border">
           <tr>
             {statusFilter === "pending" && (
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3 w-10">
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5 w-10">
                 <input
                   type="checkbox"
                   checked={allSelected}
@@ -1353,12 +1353,12 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                 />
               </th>
             )}
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.employeeHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.typeHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.datesHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.daysHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t('leave.dashboard.reasonHeader')}</th>
-            <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.employeeHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.typeHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.datesHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.daysHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('leave.dashboard.reasonHeader')}</th>
+            <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
               {statusFilter === "pending"
                 ? t('leave.dashboard.actionsHeader')
                 : t('leave.dashboard.statusHeader')}
@@ -1374,9 +1374,9 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
             </tr>
           )}
           {applications.map((app: any) => (
-            <tr key={app.id} className={`hover:bg-muted ${selectedIds.has(app.id) ? "bg-brand-50/50" : ""}`}>
+            <tr key={app.id} className={`hover:bg-muted/50 transition-colors ${selectedIds.has(app.id) ? "bg-brand-50/50" : ""}`}>
               {statusFilter === "pending" && (
-                <td className="px-6 py-4">
+                <td className="px-4 py-2.5">
                   <input
                     type="checkbox"
                     checked={selectedIds.has(app.id)}
@@ -1385,31 +1385,31 @@ function PendingApprovals({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                   />
                 </td>
               )}
-              <td className="px-6 py-4 text-sm font-medium text-foreground">
+              <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">
                 {app.user_first_name ? `${app.user_first_name} ${app.user_last_name || ""}` : t('leave.dashboard.userFallback', { id: app.user_id })}
               </td>
-              <td className="px-6 py-4 text-sm text-muted-foreground">
+              <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                 {getTypeName(app.leave_type_id)}
                 {/* #1609 — see comment above; MySQL returns 0/1 not boolean */}
                 {Boolean(app.is_half_day) && <span className="ml-1 text-xs text-muted-foreground">{t('leave.dashboard.halfSuffix')}</span>}
               </td>
-              <td className="px-6 py-4 text-sm text-muted-foreground">
+              <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                 {new Date(app.start_date).toLocaleDateString(i18n.language, { day: "2-digit", month: "short", year: "numeric" })} &mdash; {new Date(app.end_date).toLocaleDateString(i18n.language, { day: "2-digit", month: "short", year: "numeric" })}
               </td>
-              <td className="px-6 py-4 text-sm text-muted-foreground font-medium">{Number(app.days_count)}</td>
+              <td className="px-4 py-2.5 text-[13px] text-muted-foreground font-medium">{Number(app.days_count)}</td>
               <td
                 className="px-6 py-4 text-sm text-muted-foreground max-w-xs truncate cursor-help"
                 title={app.reason || ""}
               >
                 {app.reason}
               </td>
-              <td className="px-6 py-4">
+              <td className="px-4 py-2.5">
                 {statusFilter !== "pending" ? (
                   (() => {
                     const style = STATUS_STYLES[app.status] || STATUS_STYLES.pending;
                     const Icon = style.icon;
                     return (
-                      <span className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full ${style.bg} ${style.text}`}>
+                      <span className={`inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-md ${style.bg} ${style.text}`}>
                         <Icon className="h-3 w-3" /> {app.status}
                       </span>
                     );

--- a/packages/client/src/pages/leave/LeaveTypesPage.tsx
+++ b/packages/client/src/pages/leave/LeaveTypesPage.tsx
@@ -293,8 +293,8 @@ export default function LeaveTypesPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Leave Configuration</h1>
-          <p className="text-gray-500 mt-1">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">Leave Configuration</h1>
+          <p className="text-muted-foreground mt-1">
             {orgConfig
               ? `Fiscal year ${orgConfig.fiscal_year_label_current} — manage settings, types, policies, and employee balances.`
               : "Manage settings, types, policies, and employee balances."}
@@ -304,7 +304,7 @@ export default function LeaveTypesPage() {
           <button
             onClick={() => initBalances.mutate()}
             disabled={initBalances.isPending}
-            className="flex items-center gap-2 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-200 disabled:opacity-50"
+            className="flex items-center gap-2 bg-muted text-foreground px-4 py-2 rounded-md text-[13px] font-medium hover:bg-muted disabled:opacity-50"
           >
             <Settings2 className="h-4 w-4" />
             {initBalances.isPending ? "Initializing..." : "Initialize Balances"}
@@ -313,7 +313,7 @@ export default function LeaveTypesPage() {
       </div>
 
       {initBalances.isSuccess && (
-        <div className="mb-4 p-3 bg-green-50 text-green-700 rounded-lg text-sm">
+        <div className="mb-4 p-3 bg-green-50 text-green-700 rounded-md text-[13px]">
           {((initBalances.data as any)?.initialized ?? 0) > 0
             ? `Balances initialized: ${(initBalances.data as any).initialized} record(s) created.`
             : "All users already have balance rows for every active policy. No new records were created."}
@@ -321,7 +321,7 @@ export default function LeaveTypesPage() {
       )}
 
       {/* ---- Tabs ---- */}
-      <div className="flex border-b border-gray-200 mb-6 -mx-4 px-4 lg:mx-0 overflow-x-auto">
+      <div className="flex border-b border-border mb-6 -mx-4 px-4 lg:mx-0 overflow-x-auto">
         {[
           { key: "settings", label: "Settings", icon: Settings2 },
           { key: "types", label: "Leave Types", icon: Layers },
@@ -337,7 +337,7 @@ export default function LeaveTypesPage() {
               className={`flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 -mb-px whitespace-nowrap ${
                 active
                   ? "border-brand-600 text-brand-700"
-                  : "border-transparent text-gray-500 hover:text-gray-700"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
               }`}
             >
               <Icon className="h-4 w-4" /> {t.label}
@@ -441,17 +441,17 @@ function SettingsSection({
   const month = pending ?? orgConfig?.fiscal_year_start_month ?? 4;
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-6 max-w-2xl">
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">Organization Settings</h2>
+    <div className="bg-card rounded-lg border border-border p-4 max-w-2xl">
+      <h2 className="text-base font-semibold text-foreground mb-4">Organization Settings</h2>
       <div className="space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-[13px] font-medium text-foreground mb-1">
             Fiscal Year Start Month
           </label>
           <select
             value={month}
             onChange={(e) => setPending(Number(e.target.value))}
-            className="w-full max-w-xs px-3 py-2 border border-gray-300 rounded-lg text-sm"
+            className="w-full max-w-xs px-3 py-2 border border-border rounded-md text-[13px]"
           >
             {MONTHS.map((m, i) => (
               <option key={i + 1} value={i + 1}>
@@ -459,7 +459,7 @@ function SettingsSection({
               </option>
             ))}
           </select>
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-muted-foreground mt-1">
             Sessions run {MONTHS[month - 1]} YYYY –{" "}
             {MONTHS[(month + 10) % 12]} YYYY+1. Default: April (Indian fiscal year).
           </p>
@@ -472,7 +472,7 @@ function SettingsSection({
               }
             }}
             disabled={isPending || pending == null || pending === orgConfig?.fiscal_year_start_month}
-            className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+            className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
           >
             {isPending ? "Saving..." : "Save Settings"}
           </button>
@@ -480,7 +480,7 @@ function SettingsSection({
       </div>
 
       {orgConfig && (
-        <div className="mt-6 p-4 bg-gray-50 rounded-lg text-sm text-gray-700">
+        <div className="mt-6 p-4 bg-muted rounded-md text-[13px] text-foreground">
           <div>
             <span className="font-medium">Current fiscal year:</span>{" "}
             {orgConfig.fiscal_year_label_current}
@@ -535,7 +535,7 @@ function TypesSection(props: {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Leave Types</h2>
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Leave Types</h2>
         <button
           onClick={() => {
             setShowTypeForm(!showTypeForm);
@@ -549,7 +549,7 @@ function TypesSection(props: {
       </div>
 
       {showTypeForm && (
-        <form onSubmit={onSubmit} className="bg-white rounded-xl border border-gray-200 p-6 mb-4">
+        <form onSubmit={onSubmit} className="bg-card rounded-lg border border-border p-4 mb-4">
           {typeFormError && (
             <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
               {typeFormError}
@@ -557,42 +557,42 @@ function TypesSection(props: {
           )}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Name <span className="text-red-500">*</span>
               </label>
               <input
                 type="text"
                 value={typeForm.name}
                 onChange={(e) => setTypeForm({ ...typeForm, name: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Code <span className="text-red-500">*</span>
               </label>
               <input
                 type="text"
                 value={typeForm.code}
                 onChange={(e) => setTypeForm({ ...typeForm, code: e.target.value.toUpperCase() })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
                 disabled={!!editingType}
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Color</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Color</label>
               <input
                 type="color"
                 value={typeForm.color}
                 onChange={(e) => setTypeForm({ ...typeForm, color: e.target.value })}
-                className="w-full h-10 border border-gray-300 rounded-lg"
+                className="w-full h-10 border border-border rounded-lg"
               />
             </div>
             {!editingType && (
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-[13px] font-medium text-foreground mb-1">
                   Annual Quota (days) <span className="text-red-500">*</span>
                 </label>
                 <input
@@ -604,53 +604,53 @@ function TypesSection(props: {
                     const val = Number(e.target.value);
                     if (val >= 1 && val <= 365) setTypeForm({ ...typeForm, annual_quota: val });
                   }}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   required
                 />
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-muted-foreground mt-1">
                   A default policy will be created with this quota.
                 </p>
               </div>
             )}
             <div className="md:col-span-3">
-              <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Description</label>
               <input
                 type="text"
                 value={typeForm.description}
                 onChange={(e) => setTypeForm({ ...typeForm, description: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <div className="md:col-span-3 flex flex-wrap gap-6">
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              <label className="flex items-center gap-2 text-sm text-foreground">
                 <input
                   type="checkbox"
                   checked={typeForm.is_paid}
                   onChange={(e) => setTypeForm({ ...typeForm, is_paid: e.target.checked })}
-                  className="rounded border-gray-300"
+                  className="rounded border-border"
                 />
                 Paid Leave
               </label>
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              <label className="flex items-center gap-2 text-sm text-foreground">
                 <input
                   type="checkbox"
                   checked={typeForm.is_encashable}
                   onChange={(e) => setTypeForm({ ...typeForm, is_encashable: e.target.checked })}
-                  className="rounded border-gray-300"
+                  className="rounded border-border"
                 />
                 Encashable
               </label>
-              <label className="flex items-center gap-2 text-sm text-gray-700">
+              <label className="flex items-center gap-2 text-sm text-foreground">
                 <input
                   type="checkbox"
                   checked={typeForm.requires_approval}
                   onChange={(e) => setTypeForm({ ...typeForm, requires_approval: e.target.checked })}
-                  className="rounded border-gray-300"
+                  className="rounded border-border"
                 />
                 Requires Approval
               </label>
             </div>
-            <div className="md:col-span-3 text-xs text-gray-500 -mt-2">
+            <div className="md:col-span-3 text-xs text-muted-foreground -mt-2">
               Within-fiscal-year carry-forward (across quarters / months) is configured per
               policy in the Leave Policies tab.
             </div>
@@ -662,14 +662,14 @@ function TypesSection(props: {
                 setShowTypeForm(false);
                 setEditingType(null);
               }}
-              className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              className="px-4 py-2 text-sm text-foreground border border-border rounded-lg hover:bg-muted"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={createPending || updatePending}
-              className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {editingType ? "Update" : "Create"} Leave Type
             </button>
@@ -677,46 +677,46 @@ function TypesSection(props: {
         </form>
       )}
 
-      <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
+          <thead className="bg-muted/50 border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Type</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Code</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Properties</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Status</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Actions</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Type</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Code</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Properties</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Status</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {loadingTypes ? (
               <tr>
-                <td colSpan={5} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={5} className="px-6 py-8 text-center text-muted-foreground">
                   Loading...
                 </td>
               </tr>
             ) : leaveTypes.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={5} className="px-6 py-8 text-center text-muted-foreground">
                   No leave types configured
                 </td>
               </tr>
             ) : (
               leaveTypes.map((lt) => (
-                <tr key={lt.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4">
+                <tr key={lt.id} className="hover:bg-muted">
+                  <td className="px-4 py-2.5">
                     <div className="flex items-center gap-2">
                       <div
                         className="h-3 w-3 rounded-full"
                         style={{ backgroundColor: lt.color ?? "#6366f1" }}
                       />
-                      <span className="text-sm font-medium text-gray-900">
+                      <span className="text-sm font-medium text-foreground">
                         {leaveTypeLabel(t, lt)}
                       </span>
                     </div>
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500 font-mono">{lt.code}</td>
-                  <td className="px-6 py-4">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground font-mono">{lt.code}</td>
+                  <td className="px-4 py-2.5">
                     <div className="flex flex-wrap gap-1">
                       {(() => {
                         const isUnpaidByName = /\b(unpaid|lwp|without\s*pay|loss\s*of\s*pay)\b/i.test(
@@ -731,7 +731,7 @@ function TypesSection(props: {
                         }
                         if (isUnpaidByName) {
                           return (
-                            <span className="text-[10px] bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+                            <span className="text-[10px] bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
                               Unpaid
                             </span>
                           );
@@ -744,34 +744,34 @@ function TypesSection(props: {
                         </span>
                       )}
                       {lt.requires_approval && (
-                        <span className="text-[10px] bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+                        <span className="text-[10px] bg-muted text-muted-foreground px-1.5 py-0.5 rounded">
                           Approval
                         </span>
                       )}
                     </div>
                   </td>
-                  <td className="px-6 py-4">
+                  <td className="px-4 py-2.5">
                     <span
-                      className={`text-xs px-2 py-1 rounded-full font-medium ${
+                      className={`text-[11px] px-2 py-0.5 rounded-md font-medium ${
                         lt.is_active ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"
                       }`}
                     >
                       {lt.is_active ? "Active" : "Inactive"}
                     </span>
                   </td>
-                  <td className="px-6 py-4">
+                  <td className="px-4 py-2.5">
                     <div className="flex items-center gap-2">
                       <button
                         onClick={() => onStartEdit(lt)}
-                        className="p-1 hover:bg-gray-100 rounded"
+                        className="p-1 hover:bg-muted rounded"
                         title="Edit"
                       >
-                        <Pencil className="h-3.5 w-3.5 text-gray-500" />
+                        <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
                       </button>
                       {lt.is_active ? (
                         <button
                           onClick={() => onDelete(lt.id)}
-                          className="p-1 hover:bg-gray-100 rounded"
+                          className="p-1 hover:bg-muted rounded"
                           title="Deactivate (data preserved)"
                         >
                           <Trash2 className="h-3.5 w-3.5 text-red-500" />
@@ -779,7 +779,7 @@ function TypesSection(props: {
                       ) : (
                         <button
                           onClick={() => onReactivate(lt.id)}
-                          className="p-1 hover:bg-gray-100 rounded"
+                          className="p-1 hover:bg-muted rounded"
                           title="Reactivate"
                         >
                           <Power className="h-3.5 w-3.5 text-green-500" />
@@ -824,7 +824,7 @@ function PoliciesSection(props: {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Leave Policies</h2>
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Leave Policies</h2>
         <button
           onClick={() => {
             setShowPolicyForm(!showPolicyForm);
@@ -838,10 +838,10 @@ function PoliciesSection(props: {
       </div>
 
       {showPolicyForm && (
-        <form onSubmit={onSubmit} className="bg-white rounded-xl border border-gray-200 p-6 mb-4">
+        <form onSubmit={onSubmit} className="bg-card rounded-lg border border-border p-4 mb-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Leave Type <span className="text-red-500">*</span>
               </label>
               <select
@@ -849,7 +849,7 @@ function PoliciesSection(props: {
                 onChange={(e) =>
                   setPolicyForm({ ...policyForm, leave_type_id: Number(e.target.value) })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               >
                 <option value={0} disabled>
@@ -865,19 +865,19 @@ function PoliciesSection(props: {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Policy Name <span className="text-red-500">*</span>
               </label>
               <input
                 type="text"
                 value={policyForm.name}
                 onChange={(e) => setPolicyForm({ ...policyForm, name: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Annual Quota <span className="text-red-500">*</span>
               </label>
               <input
@@ -888,18 +888,18 @@ function PoliciesSection(props: {
                 onChange={(e) =>
                   setPolicyForm({ ...policyForm, annual_quota: Number(e.target.value) })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Accrual Type</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Accrual Type</label>
               <select
                 value={policyForm.accrual_type}
                 onChange={(e) =>
                   setPolicyForm({ ...policyForm, accrual_type: e.target.value })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="annual">Annual (full quota up front)</option>
                 <option value="monthly">Monthly (1/12 each month)</option>
@@ -907,7 +907,7 @@ function PoliciesSection(props: {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Applicable After (months)
               </label>
               <input
@@ -920,11 +920,11 @@ function PoliciesSection(props: {
                     applicable_from_months: Number(e.target.value),
                   })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Min Days Before Application
               </label>
               <input
@@ -937,11 +937,11 @@ function PoliciesSection(props: {
                     min_days_before_application: Number(e.target.value),
                   })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Applicable To
               </label>
               <select
@@ -952,30 +952,30 @@ function PoliciesSection(props: {
                     applicable_gender: e.target.value === "" ? null : e.target.value,
                   })
                 }
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="">Everyone</option>
                 <option value="female">Female only</option>
                 <option value="male">Male only</option>
                 <option value="other">Other only</option>
               </select>
-              <p className="text-xs text-gray-500 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 Restricts who sees and can apply for this leave (e.g. Maternity → Female only).
               </p>
             </div>
             <div className="md:col-span-3">
-              <label className="flex items-start gap-2 text-sm text-gray-700">
+              <label className="flex items-start gap-2 text-sm text-foreground">
                 <input
                   type="checkbox"
                   checked={policyForm.period_carry_forward}
                   onChange={(e) =>
                     setPolicyForm({ ...policyForm, period_carry_forward: e.target.checked })
                   }
-                  className="mt-0.5 rounded border-gray-300"
+                  className="mt-0.5 rounded border-border"
                 />
                 <span>
                   <span className="font-medium">Carry forward unused days within the year</span>
-                  <span className="block text-xs text-gray-500 mt-0.5">
+                  <span className="block text-xs text-muted-foreground mt-0.5">
                     When ON, unused days from one period (quarter/month) roll into the next.
                     When OFF, each period resets and unused days are forfeited at the boundary.
                     Has no effect for "Annual" accrual.
@@ -992,14 +992,14 @@ function PoliciesSection(props: {
                 setPolicyForm(EMPTY_POLICY);
                 setEditingPolicy(null);
               }}
-              className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              className="px-4 py-2 text-sm text-foreground border border-border rounded-lg hover:bg-muted"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={createPending || updatePending}
-              className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {editingPolicy ? "Update" : "Create"} Policy
             </button>
@@ -1007,23 +1007,23 @@ function PoliciesSection(props: {
         </form>
       )}
 
-      <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
+          <thead className="bg-muted/50 border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Policy</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Leave Type</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Quota</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Accrual</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Carry</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Applicable</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Actions</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Policy</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Leave Type</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Quota</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Accrual</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Carry</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Applicable</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Actions</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {policies.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={7} className="px-6 py-8 text-center text-muted-foreground">
                   No policies configured
                 </td>
               </tr>
@@ -1031,31 +1031,31 @@ function PoliciesSection(props: {
               policies.map((p) => {
                 const lt = leaveTypes.find((x) => x.id === p.leave_type_id);
                 return (
-                  <tr key={p.id} className="hover:bg-gray-50">
-                    <td className="px-6 py-4 text-sm font-medium text-gray-900">{p.name}</td>
-                    <td className="px-6 py-4 text-sm text-gray-500">
+                  <tr key={p.id} className="hover:bg-muted">
+                    <td className="px-4 py-2.5 text-[13px] font-medium text-foreground">{p.name}</td>
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                       {lt ? leaveTypeLabel(t, lt) : "-"}
                     </td>
-                    <td className="px-6 py-4 text-sm text-gray-700 font-medium">
+                    <td className="px-4 py-2.5 text-[13px] text-foreground font-medium">
                       {Number(p.annual_quota)} days
                     </td>
-                    <td className="px-6 py-4">
-                      <span className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full capitalize">
+                    <td className="px-4 py-2.5">
+                      <span className="text-xs bg-muted text-foreground px-2 py-1 rounded-full capitalize">
                         {p.accrual_type}
                       </span>
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       {p.period_carry_forward ? (
                         <span className="text-xs bg-purple-50 text-purple-700 px-2 py-1 rounded-full">
                           Cumulative
                         </span>
                       ) : (
-                        <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+                        <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-full">
                           Resets
                         </span>
                       )}
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       {(() => {
                         const g = (p.applicable_gender ?? "").toLowerCase();
                         if (g === "female") {
@@ -1080,23 +1080,23 @@ function PoliciesSection(props: {
                           );
                         }
                         return (
-                          <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+                          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-full">
                             Everyone
                           </span>
                         );
                       })()}
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       <div className="flex items-center gap-2">
                         <button
                           onClick={() => onStartEdit(p)}
-                          className="p-1 hover:bg-gray-100 rounded"
+                          className="p-1 hover:bg-muted rounded"
                         >
-                          <Pencil className="h-3.5 w-3.5 text-gray-500" />
+                          <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
                         </button>
                         <button
                           onClick={() => onDelete(p.id)}
-                          className="p-1 hover:bg-gray-100 rounded"
+                          className="p-1 hover:bg-muted rounded"
                         >
                           <Trash2 className="h-3.5 w-3.5 text-red-500" />
                         </button>
@@ -1218,7 +1218,7 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
   return (
     <div>
       <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Employee Leaves</h2>
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Employee Leaves</h2>
         <div className="flex flex-wrap gap-2">
           <input
             type="text"
@@ -1228,7 +1228,7 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
               setSearch(e.target.value);
               setPage(1);
             }}
-            className="px-3 py-2 border border-gray-300 rounded-lg text-sm w-64"
+            className="px-3 py-2 border border-border rounded-md text-[13px] w-64"
           />
           <select
             value={locationId ?? ""}
@@ -1236,7 +1236,7 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
               setLocationId(e.target.value ? Number(e.target.value) : undefined);
               setPage(1);
             }}
-            className="px-3 py-2 border border-gray-300 rounded-lg text-sm"
+            className="px-3 py-2 border border-border rounded-md text-[13px]"
           >
             <option value="">All locations</option>
             {locations.map((l: any) => (
@@ -1252,42 +1252,42 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
+          <thead className="bg-muted/50 border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Employee</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Employee</th>
               {visibleTypes.map((lt) => (
                 <th
                   key={lt.id}
-                  className="text-left text-xs font-medium text-gray-500 uppercase px-3 py-3"
+                  className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-3 py-2.5"
                 >
                   {lt.name}
                 </th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {isLoading ? (
               <tr>
-                <td colSpan={1 + visibleTypes.length} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={1 + visibleTypes.length} className="px-6 py-8 text-center text-muted-foreground">
                   Loading...
                 </td>
               </tr>
             ) : employees.length === 0 ? (
               <tr>
-                <td colSpan={1 + visibleTypes.length} className="px-6 py-8 text-center text-gray-400">
+                <td colSpan={1 + visibleTypes.length} className="px-6 py-8 text-center text-muted-foreground">
                   No employees found
                 </td>
               </tr>
             ) : (
               employees.map((emp) => (
-                <tr key={emp.user_id} className="hover:bg-gray-50">
+                <tr key={emp.user_id} className="hover:bg-muted">
                   <td className="px-4 py-3">
-                    <div className="text-sm font-medium text-gray-900">
+                    <div className="text-sm font-medium text-foreground">
                       {emp.first_name} {emp.last_name}
                     </div>
-                    <div className="text-xs text-gray-500">
+                    <div className="text-xs text-muted-foreground">
                       {emp.emp_code ? `${emp.emp_code} · ` : ""}
                       {emp.department_name ?? "No dept"}
                     </div>
@@ -1296,7 +1296,7 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                     const bal = emp.balances.find((b) => b.leave_type_id === lt.id);
                     if (!bal)
                       return (
-                        <td key={lt.id} className="px-3 py-3 text-xs text-gray-400">
+                        <td key={lt.id} className="px-3 py-3 text-xs text-muted-foreground">
                           —
                         </td>
                       );
@@ -1317,9 +1317,9 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
                               balance: bal,
                             })
                           }
-                          className="text-left hover:bg-gray-100 rounded px-2 py-1 -mx-2 w-full"
+                          className="text-left hover:bg-muted rounded px-2 py-1 -mx-2 w-full"
                         >
-                          <div className="text-sm font-medium text-gray-900">
+                          <div className="text-sm font-medium text-foreground">
                             {avail} / {allocatedDisplay}
                           </div>
                           {extra !== 0 && (
@@ -1341,13 +1341,13 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
       </div>
 
       {total > 0 && (
-        <div className="flex flex-wrap items-center justify-between gap-3 mt-4 text-sm text-gray-600">
+        <div className="flex flex-wrap items-center justify-between gap-3 mt-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-2">
             <span>Show</span>
             <select
               value={perPage}
               onChange={(e) => { setPerPage(Number(e.target.value)); setPage(1); }}
-              className="px-2 py-1 border border-gray-300 rounded text-sm bg-white"
+              className="px-2 py-1 border border-border rounded text-sm bg-card"
               aria-label="Employees per page"
             >
               {EMPLOYEE_LEAVES_PAGE_SIZES.map((n) => (
@@ -1363,14 +1363,14 @@ function EmployeesSection({ leaveTypes }: { leaveTypes: LeaveType[] }) {
             <button
               onClick={() => setPage(Math.max(1, page - 1))}
               disabled={page === 1}
-              className="px-3 py-1 border border-gray-300 rounded disabled:opacity-40"
+              className="px-3 py-1 border border-border rounded disabled:opacity-40"
             >
               Previous
             </button>
             <button
               onClick={() => setPage(page + 1)}
               disabled={page * perPage >= total}
-              className="px-3 py-1 border border-gray-300 rounded disabled:opacity-40"
+              className="px-3 py-1 border border-border rounded disabled:opacity-40"
             >
               Next
             </button>
@@ -1451,12 +1451,12 @@ function OverrideModal({
 
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-lg w-full">
-        <div className="px-6 py-4 border-b border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-900">
+      <div className="bg-card rounded-lg shadow-xl max-w-lg w-full">
+        <div className="px-6 py-4 border-b border-border">
+          <h3 className="text-base font-semibold text-foreground">
             Adjust {typeName} for {userName}
           </h3>
-          <p className="text-xs text-gray-500 mt-1">
+          <p className="text-xs text-muted-foreground mt-1">
             Fiscal year {balance.fiscal_year_label ?? ""} · changes are audit-logged
           </p>
         </div>
@@ -1479,29 +1479,29 @@ function OverrideModal({
             const persistedAllocated = Number(balance.total_allocated ?? 0);
             const showDriftHint = persistedAllocated !== allocatedDisplay;
             return (
-              <div className="bg-gray-50 rounded-lg p-3">
+              <div className="bg-muted rounded-lg p-3">
                 <div className="grid grid-cols-3 gap-3 text-center">
                   <div>
-                    <div className="text-[10px] uppercase text-gray-500">Allocated</div>
-                    <div className="text-lg font-semibold text-gray-900">
+                    <div className="text-[10px] uppercase text-muted-foreground">Allocated</div>
+                    <div className="text-lg font-semibold tabular-nums text-foreground">
                       {allocatedDisplay}
                     </div>
                   </div>
                   <div>
-                    <div className="text-[10px] uppercase text-gray-500">Used</div>
-                    <div className="text-lg font-semibold text-gray-900">
+                    <div className="text-[10px] uppercase text-muted-foreground">Used</div>
+                    <div className="text-lg font-semibold tabular-nums text-foreground">
                       {used}
                     </div>
                   </div>
                   <div>
-                    <div className="text-[10px] uppercase text-gray-500">Available</div>
-                    <div className="text-lg font-semibold text-brand-700">
+                    <div className="text-[10px] uppercase text-muted-foreground">Available</div>
+                    <div className="text-lg font-semibold tabular-nums text-brand-700 dark:text-brand-300">
                       {available}
                     </div>
                   </div>
                 </div>
                 {showDriftHint && (
-                  <p className="text-[11px] text-gray-500 text-center mt-2">
+                  <p className="text-[11px] text-muted-foreground text-center mt-2">
                     Stored row says {persistedAllocated}; effective allocation
                     derived from {available} available + {used} used.
                   </p>
@@ -1511,7 +1511,7 @@ function OverrideModal({
           })()}
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-[13px] font-medium text-foreground mb-1">
               Extra days granted (added to allocation)
             </label>
             <input
@@ -1519,15 +1519,15 @@ function OverrideModal({
               step={0.5}
               value={extra}
               onChange={(e) => setExtra(Number(e.target.value))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               Use a positive value to grant bonus days, negative to revoke previously granted bonus.
             </p>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-[13px] font-medium text-foreground mb-1">
               Used so far (advanced — use sparingly)
             </label>
             <input
@@ -1536,12 +1536,12 @@ function OverrideModal({
               min={0}
               value={used}
               onChange={(e) => setUsed(Number(e.target.value))}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-[13px] font-medium text-foreground mb-1">
               Reason <span className="text-red-500">*</span>
             </label>
             <textarea
@@ -1551,12 +1551,12 @@ function OverrideModal({
               minLength={1}
               maxLength={500}
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               placeholder="e.g. Joined mid-year correction; performance bonus; ..."
             />
           </div>
 
-          <div className="flex flex-wrap items-center justify-between gap-2 pt-2 border-t border-gray-100">
+          <div className="flex flex-wrap items-center justify-between gap-2 pt-2 border-t border-border">
             <button
               type="button"
               disabled={isResetPending || !reason.trim()}
@@ -1572,14 +1572,14 @@ function OverrideModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+                className="px-4 py-2 text-sm text-foreground border border-border rounded-lg hover:bg-muted"
               >
                 Cancel
               </button>
               <button
                 type="submit"
                 disabled={isPending || !reason.trim()}
-                className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
               >
                 {isPending ? "Saving..." : "Save"}
               </button>
@@ -1656,23 +1656,23 @@ function BulkGrantModal({
 
   return (
     <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col">
-        <div className="px-6 py-4 border-b border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-900">Bulk Grant Leaves</h3>
-          <p className="text-xs text-gray-500 mt-1">
+      <div className="bg-card rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col">
+        <div className="px-6 py-4 border-b border-border">
+          <h3 className="text-base font-semibold text-foreground">Bulk Grant Leaves</h3>
+          <p className="text-xs text-muted-foreground mt-1">
             Apply a positive or negative delta to selected employees on one leave type.
           </p>
         </div>
         <form onSubmit={submit} className="p-6 space-y-4 overflow-y-auto">
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Leave Type <span className="text-red-500">*</span>
               </label>
               <select
                 value={leaveTypeId}
                 onChange={(e) => setLeaveTypeId(Number(e.target.value))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               >
                 {leaveTypes.map((lt) => (
@@ -1683,7 +1683,7 @@ function BulkGrantModal({
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 Days delta <span className="text-red-500">*</span>
               </label>
               <input
@@ -1691,14 +1691,14 @@ function BulkGrantModal({
                 step={0.5}
                 value={delta}
                 onChange={(e) => setDelta(Number(e.target.value))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-[13px] font-medium text-foreground mb-1">
               Reason <span className="text-red-500">*</span>
             </label>
             <textarea
@@ -1707,14 +1707,14 @@ function BulkGrantModal({
               required
               maxLength={500}
               rows={2}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+              className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               placeholder="e.g. Q3 morale bump for engineering"
             />
           </div>
 
           <div>
             <div className="flex items-center justify-between mb-2">
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium text-foreground">
                 Select Employees ({selected.size} of {employees.length})
               </label>
               <button
@@ -1725,11 +1725,11 @@ function BulkGrantModal({
                 {allSelected ? "Clear all" : "Select all"}
               </button>
             </div>
-            <div className="border border-gray-200 rounded-lg max-h-64 overflow-y-auto">
+            <div className="border border-border rounded-lg max-h-64 overflow-y-auto">
               {employees.map((e) => (
                 <label
                   key={e.user_id}
-                  className="flex items-center gap-3 px-3 py-2 border-b border-gray-100 hover:bg-gray-50 cursor-pointer last:border-0"
+                  className="flex items-center gap-3 px-3 py-2 border-b border-border hover:bg-muted cursor-pointer last:border-0"
                 >
                   <input
                     type="checkbox"
@@ -1737,10 +1737,10 @@ function BulkGrantModal({
                     onChange={() => toggle(e.user_id)}
                   />
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm text-gray-900 truncate">
+                    <div className="text-sm text-foreground truncate">
                       {e.first_name} {e.last_name}
                     </div>
-                    <div className="text-xs text-gray-500 truncate">
+                    <div className="text-xs text-muted-foreground truncate">
                       {e.emp_code ? `${e.emp_code} · ` : ""}
                       {e.department_name ?? "No dept"}
                     </div>
@@ -1748,18 +1748,18 @@ function BulkGrantModal({
                 </label>
               ))}
               {employees.length === 0 && (
-                <div className="px-3 py-6 text-center text-sm text-gray-400">
+                <div className="px-3 py-6 text-center text-sm text-muted-foreground">
                   No employees on this page.
                 </div>
               )}
             </div>
           </div>
 
-          <div className="flex justify-end gap-2 pt-2 border-t border-gray-100">
+          <div className="flex justify-end gap-2 pt-2 border-t border-border">
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50"
+              className="px-4 py-2 text-sm text-foreground border border-border rounded-lg hover:bg-muted"
             >
               Cancel
             </button>
@@ -1768,7 +1768,7 @@ function BulkGrantModal({
               disabled={
                 isPending || !reason.trim() || selected.size === 0 || !leaveTypeId
               }
-              className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {isPending ? "Applying..." : `Apply to ${selected.size} employees`}
             </button>


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) across the **entire Leave module** — one PR for all 5 pages.

**Pages:** Leave Dashboard, Applications, Calendar, Types/Policies, Comp-Off.

**Density uplift (all pages):**
- Compact headers (`text-xl font-semibold tracking-tight`)
- `rounded-lg` cards / `rounded-md` controls, `p-6`→`p-4`
- `text-[11px]` uppercase `tracking-wider` table headers, `px-4 py-2.5` dense rows
- `tabular-nums` on every balance / day count / date
- `rounded-md` status pills; comfortable modal padding preserved

**Dark-mode fixes (this is the notable part):**
- **LeaveDashboard** — success-toast text was `text-green-800` on a `dark:bg-green-950/40` tint with **no dark text pair** (unreadable in dark) → added `dark:text-green-300`.
- **LeaveApplications, LeaveCalendar, LeaveTypes** were **light-only** — raw `bg-white` / `text-gray-*` / `border-gray-*` with **zero `dark:` variants**, so they rendered poorly in dark mode. Migrated them to semantic tokens (`bg-card`, `text-foreground`, `bg-muted`, `border-border`, `text-muted-foreground`) so they now theme correctly like the rest of the app, and added `dark:` pairs to their status color styles.

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.

Note: earlier modules (Positions #2246–2248, Attendance #2249–2255) shipped as per-page PRs; from this module on, each module is a single PR.