### PR TITLE
ui: enterprise-density uplift for Documents + Assets (8 pages)

### DIFF
--- a/packages/client/src/pages/assets/AssetCategoriesPage.tsx
+++ b/packages/client/src/pages/assets/AssetCategoriesPage.tsx
@@ -99,12 +99,12 @@ export default function AssetCategoriesPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("assetCategories.header.title")}</h1>
-          <p className="text-sm text-muted-foreground mt-1">{t("assetCategories.header.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("assetCategories.header.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("assetCategories.header.subtitle")}</p>
         </div>
         <button
           onClick={() => { resetForm(); setShowForm(true); }}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors text-sm font-medium"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 transition-colors text-[13px] font-medium"
         >
           <Plus className="h-4 w-4" />
           {t("assetCategories.actions.addCategory")}
@@ -121,21 +121,21 @@ export default function AssetCategoriesPage() {
           <p className="text-muted-foreground">{t("assetCategories.list.empty")}</p>
         </div>
       ) : (
-        <div className="bg-card rounded-xl border border-border overflow-hidden">
+        <div className="bg-card rounded-lg border border-border overflow-hidden">
           <table className="w-full text-sm">
             <thead>
-              <tr className="bg-muted border-b border-border">
-                <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assetCategories.table.name")}</th>
-                <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assetCategories.table.description")}</th>
-                <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t("assetCategories.table.actions")}</th>
+              <tr className="bg-muted/50 border-b border-border">
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetCategories.table.name")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetCategories.table.description")}</th>
+                <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetCategories.table.actions")}</th>
               </tr>
             </thead>
             <tbody>
               {categories.map((cat: any) => (
-                <tr key={cat.id} className="border-b border-border hover:bg-muted">
-                  <td className="px-4 py-3 font-medium text-foreground">{cat.name}</td>
-                  <td className="px-4 py-3 text-muted-foreground">{cat.description || "-"}</td>
-                  <td className="px-4 py-3 text-right">
+                <tr key={cat.id} className="border-b border-border hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-2.5 font-medium text-foreground">{cat.name}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground">{cat.description || "-"}</td>
+                  <td className="px-4 py-2.5 text-right">
                     <div className="flex items-center justify-end gap-2">
                       <button
                         onClick={() => startEdit(cat)}
@@ -166,7 +166,7 @@ export default function AssetCategoriesPage() {
       {/* Create / Edit Modal */}
       {showForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card rounded-xl shadow-xl w-full max-w-md mx-4">
+          <div className="bg-card rounded-lg shadow-xl w-full max-w-md mx-4">
             <div className="flex items-center justify-between px-6 py-4 border-b border-border">
               <h2 className="text-lg font-semibold text-foreground">
                 {editingId ? t("assetCategories.form.editTitle") : t("assetCategories.form.newTitle")}
@@ -177,37 +177,37 @@ export default function AssetCategoriesPage() {
             </div>
             <form onSubmit={handleSubmit} className="p-6 space-y-4">
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("assetCategories.form.nameLabel")}</label>
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("assetCategories.form.nameLabel")}</label>
                 <input
                   type="text"
                   required
                   value={formName}
                   onChange={(e) => setFormName(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   placeholder={t("assetCategories.form.namePlaceholder")}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("assetCategories.form.descriptionLabel")}</label>
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("assetCategories.form.descriptionLabel")}</label>
                 <textarea
                   value={formDescription}
                   onChange={(e) => setFormDescription(e.target.value)}
                   rows={3}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div className="flex justify-end gap-3 pt-2">
                 <button
                   type="button"
                   onClick={resetForm}
-                  className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
+                  className="px-4 py-2 text-[13px] text-muted-foreground border border-border rounded-md hover:bg-muted/50 transition-colors"
                 >
                   {t("assetCategories.form.cancel")}
                 </button>
                 <button
                   type="submit"
                   disabled={createCategory.isPending || updateCategory.isPending}
-                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50"
+                  className="inline-flex items-center gap-2 px-4 py-2 text-[13px] font-medium text-white bg-brand-600 rounded-md hover:bg-brand-700 disabled:opacity-50"
                 >
                   <Check className="h-4 w-4" />
                   {editingId ? t("assetCategories.form.update") : t("assetCategories.form.create")}
@@ -225,7 +225,7 @@ export default function AssetCategoriesPage() {
           onClick={() => !deleteCategory.isPending && setDeleteTarget(null)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -242,16 +242,16 @@ export default function AssetCategoriesPage() {
               </div>
             </div>
             {deleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-[13px] text-red-700 dark:text-red-300">
                 {deleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleteCategory.isPending}
-                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
+                className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
               >
                 {t("assetCategories.delete.cancel")}
               </button>
@@ -259,7 +259,7 @@ export default function AssetCategoriesPage() {
                 type="button"
                 onClick={() => deleteCategory.mutate(deleteTarget.id)}
                 disabled={deleteCategory.isPending}
-                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {deleteCategory.isPending ? (
                   <>

--- a/packages/client/src/pages/assets/AssetDashboardPage.tsx
+++ b/packages/client/src/pages/assets/AssetDashboardPage.tsx
@@ -82,12 +82,12 @@ export default function AssetDashboardPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("assetDashboard.title")}</h1>
-          <p className="text-sm text-muted-foreground mt-1">{t("assetDashboard.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("assetDashboard.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("assetDashboard.subtitle")}</p>
         </div>
         <Link
           to="/assets"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors text-sm font-medium"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 transition-colors text-[13px] font-medium"
         >
           {t("assetDashboard.viewAllAssets")}
           <ArrowRight className="h-4 w-4" />
@@ -102,15 +102,15 @@ export default function AssetDashboardPage() {
             <Link
               key={card.label}
               to={card.to}
-              className="block text-left w-full bg-card rounded-xl border border-border p-4 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <div className="flex items-center gap-3">
-                <div className={`p-2 rounded-lg ${card.color}`}>
+                <div className={`p-2 rounded-md ${card.color}`}>
                   <Icon className="h-5 w-5" />
                 </div>
                 <div>
-                  <p className="text-2xl font-bold text-foreground">{card.value}</p>
-                  <p className="text-xs text-muted-foreground">{card.label}</p>
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{card.value}</p>
+                  <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{card.label}</p>
                 </div>
               </div>
             </Link>
@@ -124,7 +124,7 @@ export default function AssetDashboardPage() {
           status was added. Linking to the unfiltered list lets the admin
           inspect the offending rows directly. */}
       {unaccounted > 0 && (
-        <div className="rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/40 px-4 py-2 text-sm text-amber-800 dark:text-amber-200 flex items-center justify-between">
+        <div className="rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-950/40 px-4 py-2 text-[13px] tabular-nums text-amber-800 dark:text-amber-200 flex items-center justify-between">
           <span>
             {t("assetDashboard.unaccounted", { count: unaccounted })}
           </span>
@@ -134,7 +134,7 @@ export default function AssetDashboardPage() {
 
       {/* Expiring Warranties Alert */}
       {stats.expiring_warranties && stats.expiring_warranties.length > 0 && (
-        <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900/50 rounded-xl p-4">
+        <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900/50 rounded-lg p-4">
           <div className="flex items-center gap-2 mb-3">
             <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
             <h2 className="text-sm font-semibold text-amber-800 dark:text-amber-200">
@@ -143,7 +143,7 @@ export default function AssetDashboardPage() {
           </div>
           <div className="space-y-2">
             {stats.expiring_warranties.slice(0, 5).map((asset: any) => (
-              <div key={asset.id} className="flex items-center justify-between text-sm">
+              <div key={asset.id} className="flex items-center justify-between text-[13px]">
                 <div>
                   <Link
                     to={`/assets/${asset.id}`}
@@ -166,10 +166,10 @@ export default function AssetDashboardPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Category Breakdown */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-2 mb-4">
             <BarChart3 className="h-5 w-5 text-muted-foreground" />
-            <h2 className="text-lg font-semibold text-foreground">{t("assetDashboard.byCategory")}</h2>
+            <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetDashboard.byCategory")}</h2>
           </div>
           {stats.category_breakdown && stats.category_breakdown.length > 0 ? (
             <div className="space-y-3">
@@ -179,7 +179,7 @@ export default function AssetDashboardPage() {
                   <div key={cat.category}>
                     <div className="flex items-center justify-between text-sm mb-1">
                       <span className="text-muted-foreground">{cat.category}</span>
-                      <span className="text-muted-foreground">{cat.count} ({pct}%)</span>
+                      <span className="tabular-nums text-muted-foreground">{cat.count} ({pct}%)</span>
                     </div>
                     <div className="w-full bg-muted rounded-full h-2">
                       <div
@@ -197,10 +197,10 @@ export default function AssetDashboardPage() {
         </div>
 
         {/* Top Assignees */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-2 mb-4">
             <UserCheck className="h-5 w-5 text-muted-foreground" />
-            <h2 className="text-lg font-semibold text-foreground">{t("assetDashboard.topAssignees")}</h2>
+            <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetDashboard.topAssignees")}</h2>
           </div>
           {stats.top_assignees && stats.top_assignees.length > 0 ? (
             <div className="space-y-3">
@@ -208,7 +208,7 @@ export default function AssetDashboardPage() {
                 <Link
                   key={assignee.user_id}
                   to={`/assets?assigned_to=${assignee.user_id}`}
-                  className="flex items-center justify-between rounded-lg p-2 -m-2 transition-all hover:bg-muted focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="flex items-center justify-between rounded-md p-2 -m-2 transition-colors hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <div className="flex items-center gap-3">
                     <div className="h-8 w-8 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center text-xs font-semibold text-brand-700 dark:text-brand-300">
@@ -227,10 +227,10 @@ export default function AssetDashboardPage() {
       </div>
 
       {/* Recent Activity */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         <div className="flex items-center gap-2 mb-4">
           <Clock className="h-5 w-5 text-muted-foreground" />
-          <h2 className="text-lg font-semibold text-foreground">{t("assetDashboard.recentActivity")}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetDashboard.recentActivity")}</h2>
         </div>
         {stats.recent_activity && stats.recent_activity.length > 0 ? (
           <div className="space-y-3">

--- a/packages/client/src/pages/assets/AssetDetailPage.tsx
+++ b/packages/client/src/pages/assets/AssetDetailPage.tsx
@@ -300,16 +300,16 @@ export default function AssetDetailPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-4">
-        <Link to={isHR ? "/assets" : "/assets/my"} className="p-2 rounded-lg hover:bg-muted transition-colors">
+        <Link to={isHR ? "/assets" : "/assets/my"} className="p-2 rounded-md hover:bg-muted transition-colors">
           <ArrowLeft className="h-5 w-5 text-muted-foreground" />
         </Link>
         <div className="flex-1">
           <div className="flex items-center gap-3">
-            <h1 className="text-2xl font-bold text-foreground">{asset.asset_tag}</h1>
-            <span className={`inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${STATUS_COLORS[asset.status] || "bg-muted"}`}>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">{asset.asset_tag}</h1>
+            <span className={`inline-flex px-2.5 py-0.5 rounded-md text-[11px] font-medium capitalize ${STATUS_COLORS[asset.status] || "bg-muted"}`}>
               {t(`assetDetail.status.${asset.status}`, { defaultValue: asset.status.replace(/_/g, " ") })}
             </span>
-            <span className={`inline-flex px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${CONDITION_COLORS[asset.condition_status] || "bg-muted"}`}>
+            <span className={`inline-flex px-2.5 py-0.5 rounded-md text-[11px] font-medium capitalize ${CONDITION_COLORS[asset.condition_status] || "bg-muted"}`}>
               {t(`assetDetail.condition.${asset.condition_status}`, { defaultValue: asset.condition_status })}
             </span>
           </div>
@@ -409,18 +409,18 @@ export default function AssetDetailPage() {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Asset Details */}
         <div className="lg:col-span-2 space-y-6">
-          <div className="bg-card rounded-xl border border-border p-6">
-            <h2 className="text-lg font-semibold text-foreground mb-4">{t("assetDetail.info.heading")}</h2>
+          <div className="bg-card rounded-lg border border-border p-4">
+            <h2 className="text-base font-semibold text-foreground mb-4">{t("assetDetail.info.heading")}</h2>
             <div className="grid grid-cols-2 gap-y-4 gap-x-8">
               <div>
-                <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.assetTag")}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.assetTag")}</p>
                 <div className="flex items-center gap-2">
                   <Hash className="h-4 w-4 text-muted-foreground" />
                   <p className="text-sm font-medium text-foreground">{asset.asset_tag}</p>
                 </div>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.category")}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.category")}</p>
                 <div className="flex items-center gap-2">
                   <Package className="h-4 w-4 text-muted-foreground" />
                   <p className="text-sm text-foreground">{asset.category_name || t("assetDetail.info.uncategorized")}</p>
@@ -428,25 +428,25 @@ export default function AssetDetailPage() {
               </div>
               {asset.serial_number && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.serialNumber")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.serialNumber")}</p>
                   <p className="text-sm text-foreground">{asset.serial_number}</p>
                 </div>
               )}
               {asset.brand && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.brand")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.brand")}</p>
                   <p className="text-sm text-foreground">{asset.brand}</p>
                 </div>
               )}
               {asset.model && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.model")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.model")}</p>
                   <p className="text-sm text-foreground">{asset.model}</p>
                 </div>
               )}
               {asset.location_name && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.location")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.location")}</p>
                   <div className="flex items-center gap-2">
                     <MapPin className="h-4 w-4 text-muted-foreground" />
                     <p className="text-sm text-foreground">{asset.location_name}</p>
@@ -455,7 +455,7 @@ export default function AssetDetailPage() {
               )}
               {asset.purchase_date && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.purchaseDate")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.purchaseDate")}</p>
                   <div className="flex items-center gap-2">
                     <Calendar className="h-4 w-4 text-muted-foreground" />
                     <p className="text-sm text-foreground">{new Date(asset.purchase_date).toLocaleDateString()}</p>
@@ -464,7 +464,7 @@ export default function AssetDetailPage() {
               )}
               {asset.purchase_cost != null && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.purchaseCost")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.purchaseCost")}</p>
                   <p className="text-sm text-foreground">
                     {new Intl.NumberFormat("en-IN", { style: "currency", currency: "INR" }).format(
                       Number(asset.purchase_cost) / 100,
@@ -474,7 +474,7 @@ export default function AssetDetailPage() {
               )}
               {asset.warranty_expiry && (
                 <div>
-                  <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.warrantyExpiry")}</p>
+                  <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.warrantyExpiry")}</p>
                   <div className="flex items-center gap-2">
                     <Shield className={`h-4 w-4 ${warrantyExpired ? "text-red-500" : "text-green-500"}`} />
                     <p className={`text-sm ${warrantyExpired ? "text-red-600 dark:text-red-400 font-medium" : "text-foreground"}`}>
@@ -487,13 +487,13 @@ export default function AssetDetailPage() {
             </div>
             {asset.description && (
               <div className="mt-4 pt-4 border-t border-border">
-                <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.description")}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.description")}</p>
                 <p className="text-sm text-muted-foreground">{asset.description}</p>
               </div>
             )}
             {asset.notes && (
               <div className="mt-4 pt-4 border-t border-border">
-                <p className="text-xs text-muted-foreground mb-1">{t("assetDetail.info.notes")}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">{t("assetDetail.info.notes")}</p>
                 <p className="text-sm text-muted-foreground">{asset.notes}</p>
               </div>
             )}
@@ -501,22 +501,22 @@ export default function AssetDetailPage() {
 
           {/* Assignment Info */}
           {asset.status === "assigned" && (
-            <div className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-900 rounded-xl p-6">
-              <h2 className="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-3">{t("assetDetail.assignment.heading")}</h2>
+            <div className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-900 rounded-lg p-4">
+              <h2 className="text-base font-semibold text-blue-900 dark:text-blue-100 mb-3">{t("assetDetail.assignment.heading")}</h2>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <p className="text-xs text-blue-600 dark:text-blue-400 mb-1">{t("assetDetail.assignment.assignedTo")}</p>
+                  <p className="text-[11px] text-blue-600 dark:text-blue-400 mb-1">{t("assetDetail.assignment.assignedTo")}</p>
                   <p className="text-sm font-medium text-blue-900 dark:text-blue-100">{asset.assigned_to_name}</p>
                 </div>
                 {asset.assigned_at && (
                   <div>
-                    <p className="text-xs text-blue-600 dark:text-blue-400 mb-1">{t("assetDetail.assignment.assignedAt")}</p>
+                    <p className="text-[11px] text-blue-600 dark:text-blue-400 mb-1">{t("assetDetail.assignment.assignedAt")}</p>
                     <p className="text-sm text-blue-900 dark:text-blue-100">{new Date(asset.assigned_at).toLocaleString()}</p>
                   </div>
                 )}
                 {asset.assigned_by_name && (
                   <div>
-                    <p className="text-xs text-blue-600 dark:text-blue-400 mb-1">{t("assetDetail.assignment.assignedBy")}</p>
+                    <p className="text-[11px] text-blue-600 dark:text-blue-400 mb-1">{t("assetDetail.assignment.assignedBy")}</p>
                     <p className="text-sm text-blue-900 dark:text-blue-100">{asset.assigned_by_name}</p>
                   </div>
                 )}
@@ -526,10 +526,10 @@ export default function AssetDetailPage() {
         </div>
 
         {/* History Timeline */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-2 mb-4">
             <Clock className="h-5 w-5 text-muted-foreground" />
-            <h2 className="text-lg font-semibold text-foreground">{t("assetDetail.history.heading")}</h2>
+            <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assetDetail.history.heading")}</h2>
           </div>
           {asset.history && asset.history.length > 0 ? (
             <div className="relative">
@@ -550,7 +550,7 @@ export default function AssetDetailPage() {
                         {entry.notes && (
                           <p className="text-xs text-muted-foreground mt-0.5">{entry.notes}</p>
                         )}
-                        <p className="text-xs text-muted-foreground mt-1">
+                        <p className="text-[11px] tabular-nums text-muted-foreground mt-1">
                           {entry.performed_by_name} &middot; {new Date(entry.created_at).toLocaleString()}
                         </p>
                       </div>
@@ -586,7 +586,7 @@ export default function AssetDetailPage() {
       {/* Assign Modal */}
       {showAssignModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card rounded-xl shadow-xl w-full max-w-md mx-4">
+          <div className="bg-card rounded-lg shadow-xl w-full max-w-md mx-4">
             <div className="flex items-center justify-between px-6 py-4 border-b border-border">
               <h2 className="text-lg font-semibold text-foreground">{t("assetDetail.assignModal.title")}</h2>
               <button onClick={() => setShowAssignModal(false)} className="p-1 rounded hover:bg-muted">
@@ -609,7 +609,7 @@ export default function AssetDetailPage() {
                   required
                   value={assignUserId}
                   onChange={(e) => setAssignUserId(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option value="">{t("assetDetail.assignModal.selectEmployee")}</option>
                   {(users || []).map((u: any) => (
@@ -625,7 +625,7 @@ export default function AssetDetailPage() {
                   value={assignNotes}
                   onChange={(e) => setAssignNotes(e.target.value)}
                   rows={2}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div className="flex justify-end gap-3">
@@ -652,7 +652,7 @@ export default function AssetDetailPage() {
       {/* Return Modal */}
       {showReturnModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card rounded-xl shadow-xl w-full max-w-md mx-4">
+          <div className="bg-card rounded-lg shadow-xl w-full max-w-md mx-4">
             <div className="flex items-center justify-between px-6 py-4 border-b border-border">
               <h2 className="text-lg font-semibold text-foreground">{t("assetDetail.returnModal.title")}</h2>
               <button onClick={() => setShowReturnModal(false)} className="p-1 rounded hover:bg-muted">
@@ -674,7 +674,7 @@ export default function AssetDetailPage() {
                 <select
                   value={returnCondition}
                   onChange={(e) => setReturnCondition(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 >
                   <option value="new">{t("assetDetail.conditionOptions.new")}</option>
                   <option value="good">{t("assetDetail.conditionOptions.good")}</option>
@@ -688,7 +688,7 @@ export default function AssetDetailPage() {
                   value={returnNotes}
                   onChange={(e) => setReturnNotes(e.target.value)}
                   rows={2}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div className="flex justify-end gap-3">
@@ -776,7 +776,7 @@ export default function AssetDetailPage() {
             onClick={() => !pending && setConfirmAction(null)}
           >
             <div
-              className="w-full max-w-md rounded-xl bg-card shadow-xl"
+              className="w-full max-w-md rounded-lg bg-card shadow-xl"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="px-6 py-5">
@@ -798,11 +798,11 @@ export default function AssetDetailPage() {
                 </div>
               </div>
               {confirmError && (
-                <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+                <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-[13px] text-red-700 dark:text-red-300">
                   {confirmError}
                 </div>
               )}
-              <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+              <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
                 <button
                   type="button"
                   onClick={() => setConfirmAction(null)}
@@ -838,7 +838,7 @@ export default function AssetDetailPage() {
           onClick={() => !updateMutation.isPending && setShowEditModal(false)}
         >
           <div
-            className="bg-card rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto"
+            className="bg-card rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between px-6 py-4 border-b border-border">
@@ -859,7 +859,7 @@ export default function AssetDetailPage() {
                     required
                     value={editForm.name}
                     onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -867,7 +867,7 @@ export default function AssetDetailPage() {
                   <select
                     value={editForm.category_id}
                     onChange={(e) => setEditForm({ ...editForm, category_id: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   >
                     <option value="">{t("assetDetail.editModal.uncategorized")}</option>
                     {(categories || []).map((c: any) => (
@@ -883,7 +883,7 @@ export default function AssetDetailPage() {
                     type="text"
                     value={editForm.serial_number}
                     onChange={(e) => setEditForm({ ...editForm, serial_number: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -892,7 +892,7 @@ export default function AssetDetailPage() {
                     type="text"
                     value={editForm.brand}
                     onChange={(e) => setEditForm({ ...editForm, brand: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -901,7 +901,7 @@ export default function AssetDetailPage() {
                     type="text"
                     value={editForm.model}
                     onChange={(e) => setEditForm({ ...editForm, model: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -911,7 +911,7 @@ export default function AssetDetailPage() {
                     onChange={(e) =>
                       setEditForm({ ...editForm, condition_status: e.target.value })
                     }
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   >
                     <option value="new">{t("assetDetail.conditionOptions.new")}</option>
                     <option value="good">{t("assetDetail.conditionOptions.good")}</option>
@@ -925,13 +925,13 @@ export default function AssetDetailPage() {
                     type="date"
                     value={editForm.purchase_date}
                     onChange={(e) => setEditForm({ ...editForm, purchase_date: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-muted-foreground mb-1">{t("assetDetail.editModal.purchaseCostLabel")}</label>
                   <div className="flex items-stretch">
-                    <span className="inline-flex items-center px-3 py-2 rounded-l-lg border border-r-0 border-border bg-muted text-sm text-muted-foreground">
+                    <span className="inline-flex items-center px-3 py-2 rounded-l-md border border-r-0 border-border bg-muted text-sm text-muted-foreground">
                       ₹ INR
                     </span>
                     <input
@@ -940,10 +940,10 @@ export default function AssetDetailPage() {
                       onChange={(e) =>
                         setEditForm({ ...editForm, purchase_cost: e.target.value })
                       }
-                      className="bg-card text-foreground flex-1 min-w-0 px-3 py-2 border border-border rounded-r-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      className="bg-card text-foreground flex-1 min-w-0 px-3 py-2 border border-border rounded-r-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                     />
                   </div>
-                  <p className="text-xs text-muted-foreground mt-1">{t("assetDetail.editModal.purchaseCostHint")}</p>
+                  <p className="text-[11px] tabular-nums text-muted-foreground mt-1">{t("assetDetail.editModal.purchaseCostHint")}</p>
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-muted-foreground mb-1">{t("assetDetail.editModal.warrantyExpiryLabel")}</label>
@@ -952,7 +952,7 @@ export default function AssetDetailPage() {
                     value={editForm.warranty_expiry}
                     onChange={(e) => setEditForm({ ...editForm, warranty_expiry: e.target.value })}
                     min={editForm.purchase_date || undefined}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -961,7 +961,7 @@ export default function AssetDetailPage() {
                     type="text"
                     value={editForm.location_name}
                     onChange={(e) => setEditForm({ ...editForm, location_name: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
               </div>
@@ -971,7 +971,7 @@ export default function AssetDetailPage() {
                   value={editForm.description}
                   onChange={(e) => setEditForm({ ...editForm, description: e.target.value })}
                   rows={2}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
@@ -980,11 +980,11 @@ export default function AssetDetailPage() {
                   value={editForm.notes}
                   onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
                   rows={2}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               {editError && (
-                <div className="rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">{editError}</div>
+                <div className="rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-[13px] text-red-700 dark:text-red-300">{editError}</div>
               )}
               <div className="flex justify-end gap-3 pt-2 border-t border-border">
                 <button
@@ -1021,7 +1021,7 @@ export default function AssetDetailPage() {
           onClick={() => !deleteHistoryMutation.isPending && setHistoryDeleteId(null)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -1038,11 +1038,11 @@ export default function AssetDetailPage() {
               </div>
             </div>
             {historyDeleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-[13px] text-red-700 dark:text-red-300">
                 {historyDeleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setHistoryDeleteId(null)}

--- a/packages/client/src/pages/assets/AssetListPage.tsx
+++ b/packages/client/src/pages/assets/AssetListPage.tsx
@@ -251,8 +251,8 @@ export default function AssetListPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("assets.list.title")}</h1>
-          <p className="text-sm text-muted-foreground mt-1">{t("assets.list.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("assets.list.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("assets.list.subtitle")}</p>
         </div>
         {isHR && (
           <div className="flex items-center gap-2 flex-wrap">
@@ -261,23 +261,23 @@ export default function AssetListPage() {
             <div className="relative" ref={exportMenuRef}>
               <button
                 onClick={() => setShowExportMenu((v) => !v)}
-                className="inline-flex items-center gap-2 px-3 py-2 border border-border text-muted-foreground rounded-lg hover:bg-muted text-sm font-medium"
+                className="inline-flex items-center gap-2 px-3 py-2 border border-border text-muted-foreground rounded-md hover:bg-muted text-[13px] font-medium"
               >
                 <Download className="h-4 w-4" />
                 {t("assets.list.export")}
                 <ChevronDown className="h-3.5 w-3.5" />
               </button>
               {showExportMenu && (
-                <div className="absolute right-0 mt-1 w-48 bg-card rounded-lg shadow-lg border border-border z-40">
+                <div className="absolute right-0 mt-1 w-48 bg-card rounded-md shadow-lg border border-border z-40">
                   <button
                     onClick={exportCsv}
-                    className="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted rounded-t-lg"
+                    className="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted rounded-t-md"
                   >
                     {t("assets.list.exportCsv")}
                   </button>
                   <button
                     onClick={exportPdf}
-                    className="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted rounded-b-lg border-t border-border"
+                    className="w-full text-left px-4 py-2 text-sm text-muted-foreground hover:bg-muted rounded-b-md border-t border-border"
                   >
                     {t("assets.list.exportPdf")}
                   </button>
@@ -286,14 +286,14 @@ export default function AssetListPage() {
             </div>
             <button
               onClick={() => setShowBulkUpload(true)}
-              className="inline-flex items-center gap-2 px-3 py-2 border border-border text-muted-foreground rounded-lg hover:bg-muted text-sm font-medium"
+              className="inline-flex items-center gap-2 px-3 py-2 border border-border text-muted-foreground rounded-md hover:bg-muted text-[13px] font-medium"
             >
               <Upload className="h-4 w-4" />
               {t("assets.list.bulkUpload")}
             </button>
             <button
               onClick={() => setShowForm(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition-colors text-sm font-medium"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 transition-colors text-sm font-medium"
             >
               <Plus className="h-4 w-4" />
               {t("assets.list.addAsset")}
@@ -311,13 +311,13 @@ export default function AssetListPage() {
             placeholder={t("assets.list.searchPlaceholder")}
             value={search}
             onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-            className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+            className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent"
           />
         </div>
         <select
           value={statusFilter}
           onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-          className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">{t("assets.list.allStatuses")}</option>
           {STATUSES.map((s) => (
@@ -327,7 +327,7 @@ export default function AssetListPage() {
         <select
           value={categoryFilter}
           onChange={(e) => { setCategoryFilter(e.target.value); setPage(1); }}
-          className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <option value="">{t("assets.list.allCategories")}</option>
           {(categories || []).map((c: any) => (
@@ -347,44 +347,44 @@ export default function AssetListPage() {
           <p className="text-muted-foreground">{t("assets.list.empty")}</p>
         </div>
       ) : (
-        <div className="bg-card rounded-xl border border-border overflow-hidden">
+        <div className="bg-card rounded-lg border border-border overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-muted border-b border-border">
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colTag")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colName")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colCategory")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colStatus")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colAssignedTo")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colCondition")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("assets.list.colWarranty")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colTag")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colName")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colCategory")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colStatus")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colAssignedTo")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colCondition")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("assets.list.colWarranty")}</th>
                 </tr>
               </thead>
               <tbody>
                 {assets.map((asset: any) => {
                   const warrantyExpired = asset.warranty_expiry && new Date(asset.warranty_expiry) < new Date();
                   return (
-                    <tr key={asset.id} className="border-b border-border hover:bg-muted transition-colors">
-                      <td className="px-4 py-3">
+                    <tr key={asset.id} className="border-b border-border hover:bg-muted/50 transition-colors">
+                      <td className="px-4 py-2.5">
                         <Link to={`/assets/${asset.id}`} className="font-medium text-brand-600 dark:text-brand-400 hover:underline">
                           {asset.asset_tag}
                         </Link>
                       </td>
-                      <td className="px-4 py-3 text-foreground">{asset.name}</td>
-                      <td className="px-4 py-3 text-muted-foreground">{asset.category_name || "-"}</td>
-                      <td className="px-4 py-3">
-                        <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[asset.status] || "bg-muted"}`}>
+                      <td className="px-4 py-2.5 text-foreground">{asset.name}</td>
+                      <td className="px-4 py-2.5 text-muted-foreground">{asset.category_name || "-"}</td>
+                      <td className="px-4 py-2.5">
+                        <span className={`inline-flex px-2 py-0.5 rounded-md text-[11px] font-medium ${STATUS_COLORS[asset.status] || "bg-muted"}`}>
                           {t(`assets.list.status.${asset.status}`, { defaultValue: asset.status.replace(/_/g, " ") })}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">{asset.assigned_to_name || "-"}</td>
-                      <td className="px-4 py-3">
-                        <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${CONDITION_COLORS[asset.condition_status] || "bg-muted"}`}>
+                      <td className="px-4 py-2.5 text-muted-foreground">{asset.assigned_to_name || "-"}</td>
+                      <td className="px-4 py-2.5">
+                        <span className={`inline-flex px-2 py-0.5 rounded-md text-[11px] font-medium ${CONDITION_COLORS[asset.condition_status] || "bg-muted"}`}>
                           {t(`assets.list.condition.${asset.condition_status}`, { defaultValue: asset.condition_status })}
                         </span>
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         {asset.warranty_expiry ? (
                           <span className={`flex items-center gap-1 ${warrantyExpired ? "text-red-600 dark:text-red-400" : "text-muted-foreground"}`}>
                             {warrantyExpired && <AlertTriangle className="h-3 w-3" />}
@@ -407,7 +407,7 @@ export default function AssetListPage() {
               {/* #1534 — Show the per-page count alongside the total. Previously
                   only "Page N of M (T total)" was rendered, so admins couldn't
                   tell how many rows were in view. */}
-              <p className="text-sm text-muted-foreground">
+              <p className="text-[13px] tabular-nums text-muted-foreground">
                 {t("assets.list.showing", { shown: assets.length, total: meta.total, page: meta.page, total_pages: meta.total_pages })}
               </p>
               <div className="flex gap-2">
@@ -434,7 +434,7 @@ export default function AssetListPage() {
       {/* Create Asset Modal */}
       {showForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-card rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto mx-4">
+          <div className="bg-card rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto mx-4">
             <div className="flex items-center justify-between px-6 py-4 border-b border-border">
               <h2 className="text-lg font-semibold text-foreground">{t("assets.list.addModalTitle")}</h2>
               <button onClick={() => setShowForm(false)} className="p-1 rounded hover:bg-muted">
@@ -450,7 +450,7 @@ export default function AssetListPage() {
                     required
                     value={formName}
                     onChange={(e) => setFormName(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                     placeholder={t("assets.list.namePlaceholder")}
                   />
                 </div>
@@ -459,7 +459,7 @@ export default function AssetListPage() {
                   <select
                     value={formCategoryId}
                     onChange={(e) => setFormCategoryId(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   >
                     <option value="">{t("assets.list.selectCategory")}</option>
                     {(categories || []).map((c: any) => (
@@ -473,7 +473,7 @@ export default function AssetListPage() {
                     type="text"
                     value={formSerialNumber}
                     onChange={(e) => setFormSerialNumber(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -482,7 +482,7 @@ export default function AssetListPage() {
                     type="text"
                     value={formBrand}
                     onChange={(e) => setFormBrand(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -491,7 +491,7 @@ export default function AssetListPage() {
                     type="text"
                     value={formModel}
                     onChange={(e) => setFormModel(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -499,7 +499,7 @@ export default function AssetListPage() {
                   <select
                     value={formCondition}
                     onChange={(e) => setFormCondition(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   >
                     {CONDITIONS.map((c) => (
                       <option key={c} value={c}>{t(`assets.list.condition.${c}`)}</option>
@@ -512,20 +512,20 @@ export default function AssetListPage() {
                     type="date"
                     value={formPurchaseDate}
                     onChange={(e) => setFormPurchaseDate(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-muted-foreground mb-1">{t("assets.list.fieldPurchaseCost")}</label>
                   <div className="flex items-stretch">
-                    <span className="inline-flex items-center px-3 py-2 rounded-l-lg border border-r-0 border-border bg-muted text-sm text-muted-foreground">
+                    <span className="inline-flex items-center px-3 py-2 rounded-l-md border border-r-0 border-border bg-muted text-sm text-muted-foreground">
                       ₹ INR
                     </span>
                     <input
                       type="number"
                       value={formPurchaseCost}
                       onChange={(e) => setFormPurchaseCost(e.target.value)}
-                      className="bg-card text-foreground flex-1 min-w-0 px-3 py-2 border border-border rounded-r-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                      className="bg-card text-foreground flex-1 min-w-0 px-3 py-2 border border-border rounded-r-md text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
                       placeholder={t("assets.list.costPlaceholder")}
                     />
                   </div>
@@ -538,7 +538,7 @@ export default function AssetListPage() {
                     value={formWarrantyExpiry}
                     onChange={(e) => setFormWarrantyExpiry(e.target.value)}
                     min={formPurchaseDate || undefined}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                   />
                 </div>
                 <div>
@@ -547,7 +547,7 @@ export default function AssetListPage() {
                     type="text"
                     value={formLocation}
                     onChange={(e) => setFormLocation(e.target.value)}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                     placeholder={t("assets.list.locationPlaceholder")}
                   />
                 </div>
@@ -558,7 +558,7 @@ export default function AssetListPage() {
                   value={formDescription}
                   onChange={(e) => setFormDescription(e.target.value)}
                   rows={2}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div>
@@ -567,14 +567,14 @@ export default function AssetListPage() {
                   value={formNotes}
                   onChange={(e) => setFormNotes(e.target.value)}
                   rows={2}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500"
                 />
               </div>
               <div className="flex justify-end gap-3 pt-2">
                 <button
                   type="button"
                   onClick={() => setShowForm(false)}
-                  className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
+                  className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-md hover:bg-muted"
                 >
                   {t("assets.list.cancel")}
                 </button>

--- a/packages/client/src/pages/assets/MyAssetsPage.tsx
+++ b/packages/client/src/pages/assets/MyAssetsPage.tsx
@@ -28,12 +28,12 @@ export default function MyAssetsPage() {
     return (
       <div className="space-y-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("myAssets.page.title")}</h1>
-          <p className="text-sm text-muted-foreground mt-1">{t("myAssets.page.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myAssets.page.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("myAssets.page.subtitle")}</p>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="bg-card rounded-xl border border-border p-5 animate-pulse">
+            <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
               <div className="flex items-start justify-between mb-3">
                 <div>
                   <div className="h-4 w-32 bg-muted rounded mb-2" />
@@ -55,15 +55,15 @@ export default function MyAssetsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-foreground">{t("myAssets.page.title")}</h1>
-        <p className="text-sm text-muted-foreground mt-1">{t("myAssets.page.subtitle")}</p>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myAssets.page.title")}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{t("myAssets.page.subtitle")}</p>
       </div>
 
       {!assets || assets.length === 0 ? (
-        <div className="bg-card rounded-xl border border-border p-12 text-center">
+        <div className="bg-card rounded-lg border border-border p-12 text-center">
           <Package className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
-          <p className="text-lg font-medium text-muted-foreground mb-1">{t("myAssets.empty.title")}</p>
-          <p className="text-sm text-muted-foreground">{t("myAssets.empty.description")}</p>
+          <p className="text-base font-medium text-muted-foreground mb-1">{t("myAssets.empty.title")}</p>
+          <p className="text-[13px] text-muted-foreground">{t("myAssets.empty.description")}</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -73,22 +73,22 @@ export default function MyAssetsPage() {
               <Link
                 key={asset.id}
                 to={`/assets/${asset.id}`}
-                className="bg-card rounded-xl border border-border p-5 hover:shadow-md transition-shadow"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start justify-between mb-3">
                   <div>
                     <h3 className="text-sm font-semibold text-foreground">{asset.name}</h3>
                     <div className="flex items-center gap-1 mt-1">
                       <Hash className="h-3 w-3 text-muted-foreground" />
-                      <span className="text-xs text-muted-foreground">{asset.asset_tag}</span>
+                      <span className="text-[11px] tabular-nums text-muted-foreground">{asset.asset_tag}</span>
                     </div>
                   </div>
-                  <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium capitalize ${CONDITION_COLORS[asset.condition_status] || "bg-muted"}`}>
+                  <span className={`inline-flex px-2 py-0.5 rounded-md text-[11px] font-medium capitalize ${CONDITION_COLORS[asset.condition_status] || "bg-muted"}`}>
                     {t(`myAssets.condition.${asset.condition_status}`, { defaultValue: asset.condition_status })}
                   </span>
                 </div>
 
-                <div className="space-y-2 text-sm">
+                <div className="space-y-2 text-[13px]">
                   {asset.category_name && (
                     <div className="flex items-center gap-2 text-muted-foreground">
                       <Package className="h-4 w-4 text-muted-foreground" />

--- a/packages/client/src/pages/documents/DocumentCategoriesPage.tsx
+++ b/packages/client/src/pages/documents/DocumentCategoriesPage.tsx
@@ -92,14 +92,14 @@ export default function DocumentCategoriesPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t("documentCategories.page.title")}</h1>
-          <p className="text-gray-500 mt-1">{t("documentCategories.page.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("documentCategories.page.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("documentCategories.page.subtitle")}</p>
         </div>
         <button
           onClick={() => { resetForm(); setShowForm(true); }}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {t("documentCategories.actions.newCategory")}
         </button>
@@ -107,34 +107,34 @@ export default function DocumentCategoriesPage() {
 
       {/* Form */}
       {showForm && (
-        <form onSubmit={handleSubmit} className="bg-white rounded-xl border border-gray-200 p-6 mb-6">
+        <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-sm font-semibold text-gray-900">
+            <h3 className="text-sm font-semibold text-foreground">
               {editingId ? t("documentCategories.form.editTitle") : t("documentCategories.form.createTitle")}
             </h3>
-            <button type="button" onClick={resetForm} className="text-gray-400 hover:text-gray-600">
+            <button type="button" onClick={resetForm} className="text-muted-foreground hover:text-foreground transition-colors">
               <X className="h-4 w-4" />
             </button>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">{t("documentCategories.form.nameLabel")}</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">{t("documentCategories.form.nameLabel")}</label>
               <input
                 type="text"
                 value={formName}
                 onChange={(e) => setFormName(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("documentCategories.form.namePlaceholder")}
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">{t("documentCategories.form.descriptionLabel")}</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">{t("documentCategories.form.descriptionLabel")}</label>
               <input
                 type="text"
                 value={formDesc}
                 onChange={(e) => setFormDesc(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("documentCategories.form.descriptionPlaceholder")}
               />
             </div>
@@ -144,21 +144,21 @@ export default function DocumentCategoriesPage() {
                 id="is_mandatory"
                 checked={formMandatory}
                 onChange={(e) => setFormMandatory(e.target.checked)}
-                className="h-4 w-4 rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                className="h-4 w-4 rounded border-border text-brand-600 focus:ring-brand-500"
               />
-              <label htmlFor="is_mandatory" className="text-sm text-gray-700">
+              <label htmlFor="is_mandatory" className="text-sm text-foreground">
                 {t("documentCategories.form.mandatoryLabel")}
               </label>
             </div>
           </div>
           <div className="mt-4 flex justify-end gap-2">
-            <button type="button" onClick={resetForm} className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50">
+            <button type="button" onClick={resetForm} className="px-4 py-2 text-[13px] text-foreground border border-border rounded-md hover:bg-muted/50 transition-colors">
               {t("documentCategories.actions.cancel")}
             </button>
             <button
               type="submit"
               disabled={createCategory.isPending || updateCategory.isPending}
-              className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {editingId ? t("documentCategories.actions.update") : t("documentCategories.actions.create")}
             </button>
@@ -167,55 +167,55 @@ export default function DocumentCategoriesPage() {
       )}
 
       {/* Table */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
+          <thead className="bg-muted/50 border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("documentCategories.table.categoryHeader")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("documentCategories.table.descriptionHeader")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("documentCategories.table.documentsHeader")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("documentCategories.table.mandatoryHeader")}</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">{t("documentCategories.table.actionsHeader")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documentCategories.table.categoryHeader")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documentCategories.table.descriptionHeader")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documentCategories.table.documentsHeader")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documentCategories.table.mandatoryHeader")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documentCategories.table.actionsHeader")}</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {isLoading ? (
-              <tr><td colSpan={4} className="px-6 py-8 text-center text-gray-400">{t("documentCategories.table.loading")}</td></tr>
+              <tr><td colSpan={4} className="px-4 py-8 text-center text-[13px] text-muted-foreground">{t("documentCategories.table.loading")}</td></tr>
             ) : !categories || categories.length === 0 ? (
-              <tr><td colSpan={5} className="px-6 py-8 text-center text-gray-400">{t("documentCategories.table.empty")}</td></tr>
+              <tr><td colSpan={5} className="px-4 py-8 text-center text-[13px] text-muted-foreground">{t("documentCategories.table.empty")}</td></tr>
             ) : (
               categories.map((cat: any) => (
-                <tr key={cat.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4">
+                <tr key={cat.id} className="hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-2.5">
                     <div className="flex items-center gap-3">
-                      <div className="h-8 w-8 rounded-lg bg-brand-50 flex items-center justify-center">
-                        <FolderOpen className="h-4 w-4 text-brand-600" />
+                      <div className="h-8 w-8 rounded-md bg-brand-50 dark:bg-brand-950/40 flex items-center justify-center">
+                        <FolderOpen className="h-4 w-4 text-brand-600 dark:text-brand-400" />
                       </div>
-                      <span className="text-sm font-medium text-gray-900">{cat.name}</span>
+                      <span className="text-[13px] font-medium text-foreground">{cat.name}</span>
                     </div>
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500">{cat.description || t("documentCategories.table.emptyValue")}</td>
-                  <td className="px-6 py-4">
-                    <span className="text-sm font-medium text-gray-700">{Number(cat.document_count) || 0}</span>
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{cat.description || t("documentCategories.table.emptyValue")}</td>
+                  <td className="px-4 py-2.5">
+                    <span className="text-[13px] tabular-nums font-medium text-foreground">{Number(cat.document_count) || 0}</span>
                   </td>
-                  <td className="px-6 py-4">
+                  <td className="px-4 py-2.5">
                     {cat.is_mandatory ? (
-                      <span className="text-xs bg-red-50 text-red-700 px-2 py-1 rounded-full font-medium">{t("documentCategories.mandatory.required")}</span>
+                      <span className="text-[11px] bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 px-2 py-0.5 rounded-md font-medium">{t("documentCategories.mandatory.required")}</span>
                     ) : (
-                      <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">{t("documentCategories.mandatory.optional")}</span>
+                      <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-md">{t("documentCategories.mandatory.optional")}</span>
                     )}
                   </td>
-                  <td className="px-6 py-4">
+                  <td className="px-4 py-2.5">
                     <div className="flex items-center gap-3">
                       <button
                         onClick={() => startEdit(cat)}
-                        className="flex items-center gap-1 text-xs text-brand-600 hover:text-brand-800 font-medium"
+                        className="flex items-center gap-1 text-[11px] text-brand-600 dark:text-brand-400 hover:text-brand-800 dark:hover:text-brand-300 font-medium"
                       >
                         <Pencil className="h-3 w-3" /> {t("documentCategories.actions.edit")}
                       </button>
                       <button
                         onClick={() => setDeactivateTarget({ id: cat.id, name: cat.name })}
-                        className="flex items-center gap-1 text-xs text-red-600 hover:text-red-800 font-medium"
+                        className="flex items-center gap-1 text-[11px] text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 font-medium"
                       >
                         <Trash2 className="h-3 w-3" /> {t("documentCategories.actions.delete")}
                       </button>

--- a/packages/client/src/pages/documents/DocumentsPage.tsx
+++ b/packages/client/src/pages/documents/DocumentsPage.tsx
@@ -227,20 +227,20 @@ export default function DocumentsPage() {
     const status = doc.verification_status || (doc.is_verified ? "verified" : "pending");
     if (status === "verified" || doc.is_verified) {
       return (
-        <span className="flex items-center gap-1 text-xs text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/40 px-2 py-1 rounded-full w-fit">
+        <span className="flex items-center gap-1 text-xs text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded-md w-fit">
           <CheckCircle className="h-3 w-3" /> {t("documents.page.verified")}
         </span>
       );
     }
     if (status === "rejected") {
       return (
-        <span className="flex items-center gap-1 text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-1 rounded-full w-fit">
+        <span className="flex items-center gap-1 text-xs text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-0.5 rounded-md w-fit">
           <XCircle className="h-3 w-3" /> {t("documents.page.rejected")}
         </span>
       );
     }
     return (
-      <span className="flex items-center gap-1 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 px-2 py-1 rounded-full w-fit">
+      <span className="flex items-center gap-1 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 rounded-md w-fit">
         <Clock className="h-3 w-3" /> {t("documents.page.pending")}
       </span>
     );
@@ -248,9 +248,9 @@ export default function DocumentsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("documents.page.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("documents.page.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("documents.page.subtitle")}</p>
         </div>
         <button
@@ -267,7 +267,7 @@ export default function DocumentsPage() {
               setEmployeeSearch("");
             }
           }}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Upload className="h-4 w-4" /> {t("documents.page.uploadDocument")}
         </button>
@@ -277,10 +277,10 @@ export default function DocumentsPage() {
           Shown only when there are outstanding mandatory-doc requirements and the user is not
           already looking at the mandatory tab (so it acts as a CTA, not a redundant header). */}
       {missingCount > 0 && activeTab !== "mandatory" && (
-        <div className="mb-6 bg-red-50 dark:bg-red-950/40 border border-red-200 rounded-xl p-4 flex items-start gap-3">
+        <div className="mb-6 bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900/50 rounded-lg p-4 flex items-start gap-3">
           <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
           <div className="flex-1">
-            <p className="text-sm font-medium text-red-800">
+            <p className="text-[13px] font-medium text-red-800 dark:text-red-200">
               {t("documents.page.mandatoryOutstanding", { count: missingCount })}
             </p>
             <p className="text-xs text-red-700 dark:text-red-300 mt-0.5">
@@ -298,36 +298,36 @@ export default function DocumentsPage() {
 
       {/* Alert Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-        <button onClick={() => setActiveTab("all")} className={`bg-card rounded-xl border p-5 text-left transition ${activeTab === "all" ? "border-brand-300 ring-1 ring-brand-200" : "border-border"}`}>
+        <button onClick={() => setActiveTab("all")} className={`bg-card rounded-lg border p-4 text-left transition ${activeTab === "all" ? "border-brand-300 ring-1 ring-brand-200" : "border-border"}`}>
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
               <FileText className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">{meta?.total ?? 0}</p>
-              <p className="text-sm text-muted-foreground">{t("documents.page.totalDocuments")}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{meta?.total ?? 0}</p>
+              <p className="text-[13px] text-muted-foreground">{t("documents.page.totalDocuments")}</p>
             </div>
           </div>
         </button>
-        <button onClick={() => setActiveTab("expiring")} className={`bg-card rounded-xl border p-5 text-left transition ${activeTab === "expiring" ? "border-orange-300 ring-1 ring-orange-200" : "border-orange-200"}`}>
+        <button onClick={() => setActiveTab("expiring")} className={`bg-card rounded-lg border p-4 text-left transition ${activeTab === "expiring" ? "border-orange-300 ring-1 ring-orange-200" : "border-orange-200"}`}>
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-orange-50 dark:bg-orange-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-orange-50 dark:bg-orange-950/40 flex items-center justify-center">
               <Clock className="h-5 w-5 text-orange-600 dark:text-orange-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{expiringCount}</p>
-              <p className="text-sm text-muted-foreground">{t("documents.page.expiring30")}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-orange-600 dark:text-orange-400">{expiringCount}</p>
+              <p className="text-[13px] text-muted-foreground">{t("documents.page.expiring30")}</p>
             </div>
           </div>
         </button>
-        <button onClick={() => setActiveTab("mandatory")} className={`bg-card rounded-xl border p-5 text-left transition ${activeTab === "mandatory" ? "border-red-300 ring-1 ring-red-200" : "border-red-200"}`}>
+        <button onClick={() => setActiveTab("mandatory")} className={`bg-card rounded-lg border p-4 text-left transition ${activeTab === "mandatory" ? "border-red-300 ring-1 ring-red-200" : "border-red-200"}`}>
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-red-50 dark:bg-red-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-red-50 dark:bg-red-950/40 flex items-center justify-center">
               <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-red-600 dark:text-red-400">{missingCount}</p>
-              <p className="text-sm text-muted-foreground">{t("documents.page.missingMandatory")}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-red-600 dark:text-red-400">{missingCount}</p>
+              <p className="text-[13px] text-muted-foreground">{t("documents.page.missingMandatory")}</p>
             </div>
           </div>
         </button>
@@ -336,7 +336,7 @@ export default function DocumentsPage() {
       {/* Reject Modal */}
       {rejectingId !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-card rounded-xl shadow-xl w-full max-w-md p-6 mx-4">
+          <div className="bg-card rounded-lg shadow-xl w-full max-w-md p-6 mx-4">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-foreground">{t("documents.page.rejectTitle")}</h3>
               <button onClick={() => { setRejectingId(null); setRejectReason(""); }} className="text-muted-foreground hover:text-muted-foreground">
@@ -348,20 +348,20 @@ export default function DocumentsPage() {
               <textarea
                 value={rejectReason}
                 onChange={(e) => setRejectReason(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 rows={3}
                 placeholder={t("documents.page.rejectionPlaceholder")}
                 required
               />
             </div>
             <div className="mt-4 flex justify-end gap-2">
-              <button onClick={() => { setRejectingId(null); setRejectReason(""); }} className="bg-card text-foreground px-4 py-2 text-sm border border-border rounded-lg">
+              <button onClick={() => { setRejectingId(null); setRejectReason(""); }} className="bg-card text-foreground px-4 py-2 text-[13px] border border-border rounded-md">
                 {t("documents.page.cancel")}
               </button>
               <button
                 onClick={() => handleReject(rejectingId)}
                 disabled={rejectDoc.isPending || !rejectReason.trim()}
-                className="bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-700 disabled:opacity-50"
+                className="bg-red-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-red-700 disabled:opacity-50"
               >
                 {rejectDoc.isPending ? t("documents.page.rejecting") : t("documents.page.rejectDocument")}
               </button>
@@ -372,7 +372,7 @@ export default function DocumentsPage() {
 
       {/* Upload Form */}
       {showUpload && (
-        <form onSubmit={handleUpload} className="bg-card rounded-xl border border-border p-6 mb-6">
+        <form onSubmit={handleUpload} className="bg-card rounded-lg border border-border p-4 mb-6">
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-sm font-semibold text-foreground">{t("documents.page.uploadDocument")}</h3>
             <button type="button" onClick={() => setShowUpload(false)} className="text-muted-foreground hover:text-muted-foreground">
@@ -386,7 +386,7 @@ export default function DocumentsPage() {
                 type="file"
                 accept=".pdf,.jpg,.jpeg,.png,.docx"
                 onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
-                className="w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-brand-50 file:text-brand-700 hover:file:bg-brand-100"
+                className="w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-brand-50 file:text-brand-700 hover:file:bg-brand-100"
                 required
               />
             </div>
@@ -396,7 +396,7 @@ export default function DocumentsPage() {
                 type="text"
                 value={uploadName}
                 onChange={(e) => setUploadName(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("documents.page.docNamePlaceholder")}
               />
             </div>
@@ -405,7 +405,7 @@ export default function DocumentsPage() {
               <select
                 value={uploadCategory}
                 onChange={(e) => setUploadCategory(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               >
                 <option value="">{t("documents.page.selectCategory")}</option>
@@ -421,11 +421,11 @@ export default function DocumentsPage() {
                   type="text"
                   value={employeeSearch}
                   onChange={(e) => { setEmployeeSearch(e.target.value); if (!e.target.value) setUploadUserId(""); }}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder={t("documents.page.employeePlaceholder")}
                 />
                 {employeeSearch && employeeList && employeeList.length > 0 && !uploadUserId && (
-                  <div className="absolute z-10 mt-1 w-full bg-card border border-border rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                  <div className="absolute z-10 mt-1 w-full bg-card border border-border rounded-md shadow-lg max-h-48 overflow-y-auto">
                     {employeeList.map((u: any) => (
                       <button
                         key={u.id}
@@ -459,12 +459,12 @@ export default function DocumentsPage() {
                 type="date"
                 value={uploadExpiry}
                 onChange={(e) => setUploadExpiry(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
           </div>
           {uploadDoc.isError && (
-            <div className="mt-4 bg-red-50 dark:bg-red-950/40 border border-red-200 text-red-700 dark:text-red-300 text-sm rounded-lg px-4 py-3">
+            <div className="mt-4 bg-red-50 dark:bg-red-950/40 border border-red-200 text-red-700 dark:text-red-300 text-sm rounded-md px-4 py-3">
               {(uploadDoc.error as any)?.response?.data?.error?.message || t("documents.page.uploadFailed")}
             </div>
           )}
@@ -472,7 +472,7 @@ export default function DocumentsPage() {
             <button
               type="submit"
               disabled={uploadDoc.isPending || !uploadFile || !uploadCategory}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               <Upload className="h-4 w-4" /> {uploadDoc.isPending ? t("documents.page.uploading") : t("documents.page.upload")}
             </button>
@@ -483,53 +483,53 @@ export default function DocumentsPage() {
       {/* Tab: Expiring Documents */}
       {activeTab === "expiring" && (
         <div className="mb-6">
-          <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-2">
             <AlertTriangle className="h-4 w-4 text-orange-500" /> {t("documents.page.expiringHeading")}
           </h3>
           {expiringCount === 0 ? (
-            <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+            <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
               {t("documents.page.noExpiring")}
             </div>
           ) : (
-            <div className="bg-card rounded-xl border border-border overflow-x-auto">
+            <div className="bg-card rounded-lg border border-border overflow-x-auto">
               <table className="min-w-full">
                 <thead className="bg-muted border-b border-border">
                   <tr>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colDocument")}</th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colEmployee")}</th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colCategory")}</th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colExpires")}</th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colStatus")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colDocument")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colEmployee")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colCategory")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colExpires")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colStatus")}</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
                   {(expiryAlerts || []).map((doc: any) => {
                     const isExpired = new Date(doc.expires_at) < new Date();
                     return (
-                      <tr key={doc.id} className={isExpired ? "bg-red-50/50" : "bg-orange-50/30"}>
-                        <td className="px-6 py-4">
+                      <tr key={doc.id} className={isExpired ? "bg-red-50/50 dark:bg-red-950/30" : "bg-orange-50/30 dark:bg-orange-950/20"}>
+                        <td className="px-4 py-2.5">
                           <div className="flex items-center gap-3">
                             <FileText className={`h-5 w-5 ${isExpired ? "text-red-400" : "text-orange-400"}`} />
                             <span className="text-sm font-medium text-foreground">{doc.name}</span>
                           </div>
                         </td>
-                        <td className="px-6 py-4 text-sm text-muted-foreground">
+                        <td className="px-4 py-2.5 text-sm text-muted-foreground">
                           {doc.user_first_name} {doc.user_last_name}
                           {doc.user_emp_code && <span className="text-muted-foreground ml-1">({doc.user_emp_code})</span>}
                         </td>
-                        <td className="px-6 py-4">
-                          <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-full">{doc.category_name}</span>
+                        <td className="px-4 py-2.5">
+                          <span className="text-[11px] bg-muted text-muted-foreground px-2 py-0.5 rounded-md">{doc.category_name}</span>
                         </td>
-                        <td className="px-6 py-4">
+                        <td className="px-4 py-2.5">
                           <span className={`text-sm font-medium ${isExpired ? "text-red-600 dark:text-red-400" : "text-orange-600 dark:text-orange-400"}`}>
                             {isExpired ? t("documents.page.expiredPrefix") + " " : ""}{new Date(doc.expires_at).toLocaleDateString()}
                           </span>
                         </td>
-                        <td className="px-6 py-4">
+                        <td className="px-4 py-2.5">
                           {doc.is_verified ? (
-                            <span className="text-xs text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/40 px-2 py-1 rounded-full">{t("documents.page.verified")}</span>
+                            <span className="text-xs text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded-md">{t("documents.page.verified")}</span>
                           ) : (
-                            <span className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 px-2 py-1 rounded-full">{t("documents.page.pending")}</span>
+                            <span className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 rounded-md">{t("documents.page.pending")}</span>
                           )}
                         </td>
                       </tr>
@@ -545,30 +545,30 @@ export default function DocumentsPage() {
       {/* Tab: Missing Mandatory */}
       {activeTab === "mandatory" && (
         <div className="mb-6">
-          <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-2">
             <Users className="h-4 w-4 text-red-500" /> {t("documents.page.missingHeading")}
           </h3>
           {missingCount === 0 ? (
-            <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+            <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
               {t("documents.page.allSubmitted")}
             </div>
           ) : (
-            <div className="bg-card rounded-xl border border-border overflow-x-auto">
+            <div className="bg-card rounded-lg border border-border overflow-x-auto">
               <table className="min-w-full">
                 <thead className="bg-muted border-b border-border">
                   <tr>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colEmployee")}</th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colEmployeeCode")}</th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colMissingDocument")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colEmployee")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colEmployeeCode")}</th>
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colMissingDocument")}</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
                   {(mandatoryData?.missing || []).map((item: any, i: number) => (
-                    <tr key={i} className="hover:bg-muted">
-                      <td className="px-6 py-4 text-sm font-medium text-foreground">{item.user_name}</td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground">{item.emp_code || "--"}</td>
-                      <td className="px-6 py-4">
-                        <span className="text-xs bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 px-2 py-1 rounded-full font-medium">{item.category_name}</span>
+                    <tr key={i} className="hover:bg-muted/50 transition-colors">
+                      <td className="px-4 py-2.5 text-sm font-medium text-foreground">{item.user_name}</td>
+                      <td className="px-4 py-2.5 text-sm text-muted-foreground">{item.emp_code || "--"}</td>
+                      <td className="px-4 py-2.5">
+                        <span className="text-xs bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 px-2 py-0.5 rounded-md font-medium">{item.category_name}</span>
                       </td>
                     </tr>
                   ))}
@@ -590,14 +590,14 @@ export default function DocumentsPage() {
                 type="text"
                 value={searchText}
                 onChange={(e) => { setSearchText(e.target.value); setPage(1); }}
-                className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("documents.page.searchPlaceholder")}
               />
             </div>
             <select
               value={filterCategory}
               onChange={(e) => { setFilterCategory(e.target.value); setPage(1); }}
-              className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
             >
               <option value="">{t("documents.page.allCategories")}</option>
               {(categories || []).map((c: any) => (
@@ -607,16 +607,16 @@ export default function DocumentsPage() {
           </div>
 
           {/* Documents Table */}
-          <div className="bg-card rounded-xl border border-border overflow-x-auto -mx-4 lg:mx-0">
+          <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
             <table className="min-w-full">
               <thead className="bg-muted border-b border-border">
                 <tr>
-                  <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colDocument")}</th>
-                  <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colEmployee")}</th>
-                  <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colCategory")}</th>
-                  <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colExpiry")}</th>
-                  <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colStatus")}</th>
-                  <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("documents.page.colActions")}</th>
+                  <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colDocument")}</th>
+                  <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colEmployee")}</th>
+                  <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colCategory")}</th>
+                  <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colExpiry")}</th>
+                  <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colStatus")}</th>
+                  <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("documents.page.colActions")}</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-border">
@@ -626,8 +626,8 @@ export default function DocumentsPage() {
                   <tr><td colSpan={6} className="px-6 py-8 text-center text-muted-foreground">{t("documents.page.noDocuments")}</td></tr>
                 ) : (
                   docs.map((doc: any) => (
-                    <tr key={doc.id} className="hover:bg-muted">
-                      <td className="px-6 py-4">
+                    <tr key={doc.id} className="hover:bg-muted/50 transition-colors">
+                      <td className="px-4 py-2.5">
                         <div className="flex items-center gap-3">
                           <FileText className="h-5 w-5 text-muted-foreground" />
                           <div>
@@ -636,19 +636,19 @@ export default function DocumentsPage() {
                           </div>
                         </div>
                       </td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground">
+                      <td className="px-4 py-2.5 text-sm text-muted-foreground">
                         {doc.user_first_name} {doc.user_last_name}
                         {doc.user_emp_code && <span className="text-muted-foreground ml-1">({doc.user_emp_code})</span>}
                       </td>
-                      <td className="px-6 py-4">
-                        <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-full">{doc.category_name}</span>
+                      <td className="px-4 py-2.5">
+                        <span className="text-[11px] bg-muted text-muted-foreground px-2 py-0.5 rounded-md">{doc.category_name}</span>
                       </td>
-                      <td className="px-6 py-4">
+                      <td className="px-4 py-2.5">
                         <span className={`text-sm ${getExpiryClass(doc.expires_at)}`}>
                           {doc.expires_at ? new Date(doc.expires_at).toLocaleDateString() : "--"}
                         </span>
                       </td>
-                      <td className="px-6 py-4">
+                      <td className="px-4 py-2.5">
                         {getStatusBadge(doc)}
                         {doc.verification_status === "rejected" && doc.rejection_reason && (
                           <p className="text-xs text-red-500 mt-1 max-w-[200px] truncate" title={doc.rejection_reason}>
@@ -656,7 +656,7 @@ export default function DocumentsPage() {
                           </p>
                         )}
                       </td>
-                      <td className="px-6 py-4">
+                      <td className="px-4 py-2.5">
                         <div className="flex items-center gap-2">
                           <button
                             onClick={() => handleDownload(doc.id, doc.name)}
@@ -707,21 +707,21 @@ export default function DocumentsPage() {
             {/* Pagination */}
             {meta && meta.total_pages > 1 && (
               <div className="flex items-center justify-between px-6 py-3 border-t border-border">
-                <p className="text-sm text-muted-foreground">
+                <p className="text-[13px] text-muted-foreground">
                   {t("documents.page.pageOf", { page: meta.page, total_pages: meta.total_pages, total: meta.total })}
                 </p>
                 <div className="flex gap-2">
                   <button
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
                     disabled={page === 1}
-                    className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+                    className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
                   >
                     {t("documents.page.previous")}
                   </button>
                   <button
                     onClick={() => setPage((p) => p + 1)}
                     disabled={page >= meta.total_pages}
-                    className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+                    className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
                   >
                     {t("documents.page.next")}
                   </button>

--- a/packages/client/src/pages/documents/MyDocumentsPage.tsx
+++ b/packages/client/src/pages/documents/MyDocumentsPage.tsx
@@ -60,19 +60,19 @@ function getVerificationBadge(doc: any, t: TFunction) {
   switch (status) {
     case "verified":
       return (
-        <span className="flex items-center gap-1 text-xs text-green-700 bg-green-50 px-2 py-1 rounded-full w-fit">
+        <span className="flex items-center gap-1 text-[11px] text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded-md w-fit">
           <CheckCircle className="h-3 w-3" /> {t("myDocuments.status.verified")}
         </span>
       );
     case "rejected":
       return (
-        <span className="flex items-center gap-1 text-xs text-red-700 bg-red-50 px-2 py-1 rounded-full w-fit">
+        <span className="flex items-center gap-1 text-[11px] text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/40 px-2 py-0.5 rounded-md w-fit">
           <XCircle className="h-3 w-3" /> {t("myDocuments.status.rejected")}
         </span>
       );
     default:
       return (
-        <span className="flex items-center gap-1 text-xs text-amber-700 bg-amber-50 px-2 py-1 rounded-full w-fit">
+        <span className="flex items-center gap-1 text-[11px] text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 rounded-md w-fit">
           <Clock className="h-3 w-3" /> {t("myDocuments.status.pending")}
         </span>
       );
@@ -131,16 +131,16 @@ export default function MyDocumentsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">{t("myDocuments.page.title")}</h1>
-          <p className="text-gray-500 mt-1">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myDocuments.page.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">
             {t("myDocuments.page.subtitle")}
           </p>
         </div>
         <button
           onClick={() => setShowUpload(!showUpload)}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Upload className="h-4 w-4" /> {t("myDocuments.actions.uploadDocument")}
         </button>
@@ -150,51 +150,51 @@ export default function MyDocumentsPage() {
       {showUpload && (
         <form
           onSubmit={handleUpload}
-          className="bg-white rounded-xl border border-gray-200 p-6 mb-6"
+          className="bg-card rounded-lg border border-border p-4 mb-6"
         >
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-sm font-semibold text-gray-900">{t("myDocuments.upload.heading")}</h3>
+            <h3 className="text-sm font-semibold text-foreground">{t("myDocuments.upload.heading")}</h3>
             <button
               type="button"
               onClick={() => setShowUpload(false)}
-              className="text-gray-400 hover:text-gray-600"
+              className="text-muted-foreground hover:text-foreground transition-colors"
             >
               <X className="h-4 w-4" />
             </button>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 {t("myDocuments.upload.fileLabel")}
               </label>
               <input
                 type="file"
                 accept=".pdf,.jpg,.jpeg,.png,.docx"
                 onChange={(e) => setUploadFile(e.target.files?.[0] || null)}
-                className="w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-brand-50 file:text-brand-700 hover:file:bg-brand-100"
+                className="w-full text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-brand-50 file:text-brand-700 hover:file:bg-brand-100"
                 required
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 {t("myDocuments.upload.nameLabel")}
               </label>
               <input
                 type="text"
                 value={uploadName}
                 onChange={(e) => setUploadName(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("myDocuments.upload.namePlaceholder")}
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 {t("myDocuments.upload.categoryLabel")}
               </label>
               <select
                 value={uploadCategory}
                 onChange={(e) => setUploadCategory(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               >
                 <option value="">{t("myDocuments.upload.categoryPlaceholder")}</option>
@@ -206,14 +206,14 @@ export default function MyDocumentsPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-[13px] font-medium text-foreground mb-1">
                 {t("myDocuments.upload.expiryLabel")}
               </label>
               <input
                 type="date"
                 value={uploadExpiry}
                 onChange={(e) => setUploadExpiry(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
           </div>
@@ -221,7 +221,7 @@ export default function MyDocumentsPage() {
             <button
               type="submit"
               disabled={uploadDoc.isPending}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               <Upload className="h-4 w-4" />{" "}
               {uploadDoc.isPending
@@ -235,14 +235,14 @@ export default function MyDocumentsPage() {
       {/* Documents List */}
       <div className="space-y-3">
         {isLoading ? (
-          <div className="text-center py-12 text-gray-400">{t("myDocuments.list.loading")}</div>
+          <div className="text-center py-12 text-muted-foreground">{t("myDocuments.list.loading")}</div>
         ) : docs.length === 0 ? (
           <div className="text-center py-12">
-            <FileText className="h-12 w-12 text-gray-300 mx-auto mb-3" />
-            <p className="text-gray-400">{t("myDocuments.list.empty")}</p>
+            <FileText className="h-12 w-12 text-muted-foreground/50 mx-auto mb-3" />
+            <p className="text-muted-foreground">{t("myDocuments.list.empty")}</p>
             <button
               onClick={() => setShowUpload(true)}
-              className="mt-3 text-sm text-brand-600 font-medium hover:text-brand-800"
+              className="mt-3 text-[13px] text-brand-600 dark:text-brand-400 font-medium hover:text-brand-800 dark:hover:text-brand-300"
             >
               {t("myDocuments.list.uploadFirst")}
             </button>
@@ -257,38 +257,38 @@ export default function MyDocumentsPage() {
             return (
               <div
                 key={doc.id}
-                className={`bg-white rounded-xl border p-4 ${
+                className={`bg-card rounded-lg border p-4 ${
                   expiryStatus === "expired"
-                    ? "border-red-200"
+                    ? "border-red-200 dark:border-red-900/50"
                     : expiryStatus === "warning"
-                      ? "border-orange-200"
-                      : "border-gray-200"
+                      ? "border-orange-200 dark:border-orange-900/50"
+                      : "border-border"
                 }`}
               >
                 <div className="flex items-start justify-between">
                   <div className="flex items-start gap-3">
                     <div
-                      className={`h-10 w-10 rounded-lg flex items-center justify-center ${
+                      className={`h-10 w-10 rounded-md flex items-center justify-center ${
                         expiryStatus === "expired"
-                          ? "bg-red-50"
+                          ? "bg-red-50 dark:bg-red-950/40"
                           : expiryStatus === "warning"
-                            ? "bg-orange-50"
-                            : "bg-gray-50"
+                            ? "bg-orange-50 dark:bg-orange-950/40"
+                            : "bg-muted"
                       }`}
                     >
                       <FileText
                         className={`h-5 w-5 ${
                           expiryStatus === "expired"
-                            ? "text-red-500"
+                            ? "text-red-500 dark:text-red-400"
                             : expiryStatus === "warning"
-                              ? "text-orange-500"
-                              : "text-gray-400"
+                              ? "text-orange-500 dark:text-orange-400"
+                              : "text-muted-foreground"
                         }`}
                       />
                     </div>
                     <div>
-                      <p className="text-sm font-medium text-gray-900">{doc.name}</p>
-                      <p className="text-xs text-gray-500">
+                      <p className="text-[13px] font-medium text-foreground">{doc.name}</p>
+                      <p className="text-[11px] tabular-nums text-muted-foreground">
                         {doc.category_name} &middot;{" "}
                         {doc.file_size
                           ? `${(doc.file_size / 1024).toFixed(0)} KB`
@@ -297,12 +297,12 @@ export default function MyDocumentsPage() {
                       </p>
                       {doc.expires_at && (
                         <p
-                          className={`text-xs mt-1 flex items-center gap-1 ${
+                          className={`text-[11px] tabular-nums mt-1 flex items-center gap-1 ${
                             expiryStatus === "expired"
-                              ? "text-red-600"
+                              ? "text-red-600 dark:text-red-400"
                               : expiryStatus === "warning"
-                                ? "text-orange-600"
-                                : "text-gray-400"
+                                ? "text-orange-600 dark:text-orange-400"
+                                : "text-muted-foreground"
                           }`}
                         >
                           {expiryStatus === "expired" && (
@@ -339,14 +339,14 @@ export default function MyDocumentsPage() {
                             showToast("error", t("myDocuments.toast.downloadFailed"));
                           }
                         }}
-                        className="text-xs text-brand-600 hover:text-brand-800 font-medium"
+                        className="text-[11px] text-brand-600 dark:text-brand-400 hover:text-brand-800 dark:hover:text-brand-300 font-medium"
                       >
                         {t("myDocuments.doc.download")}
                       </button>
                       {(doc.verification_status === "rejected" || isRejected) && (
                         <button
                           onClick={() => setShowUpload(true)}
-                          className="text-xs text-brand-600 hover:text-brand-800 font-medium"
+                          className="text-[11px] text-brand-600 dark:text-brand-400 hover:text-brand-800 dark:hover:text-brand-300 font-medium"
                         >
                           {t("myDocuments.doc.reupload")}
                         </button>
@@ -363,7 +363,7 @@ export default function MyDocumentsPage() {
       {/* Pagination */}
       {meta && meta.total_pages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-sm text-gray-500">
+          <p className="text-[13px] tabular-nums text-muted-foreground">
             {t("myDocuments.pagination.summary", {
               page: meta.page,
               totalPages: meta.total_pages,
@@ -374,14 +374,14 @@ export default function MyDocumentsPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-3 py-1 text-sm border border-gray-300 rounded-lg disabled:opacity-50"
+              className="px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
             >
               {t("myDocuments.pagination.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="px-3 py-1 text-sm border border-gray-300 rounded-lg disabled:opacity-50"
+              className="px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
             >
               {t("myDocuments.pagination.next")}
             </button>


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) across the **Documents + Assets modules** — one PR for all 8 pages.

**Pages:** Documents, Document Categories, My Documents · Asset Dashboard, Asset List, Asset Detail, Asset Categories, My Assets.

**Density uplift (all pages):** compact headers; `rounded-lg` cards / `rounded-md` controls; `text-[11px]` uppercase `tracking-wider` table headers; `px-4 py-2.5` dense rows; `tabular-nums` on counts / dates / file sizes / costs / percentages; `rounded-md` status + condition pills; KPI stat tiles.
Preserved as chrome/decoration: modal titles, modal header/footer + body padding; progress bars, timeline dots, dialog icon circles, avatars keep `rounded-full`; asset-status and file-type semantic colors untouched.

**Dark-mode fixes (the notable part):**
- **DocumentsPage** — the "mandatory outstanding" banner heading was `text-red-800` on a `dark:bg-red-950/40` tint with **no dark text pair** (unreadable in dark) → added `dark:text-red-200` + a `dark:border` pair.
- **DocumentCategoriesPage** and **MyDocumentsPage** were **fully light-only** — raw `bg-white` / `text-gray-*` / `border-gray-*` with **zero `dark:` variants**, so they rendered broken in dark mode. Migrated to semantic tokens and added `dark:` pairs to their verification / mandatory / expiry status color styles.

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.