### PR TITLE
ui: enterprise-density uplift for the Employees module (3 pages)

### DIFF
--- a/packages/client/src/pages/employees/EmployeeProfilePage.tsx
+++ b/packages/client/src/pages/employees/EmployeeProfilePage.tsx
@@ -265,7 +265,7 @@ export default function EmployeeProfilePage() {
       </Link>
 
       {/* Header */}
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex items-center gap-4">
           {/* Biometric face takes precedence — when the user has a kiosk-
               enrolled face, show that image and lock manual photo edits.
@@ -326,7 +326,7 @@ export default function EmployeeProfilePage() {
                   />
                 </div>
                 <div>
-                  <h1 className="text-xl font-bold text-foreground">
+                  <h1 className="text-xl font-semibold tracking-tight text-foreground">
                     {profile.first_name} {profile.last_name}
                   </h1>
                   <p className="text-sm text-muted-foreground">{profile.designation || t("employeeProfile.header.noDesignation")}</p>
@@ -402,7 +402,7 @@ export default function EmployeeProfilePage() {
       </div>
 
       {/* Tab Content */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         {activeTab === "personal" && (
           <PersonalTab
             profile={profile}
@@ -794,7 +794,7 @@ function PersonalTab({ profile, editing, onSave, saving, error, allUsers, depart
               onSave?.(Object.fromEntries(Object.entries(form).filter(([k]) => canEditField(k)).map(([k, v]) => [k, v || null])));
             }}
             disabled={saving}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
           >
             <Check className="h-4 w-4" /> {saving ? t("employeeProfile.personal.saving") : t("employeeProfile.personal.saveChanges")}
           </button>
@@ -1671,7 +1671,7 @@ function ExperienceTab({ data, userId, canEdit }: { data?: any[]; userId: number
                   <div className="flex items-center gap-2">
                     <h3 className="text-sm font-semibold text-foreground">{exp.designation}</h3>
                     {exp.is_current && (
-                      <span className="text-xs bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-full font-medium">
+                      <span className="text-xs bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-md font-medium">
                         {t("employeeProfile.experience.currentBadge")}
                       </span>
                     )}
@@ -2229,7 +2229,7 @@ function AddressesTab({ data, userId, canEdit }: { data?: any[]; userId: number;
           {data.map((addr: any) => (
             <div key={addr.id} className="border border-border rounded-lg p-4 flex items-start justify-between">
               <div className="flex-1">
-                <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full font-medium uppercase mb-2 inline-block">
+                <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-md font-medium uppercase mb-2 inline-block">
                   {t(`employeeProfile.addresses.type.${addr.type}`, { defaultValue: addr.type })}
                 </span>
                 <p className="text-sm text-foreground">{addr.line1}</p>

--- a/packages/client/src/pages/employees/ImportEmployeesPage.tsx
+++ b/packages/client/src/pages/employees/ImportEmployeesPage.tsx
@@ -75,25 +75,25 @@ export default function ImportEmployeesPage() {
 
   return (
     <div>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">{t("importEmployees.page.title")}</h1>
-        <p className="text-gray-500 mt-1">
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("importEmployees.page.title")}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">
           {t("importEmployees.page.subtitle")}
         </p>
       </div>
 
       {/* Success message */}
       {importResult && (
-        <div className="mb-6 bg-green-50 border border-green-200 rounded-xl p-6 flex items-start gap-3">
-          <CheckCircle2 className="h-6 w-6 text-green-600 mt-0.5 shrink-0" />
+        <div className="mb-6 bg-green-50 dark:bg-green-950/40 border border-green-200 dark:border-green-900/40 rounded-lg p-4 flex items-start gap-3">
+          <CheckCircle2 className="h-6 w-6 text-green-600 dark:text-green-400 mt-0.5 shrink-0" />
           <div>
-            <h3 className="text-lg font-semibold text-green-800">{t("importEmployees.success.title")}</h3>
-            <p className="text-green-700 mt-1">
+            <h3 className="text-base font-semibold text-green-800 dark:text-green-300">{t("importEmployees.success.title")}</h3>
+            <p className="text-[13px] text-green-700 dark:text-green-300 mt-1">
               {t("importEmployees.success.message", { count: importResult.count })}
             </p>
             <button
               onClick={() => setImportResult(null)}
-              className="mt-3 text-sm text-green-700 underline hover:text-green-900"
+              className="mt-3 text-[13px] text-green-700 dark:text-green-300 underline hover:text-green-900 dark:hover:text-green-200"
             >
               {t("importEmployees.success.importMore")}
             </button>
@@ -110,20 +110,20 @@ export default function ImportEmployeesPage() {
           }}
           onDragLeave={() => setDragActive(false)}
           onDrop={handleDrop}
-          className={`border-2 border-dashed rounded-xl p-12 text-center transition-colors ${
+          className={`border-2 border-dashed rounded-lg p-12 text-center transition-colors ${
             dragActive
               ? "border-brand-400 bg-brand-50"
-              : "border-gray-300 bg-white hover:border-gray-400"
+              : "border-border bg-card hover:border-brand-400"
           }`}
         >
-          <FileSpreadsheet className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <p className="text-gray-600 mb-2">
+          <FileSpreadsheet className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <p className="text-[13px] text-muted-foreground mb-2">
             {t("importEmployees.dropzone.instructions")}
           </p>
-          <p className="text-xs text-gray-400 mb-4">
+          <p className="text-[11px] text-muted-foreground mb-4">
             {t("importEmployees.dropzone.columnsHint")}
           </p>
-          <label className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg text-sm font-medium hover:bg-brand-700 cursor-pointer transition-colors">
+          <label className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-md text-[13px] font-medium hover:bg-brand-700 cursor-pointer transition-colors">
             <Upload className="h-4 w-4" />
             {t("importEmployees.dropzone.chooseFile")}
             <input
@@ -134,7 +134,7 @@ export default function ImportEmployeesPage() {
             />
           </label>
           {file && (
-            <p className="mt-3 text-sm text-gray-500">
+            <p className="mt-3 text-[13px] text-muted-foreground">
               {t("importEmployees.dropzone.selectedFile", { name: file.name })}
             </p>
           )}
@@ -143,65 +143,65 @@ export default function ImportEmployeesPage() {
 
       {/* Loading */}
       {previewMutation.isPending && (
-        <div className="mt-6 text-center text-gray-400">{t("importEmployees.loading.parsing")}</div>
+        <div className="mt-6 text-center text-[13px] text-muted-foreground">{t("importEmployees.loading.parsing")}</div>
       )}
 
       {/* Preview results */}
       {preview && (
         <div className="mt-6 space-y-6">
           {/* Summary */}
-          <div className="flex gap-4">
-            <div className="flex-1 bg-white border border-gray-200 rounded-xl p-4">
-              <p className="text-sm text-gray-500">{t("importEmployees.summary.totalRows")}</p>
-              <p className="text-2xl font-bold text-gray-900">{preview.totalRows}</p>
+          <div className="flex gap-2.5">
+            <div className="flex-1 bg-card border border-border rounded-lg p-4">
+              <p className="text-[13px] text-muted-foreground">{t("importEmployees.summary.totalRows")}</p>
+              <p className="text-2xl font-bold tabular-nums text-foreground">{preview.totalRows}</p>
             </div>
-            <div className="flex-1 bg-green-50 border border-green-200 rounded-xl p-4">
-              <p className="text-sm text-green-600">{t("importEmployees.summary.valid")}</p>
-              <p className="text-2xl font-bold text-green-700">{preview.valid.length}</p>
+            <div className="flex-1 bg-green-50 dark:bg-green-950/40 border border-green-200 dark:border-green-900/40 rounded-lg p-4">
+              <p className="text-[13px] text-green-600 dark:text-green-400">{t("importEmployees.summary.valid")}</p>
+              <p className="text-2xl font-bold tabular-nums text-green-700 dark:text-green-300">{preview.valid.length}</p>
             </div>
-            <div className="flex-1 bg-red-50 border border-red-200 rounded-xl p-4">
-              <p className="text-sm text-red-600">{t("importEmployees.summary.errors")}</p>
-              <p className="text-2xl font-bold text-red-700">{preview.errors.length}</p>
+            <div className="flex-1 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900/40 rounded-lg p-4">
+              <p className="text-[13px] text-red-600 dark:text-red-400">{t("importEmployees.summary.errors")}</p>
+              <p className="text-2xl font-bold tabular-nums text-red-700 dark:text-red-300">{preview.errors.length}</p>
             </div>
           </div>
 
           {/* Valid rows table */}
           {preview.valid.length > 0 && (
-            <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
-              <div className="px-6 py-3 bg-gray-50 border-b border-gray-200 flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4 text-green-600" />
-                <h3 className="text-sm font-medium text-gray-700">
+            <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
+              <div className="px-4 py-2.5 bg-muted/50 border-b border-border flex items-center gap-2">
+                <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground tabular-nums">
                   {t("importEmployees.validTable.title", { count: preview.valid.length })}
                 </h3>
               </div>
               <table className="w-full">
-                <thead className="bg-gray-50 border-b border-gray-100">
+                <thead className="bg-muted border-b border-border">
                   <tr>
-                    <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-2">{t("importEmployees.validTable.col.name")}</th>
-                    <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-2">{t("importEmployees.validTable.col.email")}</th>
-                    <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-2">{t("importEmployees.validTable.col.empCode")}</th>
-                    <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-2">{t("importEmployees.validTable.col.designation")}</th>
-                    <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-2">{t("importEmployees.validTable.col.department")}</th>
-                    <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-2">{t("importEmployees.validTable.col.status")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("importEmployees.validTable.col.name")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("importEmployees.validTable.col.email")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("importEmployees.validTable.col.empCode")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("importEmployees.validTable.col.designation")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("importEmployees.validTable.col.department")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("importEmployees.validTable.col.status")}</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-100">
+                <tbody className="divide-y divide-border">
                   {preview.valid.slice(0, 50).map((row: any, i: number) => (
                     <tr key={i}>
-                      <td className="px-6 py-2 text-sm text-gray-900">
+                      <td className="px-4 py-2.5 text-[13px] text-foreground">
                         {row.first_name} {row.last_name}
                       </td>
-                      <td className="px-6 py-2 text-sm text-gray-500">{row.email}</td>
-                      <td className="px-6 py-2 text-sm text-gray-500">
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{row.email}</td>
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                         {row.emp_code || t("importEmployees.validTable.emptyCell")}
                       </td>
-                      <td className="px-6 py-2 text-sm text-gray-500">
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                         {row.designation || t("importEmployees.validTable.emptyCell")}
                       </td>
-                      <td className="px-6 py-2 text-sm text-gray-500">
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                         {row.department_name || t("importEmployees.validTable.emptyCell")}
                       </td>
-                      <td className="px-6 py-2">
+                      <td className="px-4 py-2.5">
                         <CheckCircle2 className="h-4 w-4 text-green-500" />
                       </td>
                     </tr>
@@ -209,7 +209,7 @@ export default function ImportEmployeesPage() {
                 </tbody>
               </table>
               {preview.valid.length > 50 && (
-                <div className="px-6 py-2 text-sm text-gray-400 border-t border-gray-100">
+                <div className="px-4 py-2.5 text-[13px] tabular-nums text-muted-foreground border-t border-border">
                   {t("importEmployees.validTable.andMore", { count: preview.valid.length - 50 })}
                 </div>
               )}
@@ -218,32 +218,32 @@ export default function ImportEmployeesPage() {
 
           {/* Error rows */}
           {preview.errors.length > 0 && (
-            <div className="bg-white rounded-xl border border-red-200 overflow-hidden">
-              <div className="px-6 py-3 bg-red-50 border-b border-red-200 flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4 text-red-600" />
-                <h3 className="text-sm font-medium text-red-700">
+            <div className="bg-card rounded-lg border border-red-200 dark:border-red-900/40 overflow-hidden">
+              <div className="px-4 py-2.5 bg-red-50 dark:bg-red-950/40 border-b border-red-200 dark:border-red-900/40 flex items-center gap-2">
+                <AlertTriangle className="h-4 w-4 text-red-600 dark:text-red-400" />
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-red-700 dark:text-red-300 tabular-nums">
                   {t("importEmployees.errorTable.title", { count: preview.errors.length })}
                 </h3>
               </div>
               <table className="w-full">
-                <thead className="bg-red-50 border-b border-red-100">
+                <thead className="bg-red-50 dark:bg-red-950/40 border-b border-red-100 dark:border-red-900/40">
                   <tr>
-                    <th className="text-left text-xs font-medium text-red-500 uppercase px-6 py-2">{t("importEmployees.errorTable.col.row")}</th>
-                    <th className="text-left text-xs font-medium text-red-500 uppercase px-6 py-2">{t("importEmployees.errorTable.col.name")}</th>
-                    <th className="text-left text-xs font-medium text-red-500 uppercase px-6 py-2">{t("importEmployees.errorTable.col.email")}</th>
-                    <th className="text-left text-xs font-medium text-red-500 uppercase px-6 py-2">{t("importEmployees.errorTable.col.errors")}</th>
+                    <th className="text-left text-[11px] font-semibold text-red-500 uppercase tracking-wider px-4 py-2.5">{t("importEmployees.errorTable.col.row")}</th>
+                    <th className="text-left text-[11px] font-semibold text-red-500 uppercase tracking-wider px-4 py-2.5">{t("importEmployees.errorTable.col.name")}</th>
+                    <th className="text-left text-[11px] font-semibold text-red-500 uppercase tracking-wider px-4 py-2.5">{t("importEmployees.errorTable.col.email")}</th>
+                    <th className="text-left text-[11px] font-semibold text-red-500 uppercase tracking-wider px-4 py-2.5">{t("importEmployees.errorTable.col.errors")}</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-red-50">
+                <tbody className="divide-y divide-red-50 dark:divide-red-900/30">
                   {preview.errors.map((err, i) => (
                     <tr key={i}>
-                      <td className="px-6 py-2 text-sm text-gray-900">{err.row}</td>
-                      <td className="px-6 py-2 text-sm text-gray-500">
+                      <td className="px-4 py-2.5 text-[13px] tabular-nums text-foreground">{err.row}</td>
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                         {err.data.first_name} {err.data.last_name}
                       </td>
-                      <td className="px-6 py-2 text-sm text-gray-500">{err.data.email}</td>
-                      <td className="px-6 py-2">
-                        <ul className="text-xs text-red-600 space-y-0.5">
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{err.data.email}</td>
+                      <td className="px-4 py-2.5">
+                        <ul className="text-[11px] text-red-600 dark:text-red-400 space-y-0.5">
                           {err.errors.map((e, j) => (
                             <li key={j} className="flex items-center gap-1">
                               <XCircle className="h-3 w-3 shrink-0" />
@@ -265,7 +265,7 @@ export default function ImportEmployeesPage() {
               <button
                 onClick={() => file && executeMutation.mutate(file)}
                 disabled={executeMutation.isPending}
-                className="flex items-center gap-2 px-6 py-3 bg-brand-600 text-white rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
+                className="flex items-center gap-2 px-6 py-3 bg-brand-600 text-white rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
               >
                 {executeMutation.isPending ? (
                   t("importEmployees.import.importing")

--- a/packages/client/src/pages/employees/OrgChartPage.tsx
+++ b/packages/client/src/pages/employees/OrgChartPage.tsx
@@ -98,7 +98,7 @@ function NodeCard({
         e.stopPropagation();
         onNavigate(node.id);
       }}
-      className={`group relative w-[200px] overflow-hidden rounded-2xl border bg-card text-left shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md ${
+      className={`group relative w-[200px] overflow-hidden rounded-xl border bg-card text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${
         isHighlighted
           ? "border-brand-300 ring-2 ring-brand-100"
           : "border-border hover:border-brand-200 dark:hover:border-brand-800"
@@ -117,10 +117,10 @@ function NodeCard({
               firstName={first}
               lastName={last}
               size="lg"
-              ring={hasChildren ? "ring-brand-100" : "ring-gray-100"}
+              ring={hasChildren ? "ring-brand-100" : "ring-border"}
             />
             {hasChildren && (
-              <span className="absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-brand-500 text-[9px] font-bold text-white ring-2 ring-white">
+              <span className="absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-brand-500 text-[9px] font-bold text-white ring-2 ring-card">
                 {node.children.length}
               </span>
             )}
@@ -264,7 +264,7 @@ function MobileTreeNode({
         )}
         <button
           onClick={() => navigate(`/employees/${node.id}`)}
-          className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted transition-colors group"
+          className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted/50 transition-colors group"
         >
           <div className="h-10 w-10 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center text-sm font-semibold text-brand-700 dark:text-brand-300 shrink-0">
             {getInitials(node.name)}
@@ -627,12 +627,12 @@ export default function OrgChartPage() {
       <div className="mb-4 shrink-0 space-y-4">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-100 to-violet-100 text-indigo-600 dark:text-indigo-400">
-              <Network className="h-6 w-6" />
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-gradient-to-br from-indigo-100 to-violet-100 text-indigo-600 dark:text-indigo-400">
+              <Network className="h-5 w-5" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold text-foreground">{t("orgChart.title")}</h1>
-              <p className="mt-0.5 text-sm text-muted-foreground">
+              <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("orgChart.title")}</h1>
+              <p className="mt-0.5 text-[13px] text-muted-foreground">
                 {t("orgChart.subtitle")}
               </p>
             </div>
@@ -644,7 +644,7 @@ export default function OrgChartPage() {
               <button
                 type="button"
                 onClick={() => setStatModal("people")}
-                className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 shadow-sm transition hover:border-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-950/40 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+                className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 shadow-sm transition hover:border-indigo-300 hover:bg-indigo-50 dark:hover:bg-indigo-950/40 focus:outline-none focus:ring-2 focus:ring-indigo-200"
                 title={t("orgChart.viewAllPeople")}
               >
                 <Users className="h-4 w-4 text-indigo-500" />
@@ -656,7 +656,7 @@ export default function OrgChartPage() {
               <button
                 type="button"
                 onClick={() => setStatModal("managers")}
-                className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-950/40 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-950/40 focus:outline-none focus:ring-2 focus:ring-emerald-200"
                 title={t("orgChart.viewAllManagers")}
               >
                 <Briefcase className="h-4 w-4 text-emerald-500" />
@@ -668,7 +668,7 @@ export default function OrgChartPage() {
               <button
                 type="button"
                 onClick={() => setStatModal("departments")}
-                className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 shadow-sm transition hover:border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/40 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-2 shadow-sm transition hover:border-amber-300 hover:bg-amber-50 dark:hover:bg-amber-950/40 focus:outline-none focus:ring-2 focus:ring-amber-200"
                 title={t("orgChart.viewAllDepartments")}
               >
                 <Building2 className="h-4 w-4 text-amber-500" />
@@ -692,7 +692,7 @@ export default function OrgChartPage() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={t("orgChart.searchPlaceholder")}
-              className="w-full rounded-lg border border-border bg-card py-2 pl-9 pr-9 text-sm outline-none transition focus:border-brand-300 dark:focus:border-brand-800 focus:ring-2 focus:ring-brand-100"
+              className="w-full rounded-md border border-border bg-card py-2 pl-9 pr-9 text-[13px] outline-none transition focus:border-brand-300 dark:focus:border-brand-800 focus:ring-2 focus:ring-brand-100"
             />
             {search && (
               <button
@@ -707,7 +707,7 @@ export default function OrgChartPage() {
               </button>
             )}
             {searchResults.length > 0 && (
-              <div className="absolute z-30 mt-1 w-full overflow-hidden rounded-lg border border-border bg-card shadow-lg">
+              <div className="absolute z-30 mt-1 w-full overflow-hidden rounded-md border border-border bg-card shadow-lg">
                 {searchResults.map((p) => (
                   <button
                     key={p.id}
@@ -740,7 +740,7 @@ export default function OrgChartPage() {
               onClick={() => exportChart("png")}
               disabled={exporting !== null}
               title={t("orgChart.downloadPng")}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm text-muted-foreground shadow-sm transition hover:border-brand-300 dark:hover:border-brand-800 hover:bg-brand-50 dark:hover:bg-brand-950/40 hover:text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground shadow-sm transition hover:border-brand-300 dark:hover:border-brand-800 hover:bg-brand-50 dark:hover:bg-brand-950/40 hover:text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {exporting === "png" ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -754,7 +754,7 @@ export default function OrgChartPage() {
               onClick={() => exportChart("pdf")}
               disabled={exporting !== null}
               title={t("orgChart.downloadPdf")}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm text-muted-foreground shadow-sm transition hover:border-brand-300 dark:hover:border-brand-800 hover:bg-brand-50 dark:hover:bg-brand-950/40 hover:text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-3 py-2 text-sm text-muted-foreground shadow-sm transition hover:border-brand-300 dark:hover:border-brand-800 hover:bg-brand-50 dark:hover:bg-brand-950/40 hover:text-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {exporting === "pdf" ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -781,7 +781,7 @@ export default function OrgChartPage() {
           {/* ====== Desktop: pannable / zoomable viewport ====== */}
           <div
             ref={containerRef}
-            className="hidden lg:block relative flex-1 h-[calc(100vh-16rem)] overflow-hidden rounded-xl border border-border bg-gradient-to-br from-muted to-background dark:from-gray-900 dark:to-gray-800"
+            className="hidden lg:block relative flex-1 h-[calc(100vh-16rem)] overflow-hidden rounded-lg border border-border bg-gradient-to-br from-muted to-background dark:from-gray-900 dark:to-gray-800"
             style={{
               cursor: isDragging ? "grabbing" : "grab",
               backgroundImage:
@@ -799,7 +799,7 @@ export default function OrgChartPage() {
                 onClick={() =>
                   setScale((s) => Math.min(2.5, s + 0.15))
                 }
-                className="h-9 w-9 rounded-lg bg-card border border-border shadow-sm flex items-center justify-center hover:bg-muted text-muted-foreground"
+                className="h-9 w-9 rounded-md bg-card border border-border shadow-sm flex items-center justify-center hover:bg-muted text-muted-foreground"
                 title={t("orgChart.zoomIn")}
               >
                 <Plus className="h-4 w-4" />
@@ -811,14 +811,14 @@ export default function OrgChartPage() {
                 onClick={() =>
                   setScale((s) => Math.max(0.15, s - 0.15))
                 }
-                className="h-9 w-9 rounded-lg bg-card border border-border shadow-sm flex items-center justify-center hover:bg-muted text-muted-foreground"
+                className="h-9 w-9 rounded-md bg-card border border-border shadow-sm flex items-center justify-center hover:bg-muted text-muted-foreground"
                 title={t("orgChart.zoomOut")}
               >
                 <Minus className="h-4 w-4" />
               </button>
               <button
                 onClick={toggleFullscreen}
-                className="h-9 w-9 rounded-lg bg-card border border-border shadow-sm flex items-center justify-center hover:bg-muted text-muted-foreground mt-1"
+                className="h-9 w-9 rounded-md bg-card border border-border shadow-sm flex items-center justify-center hover:bg-muted text-muted-foreground mt-1"
                 title={t("orgChart.fullscreen")}
               >
                 <Maximize2 className="h-4 w-4" />
@@ -852,7 +852,7 @@ export default function OrgChartPage() {
 
           {/* ====== Mobile / Tablet: vertical list tree ====== */}
           <div
-            className="lg:hidden bg-card rounded-xl border border-border p-4 overflow-auto"
+            className="lg:hidden bg-card rounded-lg border border-border p-4 overflow-auto"
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
@@ -924,13 +924,13 @@ function StatListModal({
     <Dialog.Root open={open} onOpenChange={(v) => !v && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[80vh] w-full max-w-xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl bg-card shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95">
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[80vh] w-full max-w-xl -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg bg-card shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95">
           <div className="flex items-center justify-between border-b border-border px-6 py-4">
             <Dialog.Title className="text-base font-semibold text-foreground">
               {title}
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-lg p-1.5 text-muted-foreground hover:bg-muted hover:text-muted-foreground">
+              <button className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-muted-foreground">
                 <X className="h-4 w-4" />
               </button>
             </Dialog.Close>
@@ -947,7 +947,7 @@ function StatListModal({
                     ? t("orgChart.filterDepartments")
                     : t("orgChart.filterPeople")
                 }
-                className="w-full rounded-lg border border-border bg-card py-2 pl-9 pr-3 text-sm outline-none focus:border-brand-300 dark:focus:border-brand-800 focus:ring-2 focus:ring-brand-100"
+                className="w-full rounded-md border border-border bg-card py-2 pl-9 pr-3 text-[13px] outline-none focus:border-brand-300 dark:focus:border-brand-800 focus:ring-2 focus:ring-brand-100"
               />
             </div>
           </div>
@@ -986,13 +986,13 @@ function PersonList({
     return <p className="px-4 py-8 text-center text-sm text-muted-foreground">{t("orgChart.noMatches")}</p>;
   }
   return (
-    <ul className="divide-y divide-gray-100">
+    <ul className="divide-y divide-border">
       {people.map((p) => (
         <li key={p.id}>
           <button
             type="button"
             onClick={() => onNavigate(p.id)}
-            className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted"
+            className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/50 transition-colors"
           >
             <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-300 to-violet-400 text-[11px] font-semibold text-white">
               {getInitials(p.name)}
@@ -1005,7 +1005,7 @@ function PersonList({
               </p>
             </div>
             {p.children.length > 0 && (
-              <span className="shrink-0 rounded-full bg-brand-50 dark:bg-brand-950/40 px-2 py-0.5 text-[10px] font-semibold text-brand-600 dark:text-brand-400">
+              <span className="shrink-0 rounded-md bg-brand-50 dark:bg-brand-950/40 px-2 py-0.5 text-[10px] font-semibold text-brand-600 dark:text-brand-400">
                 {t("orgChart.reportsBadge", { count: p.children.length })}
               </span>
             )}
@@ -1029,7 +1029,7 @@ function DepartmentList({
     return <p className="px-4 py-8 text-center text-sm text-muted-foreground">{t("orgChart.noMatches")}</p>;
   }
   return (
-    <ul className="divide-y divide-gray-100">
+    <ul className="divide-y divide-border">
       {departments.map((d) => {
         const expanded = openDept === d.name;
         return (
@@ -1037,9 +1037,9 @@ function DepartmentList({
             <button
               type="button"
               onClick={() => setOpenDept(expanded ? null : d.name)}
-              className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted"
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/50 transition-colors"
             >
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300">
                 <Building2 className="h-4 w-4" />
               </div>
               <div className="min-w-0 flex-1">


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) to the **Employees module** — one PR for the 3 remaining pages (Directory + Probation shipped earlier).

**Pages:** Employee Profile, Org Chart, Import Employees.

- **Employee Profile** (already token-based): tightened card radii (`rounded-lg` / `p-4`), status pills → `rounded-md`, header → `font-semibold tracking-tight`.
- **Org Chart** (chrome only): header, toolbar stat pills, search, export, zoom, viewport, mobile card and modal → `rounded-md`/`rounded-lg` with `tabular-nums` on the people/managers/departments counts. **The org-chart node diagram, department gradients, and connector lines are left untouched.** Migrated raw-gray stragglers (`divide-gray-100`, `ring-white`, `ring-gray-100`) to tokens.
- **Import Employees** was **fully light-only** — raw `bg-white` / `text-gray-*` / `border-gray-*` with **zero `dark:` variants** (broken in dark mode). Migrated to semantic tokens, applied density (compact header, `rounded-lg` cards, `text-[11px]` uppercase table headers, `px-4 py-2.5` rows, `tabular-nums` on all counts), and added `dark:` pairs to the green/red status summary cards and tables.

**Dark-mode bug fix:** the Import success-banner heading was `text-green-800` — once the banner gains a `dark:bg-green-950/40` tint (this PR) that would be unreadable in dark, so added `dark:text-green-300` (guide §5 "Don't").

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.