### PR TITLE
ui: enterprise-density uplift for Helpdesk + Feedback (engagement 1/3, 9 pages)

### DIFF
--- a/packages/client/src/pages/feedback/FeedbackDashboardPage.tsx
+++ b/packages/client/src/pages/feedback/FeedbackDashboardPage.tsx
@@ -49,8 +49,8 @@ export default function FeedbackDashboardPage() {
   if (isLoading) {
     return (
       <div>
-        <h1 className="text-2xl font-bold text-foreground mb-8">{t("feedbackDashboard.title")}</h1>
-        <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground mb-6">{t("feedbackDashboard.title")}</h1>
+        <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
           {t("feedbackDashboard.loading")}
         </div>
       </div>
@@ -72,70 +72,70 @@ export default function FeedbackDashboardPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("feedbackDashboard.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("feedbackDashboard.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("feedbackDashboard.subtitle")}</p>
         </div>
       </div>
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-        <Link to="/feedback" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <Link to="/feedback" className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-md bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
               <MessageSquare className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">{stats.total}</p>
-              <p className="text-xs text-muted-foreground">{t("feedbackDashboard.stats.totalFeedback")}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{stats.total}</p>
+              <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t("feedbackDashboard.stats.totalFeedback")}</p>
             </div>
           </div>
         </Link>
 
-        <Link to="/feedback" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/feedback" className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-red-100 dark:bg-red-950/40 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-md bg-red-100 dark:bg-red-950/40 flex items-center justify-center">
               <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">{stats.urgentCount}</p>
-              <p className="text-xs text-muted-foreground">{t("feedbackDashboard.stats.urgentItems")}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{stats.urgentCount}</p>
+              <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t("feedbackDashboard.stats.urgentItems")}</p>
             </div>
           </div>
         </Link>
 
-        <Link to="/feedback" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/feedback" className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-md bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
               <Reply className="h-5 w-5 text-green-600 dark:text-green-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">{stats.responseRate}%</p>
-              <p className="text-xs text-muted-foreground">{t("feedbackDashboard.stats.responseRate")}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{stats.responseRate}%</p>
+              <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t("feedbackDashboard.stats.responseRate")}</p>
             </div>
           </div>
         </Link>
 
-        <Link to="/feedback" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/feedback" className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-950/40 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-md bg-purple-100 dark:bg-purple-950/40 flex items-center justify-center">
               <TrendingUp className="h-5 w-5 text-purple-600 dark:text-purple-400" />
             </div>
             <div>
-              <p className="text-2xl font-bold text-foreground">
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">
                 {stats.byStatus.find((s: any) => s.status === "new")?.count || 0}
               </p>
-              <p className="text-xs text-muted-foreground">{t("feedbackDashboard.stats.newUnread")}</p>
+              <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t("feedbackDashboard.stats.newUnread")}</p>
             </div>
           </div>
         </Link>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {/* Category Breakdown */}
-        <div className="bg-card rounded-xl border border-border p-5">
-          <h2 className="text-sm font-semibold text-foreground mb-4">{t("feedbackDashboard.sections.byCategory")}</h2>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("feedbackDashboard.sections.byCategory")}</h2>
           {stats.byCategory.length === 0 ? (
             <p className="text-sm text-muted-foreground">{t("feedbackDashboard.empty.noData")}</p>
           ) : (
@@ -159,8 +159,8 @@ export default function FeedbackDashboardPage() {
         </div>
 
         {/* Sentiment Distribution */}
-        <div className="bg-card rounded-xl border border-border p-5">
-          <h2 className="text-sm font-semibold text-foreground mb-4">{t("feedbackDashboard.sections.sentimentDistribution")}</h2>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("feedbackDashboard.sections.sentimentDistribution")}</h2>
           {stats.bySentiment.length === 0 ? (
             <p className="text-sm text-muted-foreground">{t("feedbackDashboard.empty.noData")}</p>
           ) : (
@@ -185,8 +185,8 @@ export default function FeedbackDashboardPage() {
       </div>
 
       {/* Status Breakdown */}
-      <div className="bg-card rounded-xl border border-border p-5 mb-8">
-        <h2 className="text-sm font-semibold text-foreground mb-4">{t("feedbackDashboard.sections.byStatus")}</h2>
+      <div className="bg-card rounded-lg border border-border p-4 mb-8">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("feedbackDashboard.sections.byStatus")}</h2>
         <div className="flex flex-wrap gap-3">
           {stats.byStatus.map((item: any) => {
             const cfg = STATUS_CONFIG[item.status] || STATUS_CONFIG.new;
@@ -194,7 +194,7 @@ export default function FeedbackDashboardPage() {
             return (
               <div
                 key={item.status}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg ${cfg.color}`}
+                className={`flex items-center gap-2 px-4 py-2 rounded-md ${cfg.color}`}
               >
                 <StatusIcon className="h-4 w-4" />
                 <span className="text-sm font-medium">{t(`feedbackDashboard.status.${item.status}`, { defaultValue: cfg.label })}</span>
@@ -206,8 +206,8 @@ export default function FeedbackDashboardPage() {
       </div>
 
       {/* Recent Feedback */}
-      <div className="bg-card rounded-xl border border-border p-5">
-        <h2 className="text-sm font-semibold text-foreground mb-4">{t("feedbackDashboard.sections.recentFeedback")}</h2>
+      <div className="bg-card rounded-lg border border-border p-4">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("feedbackDashboard.sections.recentFeedback")}</h2>
         {stats.recent.length === 0 ? (
           <p className="text-sm text-muted-foreground">{t("feedbackDashboard.empty.noFeedback")}</p>
         ) : (
@@ -218,14 +218,14 @@ export default function FeedbackDashboardPage() {
               return (
                 <div
                   key={f.id}
-                  className={`flex items-center gap-4 p-3 rounded-lg border ${
+                  className={`flex items-center gap-4 p-3 rounded-md border ${
                     f.is_urgent ? "border-red-200 dark:border-red-900/50 bg-red-50/30 dark:bg-red-950/30" : "border-border"
                   }`}
                 >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                       <span className="text-xs font-medium text-muted-foreground capitalize">{t(`feedbackDashboard.category.${f.category}`, { defaultValue: f.category })}</span>
-                      <span className={`inline-flex items-center gap-1 text-xs ${statusCfg.color} px-2 py-0.5 rounded-full`}>
+                      <span className={`inline-flex items-center gap-1 text-[11px] ${statusCfg.color} px-2 py-0.5 rounded-md`}>
                         <StatusIcon className="h-3 w-3" />
                         {t(`feedbackDashboard.status.${f.status}`, { defaultValue: statusCfg.label })}
                       </span>

--- a/packages/client/src/pages/feedback/FeedbackListPage.tsx
+++ b/packages/client/src/pages/feedback/FeedbackListPage.tsx
@@ -141,7 +141,7 @@ export default function FeedbackListPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("feedback.list.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("feedback.list.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("feedback.list.subtitle")}</p>
         </div>
       </div>
@@ -160,17 +160,17 @@ export default function FeedbackListPage() {
                 setStatusFilter(active ? "" : s);
                 setPage(1);
               }}
-              className={`bg-card rounded-xl border p-4 text-left transition-shadow hover:shadow-md ${
+              className={`bg-card rounded-lg border p-4 text-left hover:border-brand-400 transition-colors duration-150 ${
                 active ? "border-brand-400 ring-1 ring-brand-200" : "border-border"
               }`}
             >
               <div className="flex items-center justify-between mb-1">
-                <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${cfg.color}`}>
+                <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-md ${cfg.color}`}>
                   <Icon className="h-3 w-3" />
                   {t(`feedback.list.status.${s}`)}
                 </span>
               </div>
-              <div className="text-2xl font-bold text-foreground">
+              <div className="text-2xl font-semibold tabular-nums leading-none text-foreground">
                 {statusCounts[s] ?? 0}
               </div>
             </button>
@@ -179,7 +179,7 @@ export default function FeedbackListPage() {
       </div>
 
       {/* Filters */}
-      <div className="bg-card rounded-xl border border-border p-4 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex items-center gap-2 mb-3 text-sm font-medium text-muted-foreground">
           <Filter className="h-4 w-4" /> {t("feedback.list.filters")}
         </div>
@@ -187,7 +187,7 @@ export default function FeedbackListPage() {
           <select
             value={categoryFilter}
             onChange={(e) => { setCategoryFilter(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("feedback.list.allCategories")}</option>
             {CATEGORIES.map((c) => (
@@ -198,7 +198,7 @@ export default function FeedbackListPage() {
           <select
             value={statusFilter}
             onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("feedback.list.allStatuses")}</option>
             {STATUSES.map((s) => (
@@ -206,7 +206,7 @@ export default function FeedbackListPage() {
             ))}
           </select>
 
-          <label className="bg-card text-foreground flex items-center gap-2 px-3 py-2 border border-border rounded-lg text-sm cursor-pointer">
+          <label className="bg-card text-foreground flex items-center gap-2 px-3 py-2 border border-border rounded-md text-[13px] cursor-pointer">
             <input
               type="checkbox"
               checked={urgentOnly}
@@ -224,7 +224,7 @@ export default function FeedbackListPage() {
               value={searchTerm}
               onChange={(e) => { setSearchTerm(e.target.value); setPage(1); }}
               placeholder={t("feedback.list.searchPlaceholder")}
-              className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-md text-[13px]"
             />
           </div>
         </div>
@@ -233,11 +233,11 @@ export default function FeedbackListPage() {
       {/* Feedback Cards */}
       <div className="space-y-4">
         {isLoading ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             {t("feedback.list.loading")}
           </div>
         ) : feedbackList.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             <MessageSquare className="h-8 w-8 mx-auto mb-3 opacity-50" />
             <p>{t("feedback.list.empty")}</p>
           </div>
@@ -251,17 +251,17 @@ export default function FeedbackListPage() {
             return (
               <div
                 key={f.id}
-                className={`bg-card rounded-xl border overflow-hidden transition-shadow hover:shadow-md ${
+                className={`bg-card rounded-lg border overflow-hidden hover:border-brand-400 transition-colors duration-150 ${
                   f.is_urgent ? "border-red-300" : "border-border"
                 }`}
               >
-                <div className="p-6">
+                <div className="p-4">
                   <div className="flex items-start justify-between gap-4 mb-3">
                     <div className="flex items-center gap-2 flex-wrap">
-                      <span className={`text-xs font-medium px-2.5 py-0.5 rounded-full ${catColor}`}>
+                      <span className={`text-[11px] font-medium px-2.5 py-0.5 rounded-md ${catColor}`}>
                         {t(`feedback.list.category.${f.category}`, { defaultValue: f.category })}
                       </span>
-                      <span className={`inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full ${statusCfg.color}`}>
+                      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md ${statusCfg.color}`}>
                         <StatusIcon className="h-3 w-3" />
                         {t(`feedback.list.status.${f.status}`, { defaultValue: statusCfg.label })}
                       </span>
@@ -269,13 +269,13 @@ export default function FeedbackListPage() {
                         {t(`feedback.list.sentiment.${f.sentiment}`, { defaultValue: f.sentiment })}
                       </span>
                       {f.is_urgent && (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300">
+                        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300">
                           <AlertTriangle className="h-3 w-3" />
                           {t("feedback.list.urgent")}
                         </span>
                       )}
                     </div>
-                    <span className="text-xs text-muted-foreground shrink-0">
+                    <span className="text-[11px] tabular-nums text-muted-foreground shrink-0">
                       {new Date(f.created_at).toLocaleDateString("en-US", {
                         month: "short",
                         day: "numeric",
@@ -287,33 +287,33 @@ export default function FeedbackListPage() {
                   </div>
 
                   <h3 className="text-base font-semibold text-foreground mb-1">{f.subject}</h3>
-                  <p className="text-sm text-muted-foreground leading-relaxed mb-4">{f.message}</p>
+                  <p className="text-[13px] text-muted-foreground leading-relaxed mb-4">{f.message}</p>
 
                   {f.admin_response && (
-                    <div className="bg-brand-50 dark:bg-brand-950/40 border border-brand-200 rounded-lg p-3 mb-4">
+                    <div className="bg-brand-50 dark:bg-brand-950/40 border border-brand-200 dark:border-brand-900/50 rounded-md p-3 mb-4">
                       <p className="text-xs font-medium text-brand-700 dark:text-brand-300 mb-1">{t("feedback.list.hrResponse")}</p>
-                      <p className="text-sm text-brand-800 dark:text-brand-200">{f.admin_response}</p>
+                      <p className="text-[13px] text-brand-800 dark:text-brand-200">{f.admin_response}</p>
                     </div>
                   )}
 
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => { setRespondingTo(f); setResponseText(f.admin_response || ""); }}
-                      className="flex items-center gap-1.5 text-xs font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300 border border-brand-200 px-3 py-1.5 rounded-lg hover:bg-brand-50 dark:hover:bg-brand-950/40"
+                      className="flex items-center gap-1.5 text-xs font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300 border border-brand-200 px-3 py-1.5 rounded-md hover:bg-brand-50 dark:hover:bg-brand-950/40"
                     >
                       <Reply className="h-3.5 w-3.5" />
                       {f.admin_response ? t("feedback.list.editResponse") : t("feedback.list.respond")}
                     </button>
                     <button
                       onClick={() => { setStatusUpdateId(f.id); setNewStatus(f.status); }}
-                      className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground border border-border px-3 py-1.5 rounded-lg hover:bg-muted"
+                      className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground border border-border px-3 py-1.5 rounded-md hover:bg-muted"
                     >
                       {t("feedback.list.updateStatus")}
                     </button>
                     {isHR && (
                       <button
                         onClick={() => { setDeleteTarget({ id: f.id, subject: f.subject }); setDeleteError(null); }}
-                        className="flex items-center gap-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 border border-red-200 px-3 py-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/40"
+                        className="flex items-center gap-1.5 text-xs font-medium text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 border border-red-200 px-3 py-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-950/40"
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                         {t("feedback.list.delete")}
@@ -337,14 +337,14 @@ export default function FeedbackListPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("feedback.list.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("feedback.list.next")}
             </button>
@@ -356,34 +356,34 @@ export default function FeedbackListPage() {
       {respondingTo && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div className="fixed inset-0 bg-black/50" onClick={() => setRespondingTo(null)} />
-          <div className="relative bg-card rounded-xl shadow-xl max-w-lg w-full p-6 z-10">
+          <div className="relative bg-card rounded-lg shadow-xl max-w-lg w-full p-6 z-10">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-foreground">{t("feedback.list.respondTitle")}</h3>
               <button onClick={() => setRespondingTo(null)} className="text-muted-foreground hover:text-muted-foreground">
                 <X className="h-5 w-5" />
               </button>
             </div>
-            <div className="mb-4 bg-muted rounded-lg p-3">
+            <div className="mb-4 bg-muted rounded-md p-3">
               <p className="text-xs font-medium text-muted-foreground mb-1">{t(`feedback.list.category.${respondingTo.category}`, { defaultValue: respondingTo.category })} - {respondingTo.subject}</p>
               <p className="text-sm text-muted-foreground line-clamp-3">{respondingTo.message}</p>
             </div>
             <textarea
               value={responseText}
               onChange={(e) => setResponseText(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[120px] mb-4"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[120px] mb-4"
               placeholder={t("feedback.list.responsePlaceholder")}
             />
             <div className="flex justify-end gap-3">
               <button
                 onClick={() => setRespondingTo(null)}
-                className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+                className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
               >
                 {t("feedback.list.cancel")}
               </button>
               <button
                 onClick={() => respondMutation.mutate({ id: respondingTo.id, admin_response: responseText })}
                 disabled={respondMutation.isPending || !responseText.trim()}
-                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
               >
                 <Reply className="h-4 w-4" />
                 {respondMutation.isPending ? t("feedback.list.sending") : t("feedback.list.sendResponse")}
@@ -400,7 +400,7 @@ export default function FeedbackListPage() {
           onClick={() => !deleteMutation.isPending && setDeleteTarget(null)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -417,16 +417,16 @@ export default function FeedbackListPage() {
               </div>
             </div>
             {deleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
                 {deleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleteMutation.isPending}
-                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
+                className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
               >
                 {t("feedback.list.cancel")}
               </button>
@@ -434,7 +434,7 @@ export default function FeedbackListPage() {
                 type="button"
                 onClick={() => deleteMutation.mutate(deleteTarget.id)}
                 disabled={deleteMutation.isPending}
-                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {deleteMutation.isPending ? (
                   <>
@@ -453,7 +453,7 @@ export default function FeedbackListPage() {
       {statusUpdateId !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div className="fixed inset-0 bg-black/50" onClick={() => setStatusUpdateId(null)} />
-          <div className="relative bg-card rounded-xl shadow-xl max-w-sm w-full p-6 z-10">
+          <div className="relative bg-card rounded-lg shadow-xl max-w-sm w-full p-6 z-10">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-foreground">{t("feedback.list.updateStatusTitle")}</h3>
               <button onClick={() => setStatusUpdateId(null)} className="text-muted-foreground hover:text-muted-foreground">
@@ -463,7 +463,7 @@ export default function FeedbackListPage() {
             <select
               value={newStatus}
               onChange={(e) => setNewStatus(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm mb-4"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] mb-4"
             >
               {STATUSES.map((s) => (
                 <option key={s} value={s}>{t(`feedback.list.status.${s}`)}</option>
@@ -472,14 +472,14 @@ export default function FeedbackListPage() {
             <div className="flex justify-end gap-3">
               <button
                 onClick={() => setStatusUpdateId(null)}
-                className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+                className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
               >
                 {t("feedback.list.cancel")}
               </button>
               <button
                 onClick={() => statusMutation.mutate({ id: statusUpdateId, status: newStatus })}
                 disabled={statusMutation.isPending}
-                className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
               >
                 {statusMutation.isPending ? t("feedback.list.updating") : t("feedback.list.update")}
               </button>

--- a/packages/client/src/pages/feedback/MyFeedbackPage.tsx
+++ b/packages/client/src/pages/feedback/MyFeedbackPage.tsx
@@ -87,11 +87,11 @@ export default function MyFeedbackPage() {
 
   return (
     <div>
-      <div className="flex items-center gap-3 mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t("myFeedback.page.title")}</h1>
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myFeedback.page.title")}</h1>
       </div>
 
-      <p className="text-sm text-muted-foreground mb-6">
+      <p className="text-[13px] text-muted-foreground mb-6">
         {t("myFeedback.page.subtitle")}
       </p>
 
@@ -99,7 +99,7 @@ export default function MyFeedbackPage() {
         {isLoading ? (
           <div className="space-y-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-card rounded-xl border border-border p-6 animate-pulse">
+              <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
                 <div className="flex items-center gap-2 mb-3">
                   <div className="h-5 w-20 bg-muted rounded-full" />
                   <div className="h-5 w-16 bg-muted rounded-full" />
@@ -110,13 +110,13 @@ export default function MyFeedbackPage() {
             ))}
           </div>
         ) : feedbackList.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-12 text-center">
+          <div className="bg-card rounded-lg border border-border p-12 text-center">
             <MessageSquare className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
-            <p className="text-lg font-medium text-muted-foreground mb-1">{t("myFeedback.empty.title")}</p>
+            <p className="text-base font-medium text-muted-foreground mb-1">{t("myFeedback.empty.title")}</p>
             <p className="text-sm text-muted-foreground mb-4">{t("myFeedback.empty.description")}</p>
             <a
               href="/feedback/submit"
-              className="inline-flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+              className="inline-flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
             >
               {t("myFeedback.empty.submitCta")}
             </a>
@@ -130,25 +130,25 @@ export default function MyFeedbackPage() {
             return (
               <div
                 key={f.id}
-                className="bg-card rounded-xl border border-border p-6 hover:shadow-md transition-shadow"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start justify-between gap-4 mb-3">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className={`text-xs font-medium px-2.5 py-0.5 rounded-full ${catColor}`}>
+                    <span className={`text-[11px] font-medium px-2.5 py-0.5 rounded-md ${catColor}`}>
                       {t(`myFeedback.category.${f.category}`, { defaultValue: f.category })}
                     </span>
-                    <span className={`inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full ${statusCfg.color}`}>
+                    <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md ${statusCfg.color}`}>
                       <StatusIcon className="h-3 w-3" />
                       {t(`myFeedback.status.${f.status}`, { defaultValue: statusCfg.label })}
                     </span>
                     {f.is_urgent && (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300">
+                      <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300">
                         <AlertTriangle className="h-3 w-3" />
                         {t("myFeedback.card.urgentBadge")}
                       </span>
                     )}
                   </div>
-                  <span className="text-xs text-muted-foreground shrink-0">
+                  <span className="text-[11px] tabular-nums text-muted-foreground shrink-0">
                     {new Date(f.created_at).toLocaleDateString("en-US", {
                       month: "short",
                       day: "numeric",
@@ -158,13 +158,13 @@ export default function MyFeedbackPage() {
                 </div>
 
                 <h3 className="text-base font-semibold text-foreground mb-1">{f.subject}</h3>
-                <p className="text-sm text-muted-foreground leading-relaxed mb-4">{f.message}</p>
+                <p className="text-[13px] text-muted-foreground leading-relaxed mb-4">{f.message}</p>
 
                 {canEdit(f) && (
                   <div className="mb-4">
                     <button
                       onClick={() => openEdit(f)}
-                      className="inline-flex items-center gap-1.5 text-xs font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 border border-brand-200 dark:border-brand-800 px-3 py-1.5 rounded-lg hover:bg-brand-50 dark:hover:bg-brand-950/40"
+                      className="inline-flex items-center gap-1.5 text-[11px] font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 border border-brand-200 dark:border-brand-800 px-3 py-1.5 rounded-md hover:bg-brand-50 dark:hover:bg-brand-950/40"
                     >
                       <Pencil className="h-3.5 w-3.5" />
                       {t("myFeedback.card.editButton")}
@@ -174,8 +174,8 @@ export default function MyFeedbackPage() {
 
                 {f.admin_response && (
                   <div className="bg-brand-50 dark:bg-brand-950/40 border border-brand-200 dark:border-brand-800 rounded-lg p-4">
-                    <p className="text-xs font-medium text-brand-700 dark:text-brand-300 mb-1">{t("myFeedback.card.hrResponseLabel")}</p>
-                    <p className="text-sm text-brand-800 dark:text-brand-200">{f.admin_response}</p>
+                    <p className="text-[11px] font-medium text-brand-700 dark:text-brand-300 mb-1">{t("myFeedback.card.hrResponseLabel")}</p>
+                    <p className="text-[13px] text-brand-800 dark:text-brand-200">{f.admin_response}</p>
                     {f.responded_at && (
                       <p className="text-xs text-brand-500 mt-2">
                         {t("myFeedback.card.respondedOn", {
@@ -201,7 +201,7 @@ export default function MyFeedbackPage() {
             className="fixed inset-0 bg-black/50"
             onClick={() => !updateMutation.isPending && setEditing(null)}
           />
-          <div className="relative bg-card rounded-xl shadow-xl max-w-lg w-full p-6 z-10">
+          <div className="relative bg-card rounded-lg shadow-xl max-w-lg w-full p-6 z-10">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-foreground">{t("myFeedback.editModal.title")}</h3>
               <button
@@ -215,11 +215,11 @@ export default function MyFeedbackPage() {
 
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("myFeedback.editModal.categoryLabel")}</label>
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("myFeedback.editModal.categoryLabel")}</label>
                 <select
                   value={editForm.category}
                   onChange={(e) => setEditForm({ ...editForm, category: e.target.value })}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 >
                   {CATEGORIES.map((c) => (
                     <option key={c.value} value={c.value}>{t(`myFeedback.category.${c.value}`, { defaultValue: c.label })}</option>
@@ -228,21 +228,21 @@ export default function MyFeedbackPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("myFeedback.editModal.subjectLabel")}</label>
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("myFeedback.editModal.subjectLabel")}</label>
                 <input
                   type="text"
                   value={editForm.subject}
                   onChange={(e) => setEditForm({ ...editForm, subject: e.target.value })}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">{t("myFeedback.editModal.messageLabel")}</label>
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("myFeedback.editModal.messageLabel")}</label>
                 <textarea
                   value={editForm.message}
                   onChange={(e) => setEditForm({ ...editForm, message: e.target.value })}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[120px]"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[120px]"
                 />
               </div>
 
@@ -258,7 +258,7 @@ export default function MyFeedbackPage() {
               </label>
 
               {editError && (
-                <div className="rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+                <div className="rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
                   {editError}
                 </div>
               )}
@@ -268,7 +268,7 @@ export default function MyFeedbackPage() {
               <button
                 onClick={() => setEditing(null)}
                 disabled={updateMutation.isPending}
-                className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted disabled:opacity-50"
+                className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted disabled:opacity-50"
               >
                 {t("myFeedback.editModal.cancel")}
               </button>
@@ -289,7 +289,7 @@ export default function MyFeedbackPage() {
                   !editForm.subject.trim() ||
                   !editForm.message.trim()
                 }
-                className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
               >
                 {updateMutation.isPending ? t("myFeedback.editModal.saving") : t("myFeedback.editModal.save")}
               </button>
@@ -311,14 +311,14 @@ export default function MyFeedbackPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("myFeedback.pagination.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("myFeedback.pagination.next")}
             </button>

--- a/packages/client/src/pages/feedback/SubmitFeedbackPage.tsx
+++ b/packages/client/src/pages/feedback/SubmitFeedbackPage.tsx
@@ -42,18 +42,18 @@ export default function SubmitFeedbackPage() {
   if (submitted) {
     return (
       <div>
-        <div className="flex items-center gap-3 mb-8">
-          <h1 className="text-2xl font-bold text-foreground">{t("submitFeedback.page.title")}</h1>
+        <div className="flex items-center gap-3 mb-6">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("submitFeedback.page.title")}</h1>
         </div>
-        <div className="bg-card rounded-xl border border-border p-8 text-center max-w-lg mx-auto">
+        <div className="bg-card rounded-lg border border-border p-8 text-center max-w-lg mx-auto">
           <CheckCircle className="h-12 w-12 text-green-500 mx-auto mb-4" />
-          <h2 className="text-lg font-semibold text-foreground mb-2">{t("submitFeedback.success.title")}</h2>
-          <p className="text-sm text-muted-foreground mb-6">
+          <h2 className="text-base font-semibold text-foreground mb-2">{t("submitFeedback.success.title")}</h2>
+          <p className="text-[13px] text-muted-foreground mb-6">
             {t("submitFeedback.success.description")}
           </p>
           <button
             onClick={() => setSubmitted(false)}
-            className="bg-brand-600 text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            className="bg-brand-600 text-white px-6 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 transition-colors"
           >
             {t("submitFeedback.success.submitAnother")}
           </button>
@@ -64,29 +64,29 @@ export default function SubmitFeedbackPage() {
 
   return (
     <div>
-      <div className="flex items-center gap-3 mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t("submitFeedback.page.title")}</h1>
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("submitFeedback.page.title")}</h1>
       </div>
 
-      <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-xl p-4 mb-6 max-w-2xl">
+      <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg p-4 mb-6 max-w-2xl">
         <div className="flex items-start gap-3">
           <MessageSquarePlus className="h-5 w-5 text-amber-600 dark:text-amber-400 mt-0.5" />
           <div>
-            <p className="text-sm font-medium text-amber-800 dark:text-amber-200">{t("submitFeedback.anonymousBanner.title")}</p>
-            <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+            <p className="text-[13px] font-medium text-amber-800 dark:text-amber-200">{t("submitFeedback.anonymousBanner.title")}</p>
+            <p className="text-[11px] text-amber-600 dark:text-amber-400 mt-1">
               {t("submitFeedback.anonymousBanner.description")}
             </p>
           </div>
         </div>
       </div>
 
-      <form onSubmit={handleSubmit} className="bg-card rounded-xl border border-border p-6 max-w-2xl space-y-5">
+      <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 max-w-2xl space-y-5">
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">{t("submitFeedback.field.category")} <span className="text-red-500">*</span></label>
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("submitFeedback.field.category")} <span className="text-red-500">*</span></label>
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
           >
             {CATEGORIES.map((c) => (
               <option key={c.value} value={c.value}>
@@ -97,23 +97,23 @@ export default function SubmitFeedbackPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">{t("submitFeedback.field.subject")} <span className="text-red-500">*</span></label>
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("submitFeedback.field.subject")} <span className="text-red-500">*</span></label>
           <input
             type="text"
             value={subject}
             onChange={(e) => setSubject(e.target.value)}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
             placeholder={t("submitFeedback.field.subjectPlaceholder")}
             required
           />
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">{t("submitFeedback.field.message")} <span className="text-red-500">*</span></label>
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("submitFeedback.field.message")} <span className="text-red-500">*</span></label>
           <textarea
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[160px]"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[160px]"
             placeholder={t("submitFeedback.field.messagePlaceholder")}
             required
           />
@@ -127,7 +127,7 @@ export default function SubmitFeedbackPage() {
               onChange={(e) => setIsUrgent(e.target.checked)}
               className="h-4 w-4 rounded border-border text-red-600 dark:text-red-400 focus:ring-red-500"
             />
-            <span className="text-sm text-muted-foreground flex items-center gap-1.5">
+            <span className="text-[13px] text-muted-foreground flex items-center gap-1.5">
               <AlertTriangle className="h-4 w-4 text-red-500" />
               {t("submitFeedback.field.markUrgent")}
             </span>
@@ -138,7 +138,7 @@ export default function SubmitFeedbackPage() {
           <button
             type="submit"
             disabled={submitMutation.isPending}
-            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
           >
             <Send className="h-4 w-4" />
             {submitMutation.isPending ? t("submitFeedback.action.submitting") : t("submitFeedback.action.submit")}
@@ -146,7 +146,7 @@ export default function SubmitFeedbackPage() {
         </div>
 
         {submitMutation.isError && (
-          <p className="text-sm text-red-600 dark:text-red-400 mt-2">
+          <p className="text-[13px] text-red-600 dark:text-red-400 mt-2">
             {t("submitFeedback.error.submitFailed")}
           </p>
         )}

--- a/packages/client/src/pages/helpdesk/HelpdeskDashboardPage.tsx
+++ b/packages/client/src/pages/helpdesk/HelpdeskDashboardPage.tsx
@@ -102,9 +102,9 @@ export default function HelpdeskDashboardPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">
             {t("helpdeskDashboard.title")}
           </h1>
           <p className="text-muted-foreground mt-1">
@@ -113,29 +113,29 @@ export default function HelpdeskDashboardPage() {
         </div>
         <Link
           to="/helpdesk/tickets"
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           {t("helpdeskDashboard.viewAllTickets")} <ArrowRight className="h-4 w-4" />
         </Link>
       </div>
 
       {/* Stat Cards */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         {statCards.map((card) => {
           const Icon = card.icon;
           return (
             <Link
               key={card.label}
               to={card.href}
-              className="bg-card rounded-xl border border-border p-6 transition-colors hover:border-brand-400 hover:bg-brand-50/30 dark:hover:bg-brand-950/30 focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="bg-card rounded-lg border border-border p-4 transition-colors hover:border-brand-400 hover:bg-brand-50/30 dark:hover:bg-brand-950/30 focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               <div className="flex items-center gap-3">
-                <div className={`p-2.5 rounded-lg ${card.color}`}>
+                <div className={`p-2.5 rounded-md ${card.color}`}>
                   <Icon className="h-5 w-5" />
                 </div>
                 <div>
                   <p className="text-sm text-muted-foreground">{card.label}</p>
-                  <p className="text-2xl font-bold text-foreground">{card.value}</p>
+                  <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{card.value}</p>
                 </div>
               </div>
             </Link>
@@ -144,10 +144,10 @@ export default function HelpdeskDashboardPage() {
       </div>
 
       {/* SLA & Metrics Row */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
         {/* SLA Compliance */}
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4 flex items-center gap-2">
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
             <BarChart3 className="h-4 w-4" /> {t("helpdeskDashboard.sla.compliance")}
           </h3>
           <div className="flex items-center justify-center">
@@ -174,7 +174,7 @@ export default function HelpdeskDashboardPage() {
                 />
               </svg>
               <div className="absolute inset-0 flex items-center justify-center">
-                <span className="text-2xl font-bold text-foreground">
+                <span className="text-2xl font-semibold tabular-nums leading-none text-foreground">
                   {stats.sla_compliance}%
                 </span>
               </div>
@@ -186,13 +186,13 @@ export default function HelpdeskDashboardPage() {
         </div>
 
         {/* Avg Resolution Time */}
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4 flex items-center gap-2">
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
             <Clock className="h-4 w-4" /> {t("helpdeskDashboard.metrics.avgResolutionTime")}
           </h3>
           <div className="flex items-center justify-center mt-4">
             <div className="text-center">
-              <p className="text-4xl font-bold text-foreground">
+              <p className="text-4xl font-semibold tabular-nums text-foreground">
                 {stats.avg_resolution_hours}
               </p>
               <p className="text-sm text-muted-foreground mt-1">
@@ -203,8 +203,8 @@ export default function HelpdeskDashboardPage() {
         </div>
 
         {/* Satisfaction */}
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4 flex items-center gap-2">
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
             <Star className="h-4 w-4" /> {t("helpdeskDashboard.satisfaction.title")}
           </h3>
           <div className="flex items-center justify-center mt-4">
@@ -221,7 +221,7 @@ export default function HelpdeskDashboardPage() {
                   />
                 ))}
               </div>
-              <p className="text-2xl font-bold text-foreground">
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">
                 {stats.avg_satisfaction ?? t("helpdeskDashboard.satisfaction.notAvailable")}
               </p>
               <p className="text-xs text-muted-foreground mt-1">
@@ -235,9 +235,9 @@ export default function HelpdeskDashboardPage() {
       </div>
 
       {/* Category Breakdown */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8">
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">
             {t("helpdeskDashboard.categoryBreakdown.title")}
           </h3>
           <div className="space-y-3">
@@ -260,7 +260,7 @@ export default function HelpdeskDashboardPage() {
                     }}
                   />
                 </div>
-                <span className="text-sm font-medium text-muted-foreground w-8 text-right">
+                <span className="text-[13px] tabular-nums font-medium text-muted-foreground w-8 text-right">
                   {cat.count}
                 </span>
               </div>
@@ -274,8 +274,8 @@ export default function HelpdeskDashboardPage() {
         </div>
 
         {/* Recent Tickets */}
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4">
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">
             {t("helpdeskDashboard.recentTickets.title")}
           </h3>
           <div className="space-y-3">
@@ -283,7 +283,7 @@ export default function HelpdeskDashboardPage() {
               <Link
                 key={ticket.id}
                 to={`/helpdesk/tickets/${ticket.id}`}
-                className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-muted transition-colors"
+                className="flex items-center justify-between py-2 px-3 rounded-md hover:bg-muted/50 transition-colors"
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">

--- a/packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx
+++ b/packages/client/src/pages/helpdesk/KnowledgeBasePage.tsx
@@ -219,7 +219,7 @@ export default function KnowledgeBasePage() {
             <div className="flex items-center gap-2">
               <button
                 onClick={() => startEdit(selectedArticle)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
               >
                 <Pencil className="h-3.5 w-3.5" /> {t("kb.edit")}
               </button>
@@ -228,7 +228,7 @@ export default function KnowledgeBasePage() {
                   setDeleteTarget({ id: selectedArticle.id, title: selectedArticle.title });
                   setDeleteError(null);
                 }}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border border-red-200 rounded-lg text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40"
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-[13px] border border-red-200 dark:border-red-900/50 rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40"
               >
                 <Trash2 className="h-3.5 w-3.5" /> {t("kb.delete")}
               </button>
@@ -236,7 +236,7 @@ export default function KnowledgeBasePage() {
           )}
         </div>
 
-        <div className="bg-card rounded-xl border border-border p-8 max-w-3xl">
+        <div className="bg-card rounded-lg border border-border p-8 max-w-3xl">
           <div className="flex items-center gap-2 mb-3">
             <span
               className={`text-xs font-medium px-2 py-0.5 rounded ${
@@ -252,7 +252,7 @@ export default function KnowledgeBasePage() {
             )}
           </div>
 
-          <h1 className="text-2xl font-bold text-foreground mb-2">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground mb-2">
             {selectedArticle.title}
           </h1>
 
@@ -292,7 +292,7 @@ export default function KnowledgeBasePage() {
                   })
                 }
                 disabled={rateArticle.isPending}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium disabled:opacity-50 ${
+                className={`flex items-center gap-2 px-4 py-2 rounded-md border text-[13px] font-medium disabled:opacity-50 ${
                   currentVote === true
                     ? "border-green-500 bg-green-50 dark:bg-green-950/40 text-green-800 dark:text-green-200"
                     : "border-green-200 dark:border-green-900 text-green-700 dark:text-green-300 hover:bg-green-50 dark:hover:bg-green-950/40"
@@ -309,7 +309,7 @@ export default function KnowledgeBasePage() {
                   })
                 }
                 disabled={rateArticle.isPending}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium disabled:opacity-50 ${
+                className={`flex items-center gap-2 px-4 py-2 rounded-md border text-[13px] font-medium disabled:opacity-50 ${
                   currentVote === false
                     ? "border-red-500 bg-red-50 dark:bg-red-950/40 text-red-800 dark:text-red-200"
                     : "border-red-200 dark:border-red-900 text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/40"
@@ -327,9 +327,9 @@ export default function KnowledgeBasePage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("kb.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("kb.title")}</h1>
           <p className="text-muted-foreground mt-1">
             {t("kb.subtitle")}
           </p>
@@ -345,7 +345,7 @@ export default function KnowledgeBasePage() {
                 setShowForm(true);
               }
             }}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
           >
             <Plus className="h-4 w-4" /> {t("kb.newArticle")}
           </button>
@@ -354,28 +354,28 @@ export default function KnowledgeBasePage() {
 
       {/* Create / Edit Article Form */}
       {showForm && isHR && (
-        <div className="bg-card rounded-xl border border-border p-6 mb-6">
+        <div className="bg-card rounded-lg border border-border p-4 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground">
+            <h2 className="text-base font-semibold text-foreground">
               {editingId ? t("kb.editArticle") : t("kb.newKbArticle")}
             </h2>
             <button
               onClick={() => { setShowForm(false); resetForm(); }}
-              className="p-1 rounded-lg text-muted-foreground hover:bg-muted"
+              className="p-1 rounded-md text-muted-foreground hover:bg-muted"
             >
               <X className="h-5 w-5" />
             </button>
           </div>
           <form onSubmit={handleSubmitForm} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 {t("kb.titleLabel")}
               </label>
               <input
                 type="text"
                 value={formTitle}
                 onChange={(e) => setFormTitle(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("kb.titlePlaceholder")}
                 required
               />
@@ -383,13 +383,13 @@ export default function KnowledgeBasePage() {
 
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                   {t("kb.categoryLabel")}
                 </label>
                 <select
                   value={formCategory}
                   onChange={(e) => setFormCategory(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 >
                   {CATEGORIES.map((c) => (
                     <option key={c} value={c}>
@@ -421,7 +421,7 @@ export default function KnowledgeBasePage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 {t("kb.contentLabel")}
               </label>
               <RichTextEditor
@@ -435,7 +435,7 @@ export default function KnowledgeBasePage() {
               <button
                 type="button"
                 onClick={() => { setShowForm(false); resetForm(); }}
-                className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+                className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
               >
                 {t("kb.cancel")}
               </button>
@@ -447,7 +447,7 @@ export default function KnowledgeBasePage() {
                   !formTitle.trim() ||
                   isRichTextEmpty(formContent)
                 }
-                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <BookMarked className="h-4 w-4" />
                 {editingId
@@ -464,7 +464,7 @@ export default function KnowledgeBasePage() {
       )}
 
       {/* Search + Category Filter */}
-      <div className="bg-card rounded-xl border border-border p-4 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex flex-wrap items-center gap-3">
           <form
             onSubmit={handleSearch}
@@ -477,7 +477,7 @@ export default function KnowledgeBasePage() {
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder={t("kb.searchPlaceholder")}
-                className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <button
@@ -494,7 +494,7 @@ export default function KnowledgeBasePage() {
               setCategory("");
               setPage(1);
             }}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+            className={`px-3 py-1.5 rounded-md text-[13px] font-medium transition-colors ${
               !category
                 ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                 : "text-muted-foreground hover:bg-muted"
@@ -509,7 +509,7 @@ export default function KnowledgeBasePage() {
                 setCategory(c);
                 setPage(1);
               }}
-              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              className={`px-3 py-1.5 rounded-md text-[13px] font-medium transition-colors ${
                 category === c
                   ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                   : "text-muted-foreground hover:bg-muted"
@@ -523,11 +523,11 @@ export default function KnowledgeBasePage() {
 
       {/* Articles Grid */}
       {isLoading ? (
-        <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+        <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
           {t("kb.loading")}
         </div>
       ) : articles.length === 0 ? (
-        <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+        <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
           <BookMarked className="h-12 w-12 mx-auto mb-3 text-muted-foreground/50" />
           <p className="text-lg font-medium text-muted-foreground mb-1">
             {t("kb.noArticles")}
@@ -552,7 +552,7 @@ export default function KnowledgeBasePage() {
                   handleViewArticle(a.slug || a.id);
                 }
               }}
-              className="relative text-left bg-card rounded-xl border border-border p-5 hover:shadow-md transition-shadow cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500"
+              className="relative text-left bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-brand-500"
             >
               {isHR && (
                 <div className="absolute top-3 right-3 flex items-center gap-1">
@@ -636,14 +636,14 @@ export default function KnowledgeBasePage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               <ChevronLeft className="h-4 w-4" /> {t("kb.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("kb.next")} <ChevronRight className="h-4 w-4" />
             </button>
@@ -658,7 +658,7 @@ export default function KnowledgeBasePage() {
           onClick={() => !deleteArticle.isPending && setDeleteTarget(null)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -675,16 +675,16 @@ export default function KnowledgeBasePage() {
               </div>
             </div>
             {deleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
                 {deleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleteArticle.isPending}
-                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
+                className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
               >
                 {t("kb.cancel")}
               </button>
@@ -692,7 +692,7 @@ export default function KnowledgeBasePage() {
                 type="button"
                 onClick={() => deleteArticle.mutate(deleteTarget.id)}
                 disabled={deleteArticle.isPending}
-                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {deleteArticle.isPending ? (
                   <>

--- a/packages/client/src/pages/helpdesk/MyTicketsPage.tsx
+++ b/packages/client/src/pages/helpdesk/MyTicketsPage.tsx
@@ -89,16 +89,16 @@ export default function MyTicketsPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("helpdesk.myTicketsPage.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("helpdesk.myTicketsPage.title")}</h1>
           <p className="text-muted-foreground mt-1">
             {t("helpdesk.myTicketsPage.subtitle")}
           </p>
         </div>
         <button
           onClick={() => setShowForm(!showForm)}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {t("helpdesk.myTicketsPage.raiseTicket")}
         </button>
@@ -106,14 +106,14 @@ export default function MyTicketsPage() {
 
       {/* Create Ticket Form */}
       {showForm && (
-        <div className="bg-card rounded-xl border border-border p-6 mb-6">
+        <div className="bg-card rounded-lg border border-border p-4 mb-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground">
+            <h2 className="text-base font-semibold text-foreground">
               {t("helpdesk.myTicketsPage.newTicket")}
             </h2>
             <button
               onClick={() => setShowForm(false)}
-              className="p-1 rounded-lg text-muted-foreground hover:bg-muted hover:text-muted-foreground"
+              className="p-1 rounded-md text-muted-foreground hover:bg-muted hover:text-muted-foreground"
             >
               <X className="h-5 w-5" />
             </button>
@@ -121,13 +121,13 @@ export default function MyTicketsPage() {
           <form onSubmit={handleCreate} className="space-y-4">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                   {t("helpdesk.myTicketsPage.category")}
                 </label>
                 <select
                   value={formCategory}
                   onChange={(e) => setFormCategory(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 >
                   {CATEGORIES.map((c) => (
                     <option key={c} value={c}>
@@ -137,13 +137,13 @@ export default function MyTicketsPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">
+                <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                   {t("helpdesk.myTicketsPage.priorityLabel")}
                 </label>
                 <select
                   value={formPriority}
                   onChange={(e) => setFormPriority(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 >
                   {PRIORITIES.map((p) => (
                     <option key={p} value={p}>
@@ -155,21 +155,21 @@ export default function MyTicketsPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 {t("helpdesk.myTicketsPage.subject")}
               </label>
               <input
                 type="text"
                 value={formSubject}
                 onChange={(e) => setFormSubject(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("helpdesk.myTicketsPage.subjectPlaceholder")}
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 {t("helpdesk.myTicketsPage.description")}
               </label>
               <RichTextEditor
@@ -183,14 +183,14 @@ export default function MyTicketsPage() {
               <button
                 type="button"
                 onClick={() => setShowForm(false)}
-                className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+                className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
               >
                 {t("helpdesk.myTicketsPage.cancel")}
               </button>
               <button
                 type="submit"
                 disabled={createTicket.isPending || !formSubject.trim() || isRichTextEmpty(formDescription)}
-                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <TicketCheck className="h-4 w-4" />
                 {createTicket.isPending ? t("helpdesk.myTicketsPage.submitting") : t("helpdesk.myTicketsPage.submit")}
@@ -204,7 +204,7 @@ export default function MyTicketsPage() {
       <div className="flex items-center gap-2 mb-4">
         <button
           onClick={() => { setStatusFilter(""); setPage(1); }}
-          className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+          className={`px-3 py-1.5 rounded-md text-[13px] font-medium transition-colors ${
             !statusFilter ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300" : "text-muted-foreground hover:bg-muted"
           }`}
         >
@@ -214,7 +214,7 @@ export default function MyTicketsPage() {
           <button
             key={s}
             onClick={() => { setStatusFilter(s); setPage(1); }}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+            className={`px-3 py-1.5 rounded-md text-[13px] font-medium transition-colors ${
               statusFilter === s
                 ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                 : "text-muted-foreground hover:bg-muted"
@@ -230,7 +230,7 @@ export default function MyTicketsPage() {
         {isLoading ? (
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-card rounded-xl border border-border p-4 animate-pulse">
+              <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
@@ -247,7 +247,7 @@ export default function MyTicketsPage() {
             ))}
           </div>
         ) : tickets.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             <TicketCheck className="h-12 w-12 mx-auto mb-3 text-muted-foreground/50" />
             <p className="text-lg font-medium text-muted-foreground mb-1">{t("helpdesk.myTicketsPage.noTickets")}</p>
             <p className="text-sm">
@@ -259,7 +259,7 @@ export default function MyTicketsPage() {
             <Link
               key={ticket.id}
               to={`/helpdesk/tickets/${ticket.id}`}
-              className="block bg-card rounded-xl border border-border p-4 hover:shadow-md transition-shadow"
+              className="block bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
             >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
@@ -280,7 +280,7 @@ export default function MyTicketsPage() {
                       {t(`helpdesk.myTicketsPage.status.${ticket.status}`, { defaultValue: ticket.status.replace(/_/g, " ") })}
                     </span>
                   </div>
-                  <h3 className="text-sm font-semibold text-foreground truncate">
+                  <h3 className="text-[13px] font-semibold text-foreground truncate">
                     {ticket.subject}
                   </h3>
                   <p className="text-xs text-muted-foreground mt-1 line-clamp-1">
@@ -313,14 +313,14 @@ export default function MyTicketsPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               <ChevronLeft className="h-4 w-4" /> {t("helpdesk.myTicketsPage.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("helpdesk.myTicketsPage.next")} <ChevronRight className="h-4 w-4" />
             </button>

--- a/packages/client/src/pages/helpdesk/TicketDetailPage.tsx
+++ b/packages/client/src/pages/helpdesk/TicketDetailPage.tsx
@@ -202,13 +202,13 @@ export default function TicketDetailPage() {
       </Link>
 
       {/* Ticket Header */}
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex flex-col lg:flex-row lg:items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-2 flex-wrap">
               <span className="text-sm text-muted-foreground font-mono">#{ticket.id}</span>
               <span
-                className={`text-xs font-medium px-2.5 py-0.5 rounded-full border capitalize ${
+                className={`text-[11px] font-medium px-2.5 py-0.5 rounded-md border capitalize ${
                   PRIORITY_COLORS[ticket.priority] || ""
                 }`}
               >
@@ -236,7 +236,7 @@ export default function TicketDetailPage() {
                 </span>
               )}
             </div>
-            <h1 className="text-xl font-bold text-foreground">{ticket.subject}</h1>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">{ticket.subject}</h1>
             <div
               className={`rich-text text-sm text-muted-foreground mt-2 dark:[&]:text-slate-300 dark:[&_h1]:text-slate-100 dark:[&_h2]:text-slate-100 ${isHtmlContent(ticket.description) ? "" : "whitespace-pre-wrap"}`}
               dangerouslySetInnerHTML={{ __html: ticket.description || "" }}
@@ -255,7 +255,7 @@ export default function TicketDetailPage() {
           </div>
 
           {/* SLA info */}
-          <div className="shrink-0 bg-muted rounded-lg p-4 min-w-[200px]">
+          <div className="shrink-0 bg-muted rounded-md p-4 min-w-[200px]">
             <h4 className="text-xs font-semibold text-muted-foreground mb-2 flex items-center gap-1">
               <Clock className="h-3.5 w-3.5" /> {t("ticketDetail.slaDeadlines")}
             </h4>
@@ -293,7 +293,7 @@ export default function TicketDetailPage() {
           {isHR && (
             <button
               onClick={() => setShowAssignForm(!showAssignForm)}
-              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-border text-muted-foreground hover:bg-muted"
+              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md border border-border text-muted-foreground hover:bg-muted"
             >
               <UserPlus className="h-3.5 w-3.5" /> {t("ticketDetail.action.assign")}
             </button>
@@ -302,7 +302,7 @@ export default function TicketDetailPage() {
             <button
               onClick={() => resolveMutation.mutate()}
               disabled={resolveMutation.isPending}
-              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
             >
               <CheckCircle2 className="h-3.5 w-3.5" /> {t("ticketDetail.action.resolve")}
             </button>
@@ -311,7 +311,7 @@ export default function TicketDetailPage() {
             <button
               onClick={() => closeMutation.mutate()}
               disabled={closeMutation.isPending}
-              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-border text-muted-foreground hover:bg-muted disabled:opacity-50"
+              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md border border-border text-muted-foreground hover:bg-muted disabled:opacity-50"
             >
               <XCircle className="h-3.5 w-3.5" /> {t("ticketDetail.action.close")}
             </button>
@@ -320,7 +320,7 @@ export default function TicketDetailPage() {
             <button
               onClick={() => reopenMutation.mutate()}
               disabled={reopenMutation.isPending}
-              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-orange-200 dark:border-orange-900 text-orange-700 dark:text-orange-300 hover:bg-orange-50 dark:hover:bg-orange-950/40 disabled:opacity-50"
+              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md border border-orange-200 dark:border-orange-900 text-orange-700 dark:text-orange-300 hover:bg-orange-50 dark:hover:bg-orange-950/40 disabled:opacity-50"
             >
               <RotateCcw className="h-3.5 w-3.5" /> {t("ticketDetail.action.reopen")}
             </button>
@@ -328,7 +328,7 @@ export default function TicketDetailPage() {
           {canRate && (
             <button
               onClick={() => setShowRatingForm(!showRatingForm)}
-              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-lg border border-yellow-200 dark:border-yellow-900 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-50 dark:hover:bg-yellow-950/40"
+              className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md border border-yellow-200 dark:border-yellow-900 text-yellow-700 dark:text-yellow-300 hover:bg-yellow-50 dark:hover:bg-yellow-950/40"
             >
               <Star className="h-3.5 w-3.5" /> {t("ticketDetail.action.rateService")}
             </button>
@@ -337,11 +337,11 @@ export default function TicketDetailPage() {
 
         {/* Assign Form */}
         {showAssignForm && isHR && (
-          <form onSubmit={handleAssign} className="mt-3 flex items-center gap-2 p-3 bg-muted rounded-lg">
+          <form onSubmit={handleAssign} className="mt-3 flex items-center gap-2 p-3 bg-muted rounded-md">
             <select
               value={assignUserId}
               onChange={(e) => setAssignUserId(e.target.value)}
-              className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-md text-[13px]"
             >
               <option value="">{t("ticketDetail.assign.selectUser")}</option>
               {(usersData || [])
@@ -390,7 +390,7 @@ export default function TicketDetailPage() {
               value={ratingComment}
               onChange={(e) => setRatingComment(e.target.value)}
               placeholder={t("ticketDetail.rating.feedbackPlaceholder")}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[60px] mb-3"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[60px] mb-3"
             />
             <button
               type="submit"
@@ -430,7 +430,7 @@ export default function TicketDetailPage() {
       </div>
 
       {/* Conversation Thread */}
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <h3 className="text-sm font-semibold text-muted-foreground mb-4">{t("ticketDetail.conversation")}</h3>
 
         {ticket.comments && ticket.comments.length > 0 ? (
@@ -440,7 +440,7 @@ export default function TicketDetailPage() {
               return (
                 <div
                   key={c.id}
-                  className={`p-4 rounded-lg ${
+                  className={`p-4 rounded-md ${
                     c.is_internal
                       ? "bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900"
                       : isSelf
@@ -481,13 +481,13 @@ export default function TicketDetailPage() {
 
       {/* Reply Input */}
       {canReply && ticket.status !== "closed" && (
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <form onSubmit={handleComment}>
             <textarea
               value={comment}
               onChange={(e) => setComment(e.target.value)}
               placeholder={t("ticketDetail.replyPlaceholder")}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[80px] mb-3"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[80px] mb-3"
               required
             />
             <div className="flex items-center justify-between">
@@ -508,7 +508,7 @@ export default function TicketDetailPage() {
               <button
                 type="submit"
                 disabled={addCommentMutation.isPending || !comment.trim()}
-                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
               >
                 <Send className="h-4 w-4" />
                 {addCommentMutation.isPending ? t("ticketDetail.sending") : t("ticketDetail.sendReply")}

--- a/packages/client/src/pages/helpdesk/TicketListPage.tsx
+++ b/packages/client/src/pages/helpdesk/TicketListPage.tsx
@@ -112,15 +112,15 @@ export default function TicketListPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("helpdesk.list.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("helpdesk.list.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("helpdesk.list.subtitle")}</p>
         </div>
       </div>
 
       {/* Filters */}
-      <div className="bg-card rounded-xl border border-border p-4 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex flex-wrap items-center gap-3">
           <form onSubmit={handleSearch} className="flex items-center gap-2 flex-1 min-w-[200px]">
             <div className="relative flex-1">
@@ -130,12 +130,12 @@ export default function TicketListPage() {
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder={t("helpdesk.list.searchPlaceholder")}
-                className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <button
               type="submit"
-              className="px-3 py-2 bg-brand-600 text-white text-sm rounded-lg hover:bg-brand-700"
+              className="px-3 py-2 bg-brand-600 text-white text-[13px] rounded-md hover:bg-brand-700"
             >
               {t("helpdesk.list.search")}
             </button>
@@ -144,7 +144,7 @@ export default function TicketListPage() {
           <select
             value={status}
             onChange={(e) => { setStatus(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("helpdesk.list.allStatuses")}</option>
             {STATUSES.map((s) => (
@@ -157,7 +157,7 @@ export default function TicketListPage() {
           <select
             value={category}
             onChange={(e) => { setCategory(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("helpdesk.list.allCategories")}</option>
             {CATEGORIES.map((c) => (
@@ -170,7 +170,7 @@ export default function TicketListPage() {
           <select
             value={priority}
             onChange={(e) => { setPriority(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("helpdesk.list.allPriorities")}</option>
             {PRIORITIES.map((p) => (
@@ -182,7 +182,7 @@ export default function TicketListPage() {
         </div>
         {resolvedDate && (
           <div className="mt-3 flex items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 text-xs font-medium">
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-md bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 text-xs font-medium">
               {resolvedDate === "today" ? t("helpdesk.list.resolvedToday") : t("helpdesk.list.resolvedOn", { date: resolvedDate })}
               <button
                 type="button"
@@ -198,7 +198,7 @@ export default function TicketListPage() {
       </div>
 
       {/* Tickets Table */}
-      <div className="bg-card rounded-xl border border-border overflow-hidden">
+      <div className="bg-card rounded-lg border border-border overflow-hidden">
         {isLoading ? (
           <div className="p-8 text-center text-muted-foreground">{t("helpdesk.list.loading")}</div>
         ) : tickets.length === 0 ? (
@@ -208,15 +208,15 @@ export default function TicketListPage() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border bg-muted">
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colId")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colSubject")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colCategory")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colPriority")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colStatus")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colRaisedBy")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colAssignedTo")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colSla")}</th>
-                  <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t("helpdesk.list.colCreated")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colId")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colSubject")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colCategory")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colPriority")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colStatus")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colRaisedBy")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colAssignedTo")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colSla")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("helpdesk.list.colCreated")}</th>
                 </tr>
               </thead>
               <tbody>
@@ -225,9 +225,9 @@ export default function TicketListPage() {
                   return (
                     <tr
                       key={ticket.id}
-                      className="border-b border-border hover:bg-muted transition-colors"
+                      className="border-b border-border hover:bg-muted/50 transition-colors"
                     >
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         <Link
                           to={`/helpdesk/tickets/${ticket.id}`}
                           className="text-brand-600 dark:text-brand-400 font-medium hover:underline"
@@ -235,7 +235,7 @@ export default function TicketListPage() {
                           #{ticket.id}
                         </Link>
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         <Link
                           to={`/helpdesk/tickets/${ticket.id}`}
                           className="text-foreground hover:text-brand-600 font-medium truncate block max-w-[250px]"
@@ -243,10 +243,10 @@ export default function TicketListPage() {
                           {ticket.subject}
                         </Link>
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         <span className="text-muted-foreground">{t(`helpdesk.list.category.${ticket.category}`, { defaultValue: ticket.category })}</span>
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         <span
                           className={`text-xs font-medium px-2 py-0.5 rounded ${
                             PRIORITY_COLORS[ticket.priority] || ""
@@ -255,7 +255,7 @@ export default function TicketListPage() {
                           {t(`helpdesk.list.priority.${ticket.priority}`, { defaultValue: ticket.priority })}
                         </span>
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         <span
                           className={`text-xs font-medium px-2 py-0.5 rounded ${
                             STATUS_COLORS[ticket.status] || ""
@@ -264,15 +264,15 @@ export default function TicketListPage() {
                           {t(`helpdesk.list.status.${ticket.status}`, { defaultValue: ticket.status.replace(/_/g, " ") })}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className="px-4 py-2.5 text-muted-foreground">
                         {ticket.raised_by_name || "-"}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className="px-4 py-2.5 text-muted-foreground">
                         {ticket.assigned_to_name || (
                           <span className="text-muted-foreground italic">{t("helpdesk.list.unassigned")}</span>
                         )}
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         {sla ? (
                           <span
                             className={`text-xs font-medium px-2 py-0.5 rounded ${
@@ -285,7 +285,7 @@ export default function TicketListPage() {
                           <span className="text-xs text-muted-foreground">-</span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground text-xs">
+                      <td className="px-4 py-2.5 text-muted-foreground text-xs">
                         {new Date(ticket.created_at).toLocaleDateString()}
                       </td>
                     </tr>
@@ -307,14 +307,14 @@ export default function TicketListPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50 hover:bg-muted"
+              className="flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50 hover:bg-muted"
             >
               <ChevronLeft className="h-4 w-4" /> {t("helpdesk.list.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50 hover:bg-muted"
+              className="flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50 hover:bg-muted"
             >
               {t("helpdesk.list.next")} <ChevronRight className="h-4 w-4" />
             </button>


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) to the **Helpdesk + Feedback** modules — **PR 1 of 3** for the Engagement area (26 pages total, split by sub-module pairs).

**Pages (9):** Helpdesk Dashboard, Knowledge Base, My Tickets, Ticket Detail, Ticket List · Feedback Dashboard, Feedback List, My Feedback, Submit Feedback.

- Compact headers; `rounded-lg` cards / `rounded-md` controls; `text-[11px]` uppercase table + panel headers; `px-4 py-2.5` dense rows; `tabular-nums` on counts / dates / ratings / SLA percentages; `rounded-md` status / priority / category pills; KPI stat tiles.
- **Preserved as chrome/decoration:** modal titles keep `text-lg`, modal header/footer + body padding unchanged; avatars, dialog icon circles, progress-bar tracks, star-rating, sentiment and category chart-bar colors all left untouched.

No dark-mode bugs found in this batch (every colored tint already pairs a dark text — this module family is consistent).

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.

Next: PR 2 = Wellness + Events, PR 3 = Forum + Surveys.