### PR TITLE
ui: enterprise-density uplift for Home surfaces (4 pages)

### DIFF
--- a/packages/client/src/pages/announcements/AnnouncementsPage.tsx
+++ b/packages/client/src/pages/announcements/AnnouncementsPage.tsx
@@ -16,9 +16,9 @@ const AVAILABLE_ROLES = ["employee", "manager", "hr_admin", "org_admin"];
 // Priority → colour + icon. Label text comes from i18n
 // (announcements.page.priority.*).
 const PRIORITY_CONFIG: Record<string, { color: string; icon: typeof Info }> = {
-  urgent: { color: "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300 border-red-200", icon: AlertCircle },
-  high: { color: "bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300 border-orange-200", icon: AlertTriangle },
-  normal: { color: "bg-blue-100 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border-blue-200", icon: Info },
+  urgent: { color: "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300 border-red-200 dark:border-red-900/50", icon: AlertCircle },
+  high: { color: "bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300 border-orange-200 dark:border-orange-900/50", icon: AlertTriangle },
+  normal: { color: "bg-blue-100 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-900/50", icon: Info },
   low: { color: "bg-muted text-muted-foreground border-border", icon: Info },
 };
 
@@ -206,12 +206,12 @@ export default function AnnouncementsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-bold text-foreground">{t("announcements.page.title")}</h1>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("announcements.page.title")}</h1>
             {typeof unreadCount === "number" && unreadCount > 0 && (
-              <span className="inline-flex items-center justify-center h-6 min-w-[1.5rem] px-2 text-xs font-bold text-white bg-red-500 rounded-full">
+              <span className="inline-flex items-center justify-center h-6 min-w-[1.5rem] px-2 text-[11px] tabular-nums font-bold text-white bg-red-500 rounded-full">
                 {unreadCount}
               </span>
             )}
@@ -221,7 +221,7 @@ export default function AnnouncementsPage() {
         {isHR && (
           <button
             onClick={() => (showForm ? closeForm() : (setEditId(null), resetForm(), setShowForm(true)))}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
           >
             <Plus className="h-4 w-4" /> {t("announcements.page.newAnnouncement")}
           </button>
@@ -230,25 +230,25 @@ export default function AnnouncementsPage() {
 
       {/* Create Announcement Form */}
       {showForm && isHR && (
-        <form onSubmit={handleSubmit} className="bg-card rounded-xl border border-border p-6 mb-6 space-y-4">
-          <h2 className="text-lg font-semibold text-foreground">
+        <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 mb-6 space-y-4">
+          <h2 className="text-base font-semibold text-foreground">
             {editId != null ? t("announcements.page.editTitle") : t("announcements.page.createTitle")}
           </h2>
 
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">{t("announcements.page.fieldTitle")} <span className="text-red-500">*</span></label>
+            <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("announcements.page.fieldTitle")} <span className="text-red-500">*</span></label>
             <input
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               placeholder={t("announcements.page.titlePlaceholder")}
               required
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">{t("announcements.page.fieldContent")} <span className="text-red-500">*</span></label>
+            <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("announcements.page.fieldContent")} <span className="text-red-500">*</span></label>
             <RichTextEditor
               value={content}
               onChange={setContent}
@@ -258,11 +258,11 @@ export default function AnnouncementsPage() {
 
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("announcements.page.fieldPriority")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("announcements.page.fieldPriority")}</label>
               <select
                 value={priority}
                 onChange={(e) => setPriority(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="low">{t("announcements.page.priority.low")}</option>
                 <option value="normal">{t("announcements.page.priority.normal")}</option>
@@ -272,11 +272,11 @@ export default function AnnouncementsPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("announcements.page.fieldTarget")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("announcements.page.fieldTarget")}</label>
               <select
                 value={targetType}
                 onChange={(e) => { setTargetType(e.target.value); setSelectedTargetIds([]); }}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="all">{t("announcements.page.targetAll")}</option>
                 <option value="department">{t("announcements.page.targetDepartment")}</option>
@@ -286,10 +286,10 @@ export default function AnnouncementsPage() {
 
             {targetType === "department" && (
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                   {t("announcements.page.selectDepartments")}
                 </label>
-                <div className="w-full border border-border rounded-lg p-2 max-h-40 overflow-y-auto bg-card">
+                <div className="w-full border border-border rounded-md p-2 max-h-40 overflow-y-auto bg-card">
                   {deptLoading ? (
                     <p className="text-xs text-muted-foreground p-1">{t("announcements.page.loadingDepartments")}</p>
                   ) : (departments || []).length === 0 ? (
@@ -315,10 +315,10 @@ export default function AnnouncementsPage() {
             )}
             {targetType === "role" && (
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                   {t("announcements.page.selectRoles")}
                 </label>
-                <div className="w-full border border-border rounded-lg p-2 max-h-40 overflow-y-auto bg-card">
+                <div className="w-full border border-border rounded-md p-2 max-h-40 overflow-y-auto bg-card">
                   {AVAILABLE_ROLES.map((role) => (
                     <label key={role} className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-muted cursor-pointer">
                       <input
@@ -338,12 +338,12 @@ export default function AnnouncementsPage() {
             )}
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("announcements.page.fieldExpires")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("announcements.page.fieldExpires")}</label>
               <input
                 type="datetime-local"
                 value={expiresAt}
                 onChange={(e) => setExpiresAt(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
           </div>
@@ -352,14 +352,14 @@ export default function AnnouncementsPage() {
             <button
               type="button"
               onClick={closeForm}
-              className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+              className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted/50 transition-colors"
             >
               {t("announcements.page.cancel")}
             </button>
             <button
               type="submit"
               disabled={isSaving || !title.trim() || isRichTextEmpty(content)}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Megaphone className="h-4 w-4" />{" "}
               {editId != null ? t("announcements.page.saveChanges") : t("announcements.page.publish")}
@@ -371,11 +371,11 @@ export default function AnnouncementsPage() {
       {/* Announcement Cards */}
       <div className="space-y-4">
         {isLoading ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             {t("announcements.page.loading")}
           </div>
         ) : announcements.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             {t("announcements.page.empty")}
           </div>
         ) : (
@@ -388,16 +388,16 @@ export default function AnnouncementsPage() {
             return (
               <div
                 key={a.id}
-                className={`bg-card rounded-xl border overflow-hidden transition-shadow hover:shadow-md ${
+                className={`bg-card rounded-lg border overflow-hidden hover:border-brand-400 transition-colors duration-150 ${
                   isRead ? "border-border" : "border-brand-300 shadow-sm"
                 }`}
               >
-                <div className="p-6">
+                <div className="p-4">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-3 mb-2">
                         {/* Priority Badge */}
-                        <span className={`inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full border ${config.color}`}>
+                        <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md border ${config.color}`}>
                           <PriorityIcon className="h-3 w-3" />
                           {t(`announcements.page.priority.${a.priority}`, { defaultValue: a.priority })}
                         </span>
@@ -453,7 +453,7 @@ export default function AnnouncementsPage() {
                         <button
                           onClick={() => handleMarkRead(a.id)}
                           disabled={markAsRead.isPending}
-                          className="flex items-center gap-1.5 text-xs font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 border border-brand-200 px-3 py-1.5 rounded-lg hover:bg-brand-50 dark:hover:bg-brand-950/40 disabled:opacity-50"
+                          className="flex items-center gap-1.5 text-xs font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 border border-brand-200 dark:border-brand-900/50 px-3 py-1.5 rounded-md hover:bg-brand-50 dark:hover:bg-brand-950/40 disabled:opacity-50"
                         >
                           <Check className="h-3.5 w-3.5" /> {t("announcements.page.markRead")}
                         </button>
@@ -463,7 +463,7 @@ export default function AnnouncementsPage() {
                           onClick={() => startEdit(a)}
                           title={t("announcements.page.editTitle")}
                           aria-label={t("announcements.page.editAria", { title: a.title })}
-                          className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-brand-700 border border-border px-3 py-1.5 rounded-lg hover:bg-brand-50 dark:hover:bg-brand-950/40"
+                          className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-brand-700 border border-border px-3 py-1.5 rounded-md hover:bg-brand-50 dark:hover:bg-brand-950/40"
                         >
                           <Pencil className="h-3.5 w-3.5" /> {t("announcements.page.edit")}
                         </button>
@@ -474,7 +474,7 @@ export default function AnnouncementsPage() {
                           disabled={deleteAnnouncement.isPending}
                           title={t("announcements.page.deleteTitle")}
                           aria-label={t("announcements.page.deleteAria", { title: a.title })}
-                          className="flex items-center gap-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:text-red-700 border border-red-200 px-3 py-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/40 disabled:opacity-50"
+                          className="flex items-center gap-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:text-red-700 border border-red-200 dark:border-red-900/50 px-3 py-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-950/40 disabled:opacity-50"
                         >
                           <Trash2 className="h-3.5 w-3.5" /> {t("announcements.page.delete")}
                         </button>
@@ -523,14 +523,14 @@ export default function AnnouncementsPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
             >
               {t("announcements.page.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
             >
               {t("announcements.page.next")}
             </button>

--- a/packages/client/src/pages/celebrations/CelebrationsPage.tsx
+++ b/packages/client/src/pages/celebrations/CelebrationsPage.tsx
@@ -215,12 +215,12 @@ export default function CelebrationsPage() {
       {/* ── Header — clean & light, matching the app's other page headers ── */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-brand-50 dark:bg-brand-950/40 text-brand-600 dark:text-brand-400">
-            <PartyPopper className="h-6 w-6" />
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-brand-50 dark:bg-brand-950/40 text-brand-600 dark:text-brand-400">
+            <PartyPopper className="h-5 w-5" />
           </div>
           <div>
-            <h1 className="text-2xl font-bold text-foreground">{t("celebrations.title")}</h1>
-            <p className="text-sm text-muted-foreground">{t("celebrations.subtitle")}</p>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("celebrations.title")}</h1>
+            <p className="text-[13px] text-muted-foreground">{t("celebrations.subtitle")}</p>
           </div>
         </div>
 
@@ -269,8 +269,8 @@ export default function CelebrationsPage() {
             </section>
           ) : (
             // No one celebrating today — a warm anchor instead of a bare list.
-            <div className="flex items-center gap-3 rounded-xl border border-border bg-gradient-to-r from-brand-50 to-white dark:from-brand-950/40 dark:to-gray-900 p-4">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-card text-brand-600 dark:text-brand-400 shadow-sm">
+            <div className="flex items-center gap-3 rounded-lg border border-border bg-gradient-to-r from-brand-50 to-white dark:from-brand-950/40 dark:to-gray-900 p-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-card text-brand-600 dark:text-brand-400 shadow-sm">
                 <Sparkles className="h-5 w-5" />
               </div>
               <div>
@@ -329,7 +329,7 @@ function HeroStat({
   accent: string;
 }) {
   return (
-    <div className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5">
+    <div className="flex items-center gap-2 rounded-md border border-border bg-card px-3 py-1.5">
       <Icon className={`h-4 w-4 ${accent}`} />
       <span className="text-sm font-bold tabular-nums text-foreground">{value}</span>
       <span className="text-xs text-muted-foreground">{label}</span>
@@ -349,7 +349,7 @@ function FilterTab({
   return (
     <button
       onClick={onClick}
-      className={`inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition ${
+      className={`inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[13px] font-medium transition-colors duration-150 ${
         active
           ? "bg-brand-600 text-white shadow-sm"
           : "border border-border bg-card text-muted-foreground hover:bg-muted"
@@ -376,7 +376,7 @@ function SectionHeading({
       <span className="text-lg" aria-hidden>
         {emoji}
       </span>
-      <h2 className="text-lg font-bold text-foreground">{title}</h2>
+      <h2 className="text-base font-semibold text-foreground">{title}</h2>
       <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground tabular-nums">
         {count}
       </span>
@@ -428,7 +428,7 @@ function UpcomingRow({ c, deptName, t }: { c: Celebration; deptName: string; t: 
 
   return (
     <div
-      className={`group relative flex items-center gap-3 overflow-hidden rounded-xl border bg-card p-3.5 pl-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${
+      className={`group relative flex items-center gap-3 overflow-hidden rounded-lg border bg-card p-3.5 pl-4 hover:border-brand-400 transition-colors duration-150 ${
         soon ? "border-border" : "border-border"
       }`}
     >
@@ -461,7 +461,7 @@ function UpcomingRow({ c, deptName, t }: { c: Celebration; deptName: string; t: 
 
       {/* Date badge — soft pill so the "when" reads clearly */}
       <div
-        className={`shrink-0 rounded-lg px-2.5 py-1.5 text-center ${
+        className={`shrink-0 rounded-md px-2.5 py-1.5 text-center ${
           soon ? s.chip : "bg-muted text-muted-foreground"
         }`}
       >
@@ -469,7 +469,7 @@ function UpcomingRow({ c, deptName, t }: { c: Celebration; deptName: string; t: 
           <CalendarDays className="h-3.5 w-3.5 opacity-70" />
           {fmtMonthDay(c.nextDate)}
         </p>
-        <p className="mt-1 text-[11px] font-medium leading-none opacity-80">
+        <p className="mt-1 text-[11px] font-medium tabular-nums leading-none opacity-80">
           {c.daysUntil === 1
             ? t("celebrations.tomorrow")
             : t("celebrations.inDays", { count: c.daysUntil })}
@@ -483,7 +483,7 @@ function LoadingState() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {[1, 2, 3, 4, 5, 6].map((i) => (
-        <div key={i} className="animate-pulse rounded-2xl border border-border bg-card p-5">
+        <div key={i} className="animate-pulse rounded-lg border border-border bg-card p-5">
           <div className="mx-auto h-16 w-16 rounded-full bg-muted" />
           <div className="mx-auto mt-3 h-4 w-28 rounded bg-muted" />
           <div className="mx-auto mt-2 h-3 w-20 rounded bg-muted" />
@@ -504,7 +504,7 @@ function EmptyState({
 }) {
   return (
     <div
-      className={`flex flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-card text-center ${
+      className={`flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card text-center ${
         compact ? "py-10" : "py-16"
       }`}
     >

--- a/packages/client/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/client/src/pages/dashboard/DashboardPage.tsx
@@ -27,9 +27,9 @@ interface Module {
 
 function StatCardSkeleton() {
   return (
-    <div className="bg-card rounded-xl border border-border p-6 animate-pulse">
+    <div className="bg-card rounded-lg border border-border p-4 animate-pulse">
       <div className="flex items-center gap-4">
-        <div className="h-12 w-12 rounded-lg bg-muted" />
+        <div className="h-10 w-10 rounded-md bg-muted" />
         <div>
           <div className="h-6 w-12 rounded bg-muted mb-2" />
           <div className="h-4 w-20 rounded bg-muted" />
@@ -123,15 +123,15 @@ export default function DashboardPage() {
 
   return (
     <div>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">
           {t('common.welcome')}, {user?.first_name}
         </h1>
-        <p className="text-muted-foreground mt-1">{t('dashboard.subtitle')}</p>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{t('dashboard.subtitle')}</p>
       </div>
 
       {/* Stats cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6 mb-8">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2.5 mb-6">
         {statsLoading ? (
           <>
             <StatCardSkeleton />
@@ -141,7 +141,7 @@ export default function DashboardPage() {
             <StatCardSkeleton />
           </>
         ) : statsError ? (
-          <div className="sm:col-span-2 lg:col-span-5 bg-card rounded-xl border border-red-200 p-6 text-center">
+          <div className="sm:col-span-2 lg:col-span-5 bg-card rounded-lg border border-red-200 dark:border-red-900/40 p-6 text-center">
             <AlertCircle className="h-8 w-8 text-red-400 mx-auto mb-2" />
             <p className="text-sm text-red-600 dark:text-red-400">Failed to load organization stats. Please try refreshing the page.</p>
           </div>
@@ -149,67 +149,67 @@ export default function DashboardPage() {
           <>
             <Link
               to="/users"
-              className="bg-card rounded-xl border border-border p-6 hover:border-brand-300 transition-colors"
+              className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
             >
               <div className="flex items-center gap-4">
-                <div className="h-12 w-12 rounded-lg bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
-                  <Users className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+                <div className="h-10 w-10 rounded-md bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
+                  <Users className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-foreground">{stats?.total_users ?? 0}</p>
-                  <p className="text-sm text-muted-foreground">{t('dashboard.totalUsers')}</p>
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{stats?.total_users ?? 0}</p>
+                  <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('dashboard.totalUsers')}</p>
                 </div>
               </div>
             </Link>
             <Link
               to="/modules"
-              className="bg-card rounded-xl border border-border p-6 hover:border-brand-300 transition-colors"
+              className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
             >
               <div className="flex items-center gap-4">
-                <div className="h-12 w-12 rounded-lg bg-green-50 dark:bg-green-950/40 flex items-center justify-center">
-                  <Package className="h-6 w-6 text-green-600 dark:text-green-400" />
+                <div className="h-10 w-10 rounded-md bg-green-50 dark:bg-green-950/40 flex items-center justify-center">
+                  <Package className="h-5 w-5 text-green-600 dark:text-green-400" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-foreground">{stats?.active_subscriptions ?? 0}</p>
-                  <p className="text-sm text-muted-foreground">{t('dashboard.activeModules')}</p>
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{stats?.active_subscriptions ?? 0}</p>
+                  <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('dashboard.activeModules')}</p>
                 </div>
               </div>
             </Link>
             <Link
               to="/settings"
-              className="bg-card rounded-xl border border-border p-6 hover:border-brand-300 transition-colors"
+              className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
             >
               <div className="flex items-center gap-4">
-                <div className="h-12 w-12 rounded-lg bg-purple-50 dark:bg-purple-950/40 flex items-center justify-center">
-                  <Building2 className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+                <div className="h-10 w-10 rounded-md bg-purple-50 dark:bg-purple-950/40 flex items-center justify-center">
+                  <Building2 className="h-5 w-5 text-purple-600 dark:text-purple-400" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-foreground">{stats?.total_departments ?? 0}</p>
-                  <p className="text-sm text-muted-foreground">{t('dashboard.departments')}</p>
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{stats?.total_departments ?? 0}</p>
+                  <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('dashboard.departments')}</p>
                 </div>
               </div>
             </Link>
-            <div className="bg-card rounded-xl border border-border p-6">
+            <div className="bg-card rounded-lg border border-border p-4">
               <div className="flex items-center gap-4">
-                <div className="h-12 w-12 rounded-lg bg-amber-50 dark:bg-amber-950/40 flex items-center justify-center">
-                  <Shield className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+                <div className="h-10 w-10 rounded-md bg-amber-50 dark:bg-amber-950/40 flex items-center justify-center">
+                  <Shield className="h-5 w-5 text-amber-600 dark:text-amber-400" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-foreground">SOC 2</p>
-                  <p className="text-sm text-muted-foreground">{t('dashboard.compliant')}</p>
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">SOC 2</p>
+                  <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('dashboard.compliant')}</p>
                 </div>
               </div>
             </div>
             <Link
               to="/billing"
-              className="bg-card rounded-xl border border-border p-6 hover:border-brand-300 transition-colors"
+              className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
             >
               <div className="flex items-center gap-4">
-                <div className="h-12 w-12 rounded-lg bg-emerald-50 dark:bg-emerald-950/40 flex items-center justify-center">
-                  <Receipt className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+                <div className="h-10 w-10 rounded-md bg-emerald-50 dark:bg-emerald-950/40 flex items-center justify-center">
+                  <Receipt className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-foreground">
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">
                     {billingLoading ? (
                       <span className="inline-block h-6 w-20 bg-muted rounded animate-pulse" />
                     ) : billingSummary ? (
@@ -233,8 +233,8 @@ export default function DashboardPage() {
       {/* Core HRMS — Always shown (it IS the platform) */}
       {hrmsModule && (
         <div className="mb-8">
-          <h2 className="text-lg font-semibold text-foreground mb-4">{t('dashboard.coreHRMS')}</h2>
-          <div className="bg-gradient-to-r from-brand-600 to-brand-700 rounded-xl p-8 text-white">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t('dashboard.coreHRMS')}</h2>
+          <div className="bg-gradient-to-r from-brand-600 to-brand-700 rounded-lg p-8 text-white">
             <div className="flex items-start justify-between mb-4">
               <div>
                 <div className="flex items-center gap-2 mb-2">
@@ -275,7 +275,7 @@ export default function DashboardPage() {
       {/* Module Insights — live data from subscribed module APIs */}
       {activeSubscriptions.length > 0 && (
         <div className="mb-8">
-          <h2 className="text-lg font-semibold text-foreground mb-4">{t('dashboard.moduleInsights')}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t('dashboard.moduleInsights')}</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
             {/* Recruit Widget */}
             {subscribedSlugs.has("emp-recruit") && (
@@ -361,7 +361,7 @@ export default function DashboardPage() {
 
       {/* Monitor Admin SSO -- visible only when the user holds every monitor:* permission. */}
       {isMonitorAdmin && moduleBaseUrls.get("emp-monitor") && (
-        <div className="mb-8 bg-gradient-to-r from-slate-900 to-slate-800 rounded-xl p-5 text-white flex items-center justify-between gap-4">
+        <div className="mb-8 bg-gradient-to-r from-slate-900 to-slate-800 rounded-lg p-5 text-white flex items-center justify-between gap-4">
           <div className="flex items-center gap-4">
             <div className="h-12 w-12 rounded-lg bg-white/10 flex items-center justify-center flex-shrink-0">
               <MonitorPlay className="h-6 w-6 text-white" />
@@ -383,9 +383,9 @@ export default function DashboardPage() {
       )}
 
       {/* Subscribed Modules */}
-      <h2 className="text-lg font-semibold text-foreground mb-4">{t('dashboard.yourModules')}</h2>
+      <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t('dashboard.yourModules')}</h2>
       {activeSubscriptions.length === 0 ? (
-        <div className="bg-card rounded-xl border border-border p-12 text-center">
+        <div className="bg-card rounded-lg border border-border p-12 text-center">
           <Package className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
           <p className="text-muted-foreground">{t('dashboard.noModulesYet')}</p>
           <Link to="/modules" className="text-brand-600 dark:text-brand-400 text-sm font-medium hover:text-brand-700 mt-2 inline-block">
@@ -414,7 +414,7 @@ export default function DashboardPage() {
             return (
               <div
                 key={sub.id}
-                className="bg-card rounded-xl border border-border p-6 hover:border-brand-300 transition-colors"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start justify-between mb-3">
                   <div className="flex items-center gap-3">
@@ -432,7 +432,7 @@ export default function DashboardPage() {
                       <p className="text-xs text-muted-foreground">{mod?.slug}</p>
                     </div>
                   </div>
-                  <span className={`text-xs px-2 py-1 rounded-full font-medium ${
+                  <span className={`text-[11px] px-2 py-0.5 rounded-md font-medium ${
                     sub.status === "active"
                       ? "bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300"
                       : "bg-yellow-50 dark:bg-yellow-950/40 text-yellow-700 dark:text-yellow-300"
@@ -459,8 +459,8 @@ export default function DashboardPage() {
                 )}
 
                 <div className="flex items-center justify-between text-sm text-muted-foreground mb-3">
-                  <span>{sub.used_seats}/{sub.total_seats} {t('dashboard.seatsUsed')}</span>
-                  <span className="capitalize text-xs bg-muted px-2 py-0.5 rounded-full">{displayPlan}</span>
+                  <span className="tabular-nums">{sub.used_seats}/{sub.total_seats} {t('dashboard.seatsUsed')}</span>
+                  <span className="capitalize text-[11px] bg-muted px-2 py-0.5 rounded-md">{displayPlan}</span>
                 </div>
 
                 {/* Progress bar */}

--- a/packages/client/src/pages/feed/FeedPage.tsx
+++ b/packages/client/src/pages/feed/FeedPage.tsx
@@ -111,14 +111,14 @@ export default function FeedPage() {
             </button>
             <div className="min-w-0">
               <div className="flex items-center gap-2">
-                <h1 className="text-2xl font-bold text-foreground">{t("feed.page.title")}</h1>
+                <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("feed.page.title")}</h1>
                 {isHR && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-brand-100 dark:bg-brand-950/40 px-2 py-0.5 text-[11px] font-medium text-brand-700 dark:text-brand-300">
                     <Sparkles className="h-3 w-3" /> {t("feed.page.admin")}
                   </span>
                 )}
               </div>
-              <p className="text-muted-foreground mt-1 text-sm">
+              <p className="text-[13px] text-muted-foreground mt-1">
                 {isHR ? t("feed.page.subtitleHr") : t("feed.page.subtitleEmployee")}
               </p>
             </div>
@@ -148,7 +148,7 @@ export default function FeedPage() {
         {/* Main column — reserve 1/3 + gap on the right for the sidebar */}
         <div className={isHR ? "space-y-4 lg:pr-[calc(33.333%+1.5rem)]" : "space-y-4"}>
           {/* Search + filter chips */}
-          <div className="rounded-xl border border-border bg-card p-3 space-y-3">
+          <div className="rounded-lg border border-border bg-card p-3 space-y-3">
             <form
               onSubmit={(e) => { e.preventDefault(); setSearch(searchInput.trim() || undefined); }}
               className="relative"
@@ -266,7 +266,7 @@ export default function FeedPage() {
 
             {/* Top contributors */}
             {stats?.top_contributors && stats.top_contributors.length > 0 && (
-              <div className="rounded-xl border border-border bg-card p-4">
+              <div className="rounded-lg border border-border bg-card p-4">
                 <div className="flex items-center justify-between mb-3">
                   <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
                     <Users className="h-4 w-4 text-brand-600 dark:text-brand-400" />
@@ -295,7 +295,7 @@ export default function FeedPage() {
                           {u.first_name} {u.last_name}
                         </p>
                       </div>
-                      <span className="text-xs font-semibold text-brand-600 dark:text-brand-400">
+                      <span className="text-[11px] tabular-nums font-semibold text-brand-600 dark:text-brand-400">
                         {u.contribution_count}
                       </span>
                     </li>
@@ -306,7 +306,7 @@ export default function FeedPage() {
 
             {/* Trending posts */}
             {stats?.trending_posts && stats.trending_posts.length > 0 && (
-              <div className="rounded-xl border border-border bg-card p-4">
+              <div className="rounded-lg border border-border bg-card p-4">
                 <h3 className="text-sm font-semibold text-foreground flex items-center gap-2 mb-3">
                   <TrendingUp className="h-4 w-4 text-amber-600 dark:text-amber-400" />
                   {t("feed.page.trendingWeek")}
@@ -379,11 +379,11 @@ function StatCard({
   };
   const t = toneClasses[tone];
   return (
-    <div className={`group rounded-xl border border-border bg-card p-3 transition-all hover:shadow-sm hover:-translate-y-0.5 ring-1 ring-transparent ${t.ring}`}>
-      <div className={`h-8 w-8 rounded-lg flex items-center justify-center ${t.bg} ${t.text}`}>
+    <div className={`group rounded-lg border border-border bg-card p-3 transition-colors duration-150 hover:border-brand-400 ${t.ring}`}>
+      <div className={`h-8 w-8 rounded-md flex items-center justify-center ${t.bg} ${t.text}`}>
         {icon}
       </div>
-      <p className="mt-2 text-2xl font-bold text-foreground leading-none">{value}</p>
+      <p className="mt-2 text-2xl font-semibold tabular-nums text-foreground leading-none">{value}</p>
       <p className="mt-1 text-[11px] text-muted-foreground">{label}</p>
     </div>
   );
@@ -393,7 +393,7 @@ function FeedSkeleton() {
   return (
     <div className="space-y-4">
       {[0, 1, 2].map((i) => (
-        <div key={i} className="rounded-xl border border-border bg-card p-5 animate-pulse">
+        <div key={i} className="rounded-lg border border-border bg-card p-5 animate-pulse">
           <div className="flex items-center gap-3">
             <div className="h-10 w-10 rounded-full bg-muted" />
             <div className="space-y-2 flex-1">
@@ -414,7 +414,7 @@ function FeedSkeleton() {
 function EmptyState({ search, filter }: { search?: string; filter: FeedFilter }) {
   const { t } = useTranslation();
   return (
-    <div className="rounded-xl border border-dashed border-border bg-card p-10 text-center">
+    <div className="rounded-lg border border-dashed border-border bg-card p-10 text-center">
       <div className="mx-auto h-12 w-12 rounded-full bg-muted flex items-center justify-center text-muted-foreground mb-3">
         <MessagesSquare className="h-6 w-6" />
       </div>


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) across the 4 high-visibility **home surfaces** — one PR.

**Pages:** Dashboard (landing), Feed, Announcements, Celebrations.

- **Dashboard** — compact header; KPI stat cards (`rounded-md` icon chips, `text-2xl font-semibold tabular-nums` numbers, uppercase micro-labels); panel/section headings; `rounded-lg` module + banner cards; `rounded-md` status pills; `tabular-nums` on seats/counts. Brand + Monitor gradient banners kept (radius softened to `rounded-lg`).
- **Feed** — header + sidebar KPI tiles + panels → `rounded-lg`/`rounded-md`, `tabular-nums` on stats. The **top gradient hero keeps `rounded-2xl` by design**.
- **Announcements** — header, form card + controls, announcement cards, priority status pills and pagination → `rounded-md`; added missing `dark:border` siblings to the urgent/high/normal priority tints + a couple of action buttons for dark-mode parity.
- **Celebrations** — header, filter tabs, section headings, upcoming rows, loader/empty states → `rounded-md`/`rounded-lg` with `tabular-nums`. The **festive TodayCard (confetti + gradient) intentionally keeps `rounded-2xl`** and its decorative colors.

No dark-mode contrast bugs found in these 4 (all colored tints already pair a dark text); the only dark gaps were a few missing `dark:border-*` siblings on Announcements, now added.

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.