### PR TITLE
ui: enterprise-density uplift for Wellness + Events (engagement 2/3, 9 pages)

### DIFF
--- a/packages/client/src/pages/events/EventDashboardPage.tsx
+++ b/packages/client/src/pages/events/EventDashboardPage.tsx
@@ -212,9 +212,9 @@ export default function EventDashboardPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("eventDashboard.header.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("eventDashboard.header.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("eventDashboard.header.subtitle")}</p>
         </div>
         <button
@@ -228,7 +228,7 @@ export default function EventDashboardPage() {
               setShowForm(true);
             }
           }}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {t("eventDashboard.header.createEvent")}
         </button>
@@ -246,17 +246,17 @@ export default function EventDashboardPage() {
             const Icon = card.icon;
             const content = (
               <div className="flex items-center gap-3 mb-2">
-                <div className={`h-10 w-10 rounded-lg ${card.iconBg} flex items-center justify-center`}>
+                <div className={`h-10 w-10 rounded-md ${card.iconBg} flex items-center justify-center`}>
                   <Icon className={`h-5 w-5 ${card.iconColor}`} />
                 </div>
                 <div>
                   <p className="text-xs text-muted-foreground">{card.label}</p>
-                  <p className="text-xl font-bold text-foreground">{card.value}</p>
+                  <p className="text-xl font-semibold tabular-nums text-foreground">{card.value}</p>
                 </div>
               </div>
             );
             const sharedClass =
-              "block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500";
+              "block text-left w-full bg-card rounded-lg border border-border p-5 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500";
             if ("href" in card) {
               return (
                 <Link key={card.label} to={card.href} className={sharedClass}>
@@ -282,20 +282,20 @@ export default function EventDashboardPage() {
 
       {/* Type Breakdown */}
       {dashboard?.type_breakdown?.length > 0 && (
-        <div id="type-breakdown" className="bg-card rounded-xl border border-border p-6 mb-6 scroll-mt-4">
-          <h2 className="text-sm font-semibold text-muted-foreground mb-3">{t("eventDashboard.typeBreakdown.title")}</h2>
+        <div id="type-breakdown" className="bg-card rounded-lg border border-border p-4 mb-6 scroll-mt-4">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-3">{t("eventDashboard.typeBreakdown.title")}</h2>
           <div className="flex flex-wrap gap-3">
             {dashboard.type_breakdown.map((tb: any) => (
               <div
                 key={tb.event_type}
-                className="flex items-center gap-2 bg-muted px-3 py-1.5 rounded-lg"
+                className="flex items-center gap-2 bg-muted px-3 py-1.5 rounded-md"
               >
                 <span className="text-sm font-medium text-muted-foreground">
                   {t(`eventDashboard.eventType.${tb.event_type}`, {
                     defaultValue: EVENT_TYPE_LABELS[tb.event_type] || tb.event_type,
                   })}
                 </span>
-                <span className="text-xs bg-brand-100 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 px-2 py-0.5 rounded-full font-semibold">
+                <span className="text-[11px] tabular-nums bg-brand-100 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 px-2 py-0.5 rounded-md font-semibold">
                   {tb.count}
                 </span>
               </div>
@@ -306,8 +306,8 @@ export default function EventDashboardPage() {
 
       {/* Create / Edit Event Form */}
       {showForm && (
-        <form onSubmit={handleSubmit} className="bg-card rounded-xl border border-border p-6 mb-6 space-y-4">
-          <h2 className="text-lg font-semibold text-foreground">
+        <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 mb-6 space-y-4">
+          <h2 className="text-base font-semibold text-foreground">
             {editingId != null ? t("eventDashboard.form.editTitle") : t("eventDashboard.form.title")}
           </h2>
 
@@ -318,7 +318,7 @@ export default function EventDashboardPage() {
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("eventDashboard.form.placeholders.title")}
                 required
               />
@@ -329,7 +329,7 @@ export default function EventDashboardPage() {
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[80px]"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[80px]"
                 placeholder={t("eventDashboard.form.placeholders.description")}
               />
             </div>
@@ -343,7 +343,7 @@ export default function EventDashboardPage() {
                   setEventType(nextType);
                   if (nextType === "holiday") setVirtualLink("");
                 }}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 {EVENT_TYPES.map((type) => (
                   <option key={type} value={type}>
@@ -380,7 +380,7 @@ export default function EventDashboardPage() {
                 type="datetime-local"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
@@ -392,7 +392,7 @@ export default function EventDashboardPage() {
                 value={endDate}
                 onChange={(e) => { setEndDate(e.target.value); setDateError(""); }}
                 min={startDate || undefined}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
 
@@ -404,7 +404,7 @@ export default function EventDashboardPage() {
                   type="text"
                   value={location}
                   onChange={(e) => setLocation(e.target.value)}
-                  className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder={t("eventDashboard.form.placeholders.location")}
                 />
               </div>
@@ -419,7 +419,7 @@ export default function EventDashboardPage() {
                     type="url"
                     value={virtualLink}
                     onChange={(e) => setVirtualLink(e.target.value)}
-                    className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-md text-[13px]"
                     placeholder={t("eventDashboard.form.placeholders.virtualLink")}
                   />
                 </div>
@@ -431,7 +431,7 @@ export default function EventDashboardPage() {
               <select
                 value={targetType}
                 onChange={(e) => setTargetType(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="all">{t("eventDashboard.form.targetType.all")}</option>
                 <option value="department">{t("eventDashboard.form.targetType.department")}</option>
@@ -446,7 +446,7 @@ export default function EventDashboardPage() {
                   type="text"
                   value={targetIds}
                   onChange={(e) => setTargetIds(e.target.value)}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder='["1","2"]'
                 />
               </div>
@@ -460,7 +460,7 @@ export default function EventDashboardPage() {
                   type="number"
                   value={maxAttendees}
                   onChange={(e) => setMaxAttendees(e.target.value)}
-                  className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full pl-9 pr-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder={t("eventDashboard.form.placeholders.maxAttendees")}
                   min="1"
                 />
@@ -485,7 +485,7 @@ export default function EventDashboardPage() {
             <button
               type="submit"
               disabled={createMutation.isPending || updateMutation.isPending}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               <Calendar className="h-4 w-4" />{" "}
               {editingId != null ? t("eventDashboard.form.updateSubmit") : t("eventDashboard.form.submit")}
@@ -495,9 +495,9 @@ export default function EventDashboardPage() {
       )}
 
       {/* Upcoming Events */}
-      <div className="bg-card rounded-xl border border-border">
+      <div className="bg-card rounded-lg border border-border">
         <div className="p-4 border-b border-border flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-muted-foreground">{t("eventDashboard.upcoming.title")}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("eventDashboard.upcoming.title")}</h2>
           <Link to="/events" className="text-xs text-brand-600 dark:text-brand-400 hover:underline">
             {t("eventDashboard.upcoming.viewAll")}
           </Link>
@@ -511,7 +511,7 @@ export default function EventDashboardPage() {
             </div>
           ) : (
             dashboard.upcoming_events.map((event: any) => (
-              <div key={event.id} className="p-4 flex items-center justify-between hover:bg-muted">
+              <div key={event.id} className="p-4 flex items-center justify-between hover:bg-muted/50 transition-colors">
                 <div className="flex-1 min-w-0">
                   <Link
                     to={`/events/${event.id}`}
@@ -585,7 +585,7 @@ export default function EventDashboardPage() {
           onClick={() => !deleteMutation.isPending && setDeleteTarget(null)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -602,16 +602,16 @@ export default function EventDashboardPage() {
               </div>
             </div>
             {deleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
                 {deleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleteMutation.isPending}
-                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
+                className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
               >
                 {t("eventDashboard.deleteModal.cancel")}
               </button>
@@ -619,7 +619,7 @@ export default function EventDashboardPage() {
                 type="button"
                 onClick={() => deleteMutation.mutate(deleteTarget.id)}
                 disabled={deleteMutation.isPending}
-                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {deleteMutation.isPending ? (
                   <>

--- a/packages/client/src/pages/events/EventDetailPage.tsx
+++ b/packages/client/src/pages/events/EventDetailPage.tsx
@@ -88,7 +88,7 @@ export default function EventDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+      <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
         {t("eventDetail.state.loading")}
       </div>
     );
@@ -96,7 +96,7 @@ export default function EventDetailPage() {
 
   if (!data) {
     return (
-      <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+      <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
         {t("eventDetail.state.notFound")}
       </div>
     );
@@ -131,24 +131,24 @@ export default function EventDetailPage() {
         )}
       </div>
 
-      <div className="bg-card rounded-xl border border-border overflow-hidden">
+      <div className="bg-card rounded-lg border border-border overflow-hidden">
         {/* Header */}
         <div className="p-6 border-b border-border">
           <div className="flex items-center gap-2 mb-3 flex-wrap">
-            <span className={`inline-flex items-center text-xs font-medium px-2.5 py-0.5 rounded-full ${typeConfig.color}`}>
+            <span className={`inline-flex items-center text-[11px] font-medium px-2.5 py-0.5 rounded-md ${typeConfig.color}`}>
               {t(`eventDetail.type.${typeConfig.labelKey}`)}
             </span>
-            <span className={`inline-flex items-center text-xs font-medium px-2.5 py-0.5 rounded-full ${statusConfig.color}`}>
+            <span className={`inline-flex items-center text-[11px] font-medium px-2.5 py-0.5 rounded-md ${statusConfig.color}`}>
               {t(`eventDetail.status.${statusConfig.labelKey}`)}
             </span>
             {event.is_mandatory && (
-              <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400">
+              <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400">
                 <Star className="h-3 w-3" /> {t("eventDetail.badge.mandatory")}
               </span>
             )}
           </div>
 
-          <h1 className="text-2xl font-bold text-foreground">{event.title}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{event.title}</h1>
 
           {event.description && (
             <p className="mt-3 text-muted-foreground leading-relaxed whitespace-pre-wrap">
@@ -160,12 +160,12 @@ export default function EventDetailPage() {
         {/* Details */}
         <div className="p-6 border-b border-border grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
               <Calendar className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             </div>
             <div>
               <p className="text-xs text-muted-foreground">{t("eventDetail.details.dateLabel")}</p>
-              <p className="text-sm font-medium text-foreground">
+              <p className="text-[13px] font-medium text-foreground">
                 {event.is_all_day
                   ? new Date(event.start_date).toLocaleDateString("en-US", {
                       weekday: "long",
@@ -185,19 +185,19 @@ export default function EventDetailPage() {
 
           {event.location && (
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-green-50 dark:bg-green-950/40 flex items-center justify-center">
+              <div className="h-10 w-10 rounded-md bg-green-50 dark:bg-green-950/40 flex items-center justify-center">
                 <MapPin className="h-5 w-5 text-green-600 dark:text-green-400" />
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">{t("eventDetail.details.locationLabel")}</p>
-                <p className="text-sm font-medium text-foreground">{event.location}</p>
+                <p className="text-[13px] font-medium text-foreground">{event.location}</p>
               </div>
             </div>
           )}
 
           {event.virtual_link && (
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-purple-50 dark:bg-purple-950/40 flex items-center justify-center">
+              <div className="h-10 w-10 rounded-md bg-purple-50 dark:bg-purple-950/40 flex items-center justify-center">
                 <Video className="h-5 w-5 text-purple-600 dark:text-purple-400" />
               </div>
               <div>
@@ -215,12 +215,12 @@ export default function EventDetailPage() {
           )}
 
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-amber-50 dark:bg-amber-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-amber-50 dark:bg-amber-950/40 flex items-center justify-center">
               <Users className="h-5 w-5 text-amber-600 dark:text-amber-400" />
             </div>
             <div>
               <p className="text-xs text-muted-foreground">{t("eventDetail.details.attendeesLabel")}</p>
-              <p className="text-sm font-medium text-foreground">
+              <p className="text-[13px] font-medium text-foreground">
                 {t("eventDetail.details.attendingCount", { count: event.attending_count || 0 })}
                 {event.maybe_count > 0 &&
                   t("eventDetail.details.maybeSuffix", { count: event.maybe_count })}
@@ -247,7 +247,7 @@ export default function EventDetailPage() {
               <button
                 onClick={() => rsvpMutation.mutate("attending")}
                 disabled={rsvpMutation.isPending}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border transition-colors disabled:opacity-50 ${
+                className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium border transition-colors disabled:opacity-50 ${
                   myRsvp?.status === "attending"
                     ? "bg-green-50 dark:bg-green-950/40 border-green-300 dark:border-green-800 text-green-700 dark:text-green-300"
                     : "border-border text-muted-foreground hover:bg-green-50 dark:hover:bg-green-950/40 hover:border-green-300 dark:hover:border-green-800 hover:text-green-700 dark:hover:text-green-300"
@@ -258,7 +258,7 @@ export default function EventDetailPage() {
               <button
                 onClick={() => rsvpMutation.mutate("maybe")}
                 disabled={rsvpMutation.isPending}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border transition-colors disabled:opacity-50 ${
+                className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium border transition-colors disabled:opacity-50 ${
                   myRsvp?.status === "maybe"
                     ? "bg-amber-50 dark:bg-amber-950/40 border-amber-300 dark:border-amber-800 text-amber-700 dark:text-amber-300"
                     : "border-border text-muted-foreground hover:bg-amber-50 dark:hover:bg-amber-950/40 hover:border-amber-300 dark:hover:border-amber-800 hover:text-amber-700 dark:hover:text-amber-300"
@@ -269,7 +269,7 @@ export default function EventDetailPage() {
               <button
                 onClick={() => rsvpMutation.mutate("declined")}
                 disabled={rsvpMutation.isPending}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border transition-colors disabled:opacity-50 ${
+                className={`flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium border transition-colors disabled:opacity-50 ${
                   myRsvp?.status === "declined"
                     ? "bg-red-50 dark:bg-red-950/40 border-red-300 dark:border-red-800 text-red-700 dark:text-red-300"
                     : "border-border text-muted-foreground hover:bg-red-50 dark:hover:bg-red-950/40 hover:border-red-300 dark:hover:border-red-800 hover:text-red-700 dark:hover:text-red-300"
@@ -293,7 +293,7 @@ export default function EventDetailPage() {
                   {attendingRsvps.map((r: any) => (
                     <span
                       key={r.user_id}
-                      className="inline-flex items-center gap-1.5 text-xs bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2.5 py-1 rounded-full"
+                      className="inline-flex items-center gap-1.5 text-[11px] bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2.5 py-1 rounded-md"
                     >
                       <User className="h-3 w-3" />
                       {r.first_name} {r.last_name}
@@ -311,7 +311,7 @@ export default function EventDetailPage() {
                   {maybeRsvps.map((r: any) => (
                     <span
                       key={r.user_id}
-                      className="inline-flex items-center gap-1.5 text-xs bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 px-2.5 py-1 rounded-full"
+                      className="inline-flex items-center gap-1.5 text-[11px] bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 px-2.5 py-1 rounded-md"
                     >
                       <User className="h-3 w-3" />
                       {r.first_name} {r.last_name}
@@ -331,7 +331,7 @@ export default function EventDetailPage() {
           onClick={() => !deleteMutation.isPending && setShowDelete(false)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -348,16 +348,16 @@ export default function EventDetailPage() {
               </div>
             </div>
             {deleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
                 {deleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setShowDelete(false)}
                 disabled={deleteMutation.isPending}
-                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
+                className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
               >
                 {t("eventDetail.delete.cancel")}
               </button>
@@ -365,7 +365,7 @@ export default function EventDetailPage() {
                 type="button"
                 onClick={() => deleteMutation.mutate()}
                 disabled={deleteMutation.isPending}
-                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {deleteMutation.isPending ? (
                   <>

--- a/packages/client/src/pages/events/EventsListPage.tsx
+++ b/packages/client/src/pages/events/EventsListPage.tsx
@@ -110,15 +110,15 @@ export default function EventsListPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("events.list.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("events.list.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("events.list.subtitle")}</p>
         </div>
         {isHR && (
           <Link
             to="/events/dashboard"
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
           >
             <Plus className="h-4 w-4" /> {t("events.list.manage")}
           </Link>
@@ -132,7 +132,7 @@ export default function EventsListPage() {
           <select
             value={typeFilter}
             onChange={(e) => { setTypeFilter(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-1.5 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-1.5 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("events.list.allTypes")}</option>
             {Object.entries(EVENT_TYPE_CONFIG).map(([key, cfg]) => (
@@ -143,7 +143,7 @@ export default function EventsListPage() {
         <select
           value={statusFilter}
           onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-          className="bg-card text-foreground px-3 py-1.5 border border-border rounded-lg text-sm"
+          className="bg-card text-foreground px-3 py-1.5 border border-border rounded-md text-[13px]"
         >
           <option value="">{t("events.list.allStatuses")}</option>
           {Object.entries(STATUS_CONFIG).map(([key, cfg]) => (
@@ -155,11 +155,11 @@ export default function EventsListPage() {
       {/* Event Cards */}
       <div className="space-y-4">
         {isLoading ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             {t("events.list.loading")}
           </div>
         ) : events.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">
             {t("events.list.empty")}
           </div>
         ) : (
@@ -170,20 +170,20 @@ export default function EventsListPage() {
             return (
               <div
                 key={event.id}
-                className="bg-card rounded-xl border border-border p-6 hover:shadow-md transition-shadow"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     {/* Badges */}
                     <div className="flex items-center gap-2 mb-2 flex-wrap">
-                      <span className={`inline-flex items-center text-xs font-medium px-2.5 py-0.5 rounded-full ${typeConfig.color}`}>
+                      <span className={`inline-flex items-center text-[11px] font-medium px-2.5 py-0.5 rounded-md ${typeConfig.color}`}>
                         {t(`events.list.type.${event.event_type}`, { defaultValue: typeConfig.label })}
                       </span>
-                      <span className={`inline-flex items-center text-xs font-medium px-2.5 py-0.5 rounded-full ${statusConfig.color}`}>
+                      <span className={`inline-flex items-center text-[11px] font-medium px-2.5 py-0.5 rounded-md ${statusConfig.color}`}>
                         {t(`events.list.status.${event.status}`, { defaultValue: statusConfig.label })}
                       </span>
                       {event.is_mandatory && (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400">
+                        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400">
                           <Star className="h-3 w-3" /> {t("events.list.mandatory")}
                         </span>
                       )}
@@ -256,7 +256,7 @@ export default function EventsListPage() {
                         <button
                           onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "attending" })}
                           disabled={rsvpMutation.isPending}
-                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
+                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-md disabled:opacity-50 ${
                             event.my_rsvp_status === "attending"
                               ? "bg-green-100 dark:bg-green-950/40 border-green-400 dark:border-green-700 text-green-700 dark:text-green-300"
                               : "border-green-200 dark:border-green-900 text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-950/40"
@@ -268,7 +268,7 @@ export default function EventsListPage() {
                         <button
                           onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "maybe" })}
                           disabled={rsvpMutation.isPending}
-                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
+                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-md disabled:opacity-50 ${
                             event.my_rsvp_status === "maybe"
                               ? "bg-amber-100 dark:bg-amber-950/40 border-amber-400 dark:border-amber-700 text-amber-700 dark:text-amber-300"
                               : "border-amber-200 dark:border-amber-900 text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-950/40"
@@ -280,7 +280,7 @@ export default function EventsListPage() {
                         <button
                           onClick={() => rsvpMutation.mutate({ eventId: event.id, status: "declined" })}
                           disabled={rsvpMutation.isPending}
-                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-lg disabled:opacity-50 ${
+                          className={`flex items-center gap-1 text-xs font-medium border px-2.5 py-1.5 rounded-md disabled:opacity-50 ${
                             event.my_rsvp_status === "declined"
                               ? "bg-red-100 dark:bg-red-950/40 border-red-400 dark:border-red-700 text-red-700 dark:text-red-300"
                               : "border-red-200 dark:border-red-900 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40"
@@ -297,7 +297,7 @@ export default function EventsListPage() {
                           setDeleteTarget({ id: event.id, title: event.title });
                           setDeleteError(null);
                         }}
-                        className="p-1.5 rounded-lg text-muted-foreground hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-600 dark:hover:text-red-400"
+                        className="p-1.5 rounded-md text-muted-foreground hover:bg-red-50 dark:hover:bg-red-950/40 hover:text-red-600 dark:hover:text-red-400"
                         title={t("events.list.titleDelete")}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -321,14 +321,14 @@ export default function EventsListPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               <ChevronLeft className="h-4 w-4" /> {t("events.list.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground flex items-center gap-1 px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("events.list.next")} <ChevronRight className="h-4 w-4" />
             </button>
@@ -343,7 +343,7 @@ export default function EventsListPage() {
           onClick={() => !deleteMutation.isPending && setDeleteTarget(null)}
         >
           <div
-            className="w-full max-w-md rounded-xl bg-card shadow-xl"
+            className="w-full max-w-md rounded-lg bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="px-6 py-5">
@@ -360,16 +360,16 @@ export default function EventsListPage() {
               </div>
             </div>
             {deleteError && (
-              <div className="mx-6 mb-4 rounded-lg bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+              <div className="mx-6 mb-4 rounded-md bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
                 {deleteError}
               </div>
             )}
-            <div className="flex justify-end gap-3 rounded-b-xl border-t border-border bg-muted px-6 py-4">
+            <div className="flex justify-end gap-3 rounded-b-lg border-t border-border bg-muted px-6 py-4">
               <button
                 type="button"
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleteMutation.isPending}
-                className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
+                className="rounded-md border border-border px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-card disabled:opacity-50"
               >
                 {t("events.list.cancel")}
               </button>
@@ -377,7 +377,7 @@ export default function EventsListPage() {
                 type="button"
                 onClick={() => deleteMutation.mutate(deleteTarget.id)}
                 disabled={deleteMutation.isPending}
-                className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-red-700 disabled:opacity-50"
               >
                 {deleteMutation.isPending ? (
                   <>

--- a/packages/client/src/pages/events/HolidaysPage.tsx
+++ b/packages/client/src/pages/events/HolidaysPage.tsx
@@ -250,15 +250,15 @@ export default function HolidaysPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("holidays.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("holidays.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("holidays.subtitle")}</p>
         </div>
         {isHR && (
           <button
             onClick={() => (showAdd ? closeForm() : (setEditId(null), setShowAdd(true)))}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
           >
             <Plus className="h-4 w-4" /> {t("holidays.addHoliday")}
           </button>
@@ -267,8 +267,8 @@ export default function HolidaysPage() {
 
       {/* Add Holiday Form */}
       {showAdd && isHR && (
-        <form onSubmit={handleSubmit} className="bg-card rounded-xl border border-border p-6 mb-6">
-          <h2 className="text-lg font-semibold text-foreground mb-4">
+        <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 mb-6">
+          <h2 className="text-base font-semibold text-foreground mb-4">
             {editId != null ? t("holidays.editHoliday") : t("holidays.addHoliday")}
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -278,7 +278,7 @@ export default function HolidaysPage() {
                 type="text"
                 value={form.title}
                 onChange={(e) => setForm({ ...form, title: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
@@ -288,7 +288,7 @@ export default function HolidaysPage() {
                 type="date"
                 value={form.start_date}
                 onChange={(e) => setForm({ ...form, start_date: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 required
               />
             </div>
@@ -298,7 +298,7 @@ export default function HolidaysPage() {
                 type="date"
                 value={form.end_date}
                 onChange={(e) => setForm({ ...form, end_date: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <div>
@@ -307,7 +307,7 @@ export default function HolidaysPage() {
                 type="text"
                 value={form.description}
                 onChange={(e) => setForm({ ...form, description: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("holidays.optional")}
               />
             </div>
@@ -345,7 +345,7 @@ export default function HolidaysPage() {
             <button
               type="submit"
               disabled={isSaving}
-              className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {editId != null
                 ? isSaving
@@ -361,7 +361,7 @@ export default function HolidaysPage() {
       )}
 
       {/* Holiday List */}
-      <div className="bg-card rounded-xl border border-border overflow-hidden">
+      <div className="bg-card rounded-lg border border-border overflow-hidden">
         {isLoading ? (
           <div className="px-6 py-8 text-center text-muted-foreground">{t("holidays.loading")}</div>
         ) : sortedHolidays.length === 0 ? (
@@ -375,15 +375,15 @@ export default function HolidaysPage() {
             {sortedHolidays.map((h) => (
               <li
                 key={h.id}
-                className={`flex items-center justify-between px-6 py-4 ${isPast(h.start_date) ? "opacity-60" : ""}`}
+                className={`flex items-center justify-between px-4 py-2.5 ${isPast(h.start_date) ? "opacity-60" : ""}`}
               >
                 <div className="flex items-center gap-4">
-                  <div className="flex-shrink-0 h-10 w-10 rounded-lg bg-brand-50 dark:bg-brand-950/40 flex items-center justify-center">
+                  <div className="flex-shrink-0 h-10 w-10 rounded-md bg-brand-50 dark:bg-brand-950/40 flex items-center justify-center">
                     <CalendarDays className="h-5 w-5 text-brand-600 dark:text-brand-400" />
                   </div>
                   <div>
                     <div className="flex items-center gap-2 flex-wrap">
-                      <p className="text-sm font-semibold text-foreground">{h.title}</p>
+                      <p className="text-[13px] font-semibold text-foreground">{h.title}</p>
                       {(() => {
                         const parsed = parseHolidayType(h.description, t);
                         if (!parsed.label || !parsed.type) return null;
@@ -414,17 +414,17 @@ export default function HolidaysPage() {
                 </div>
                 <div className="flex items-center gap-3">
                   {isPast(h.start_date) && (
-                    <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">{t("holidays.past")}</span>
+                    <span className="text-[11px] text-muted-foreground bg-muted px-2 py-0.5 rounded-md">{t("holidays.past")}</span>
                   )}
                   {(() => {
                     const mandatory = !!Number(h.is_mandatory);
                     const saving = savingMandatoryId === h.id;
                     // HR can click to toggle. Non-HR sees a plain badge.
                     const baseCls =
-                      "text-[10px] uppercase tracking-wide font-medium px-2 py-0.5 rounded-full border";
+                      "text-[10px] uppercase tracking-wide font-medium px-2 py-0.5 rounded-md border";
                     const colorCls = mandatory
-                      ? "bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300 border-rose-200"
-                      : "bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border-amber-200";
+                      ? "bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300 border-rose-200 dark:border-rose-900/50"
+                      : "bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-900/50";
                     const label = mandatory ? t("holidays.mandatory") : t("holidays.optionalBadge");
                     if (!isHR) {
                       return <span className={`${baseCls} ${colorCls}`}>{label}</span>;

--- a/packages/client/src/pages/events/MyEventsPage.tsx
+++ b/packages/client/src/pages/events/MyEventsPage.tsx
@@ -64,18 +64,18 @@ export default function MyEventsPage() {
 
   return (
     <div>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t("events.my.title")}</h1>
-        <p className="text-muted-foreground mt-1">{t("events.my.subtitle")}</p>
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("events.my.title")}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{t("events.my.subtitle")}</p>
       </div>
 
       <div className="space-y-4">
         {isLoading ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-[13px] text-muted-foreground">
             {t("events.my.loading")}
           </div>
         ) : events.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center">
+          <div className="bg-card rounded-lg border border-border p-8 text-center">
             <Calendar className="h-12 w-12 mx-auto text-muted-foreground/50 mb-3" />
             <p className="text-muted-foreground mb-2">{t("events.my.empty")}</p>
             <Link
@@ -92,26 +92,26 @@ export default function MyEventsPage() {
             return (
               <div
                 key={event.id}
-                className="bg-card rounded-xl border border-border p-6 hover:shadow-md transition-shadow"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-2 flex-wrap">
-                      <span className={`inline-flex items-center text-xs font-medium px-2.5 py-0.5 rounded-full ${typeColor}`}>
+                      <span className={`inline-flex items-center text-[11px] font-medium px-2.5 py-0.5 rounded-md ${typeColor}`}>
                         {t(`events.list.type.${event.event_type}`, { defaultValue: event.event_type })}
                       </span>
                       {event.rsvp_status === "attending" && (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-green-50 dark:bg-green-950/40 text-green-600 dark:text-green-400">
+                        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-green-50 dark:bg-green-950/40 text-green-600 dark:text-green-400">
                           <CheckCircle className="h-3 w-3" /> {t("events.list.titleAttending")}
                         </span>
                       )}
                       {event.rsvp_status === "maybe" && (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-amber-50 dark:bg-amber-950/40 text-amber-600 dark:text-amber-400">
+                        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-amber-50 dark:bg-amber-950/40 text-amber-600 dark:text-amber-400">
                           <HelpCircle className="h-3 w-3" /> {t("events.list.titleMaybe")}
                         </span>
                       )}
                       {event.is_mandatory && (
-                        <span className="inline-flex items-center gap-1 text-xs font-medium px-2.5 py-0.5 rounded-full bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400">
+                        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2.5 py-0.5 rounded-md bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400">
                           <Star className="h-3 w-3" /> {t("events.list.mandatory")}
                         </span>
                       )}
@@ -125,12 +125,12 @@ export default function MyEventsPage() {
                     </Link>
 
                     {event.description && (
-                      <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+                      <p className="mt-1 text-[13px] text-muted-foreground line-clamp-2">
                         {event.description}
                       </p>
                     )}
 
-                    <div className="mt-3 flex items-center gap-4 flex-wrap text-xs text-muted-foreground">
+                    <div className="mt-3 flex items-center gap-4 flex-wrap text-[11px] tabular-nums text-muted-foreground">
                       <span className="flex items-center gap-1">
                         <Calendar className="h-3.5 w-3.5" />
                         {formatDate(event.start_date)}
@@ -176,7 +176,7 @@ export default function MyEventsPage() {
                         })
                       }
                       disabled={rsvpMutation.isPending}
-                      className="flex-shrink-0 text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 border border-red-200 dark:border-red-900 px-3 py-1.5 rounded-lg hover:bg-red-50 dark:hover:bg-red-950/40 disabled:opacity-50"
+                      className="flex-shrink-0 text-[11px] font-medium text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 border border-red-200 dark:border-red-900 px-3 py-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-950/40 disabled:opacity-50"
                     >
                       {t("events.my.cancelRsvp")}
                     </button>

--- a/packages/client/src/pages/wellness/DailyCheckInPage.tsx
+++ b/packages/client/src/pages/wellness/DailyCheckInPage.tsx
@@ -77,9 +77,9 @@ export default function DailyCheckInPage() {
   if (submitted || alreadyCheckedIn) {
     return (
       <div className="max-w-lg mx-auto mt-12">
-        <div className="bg-card rounded-xl border border-border p-8 text-center">
+        <div className="bg-card rounded-lg border border-border p-8 text-center">
           <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-foreground mb-2">
+          <h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">
             {submitted ? t("wellness.checkIn.completeTitle") : t("wellness.checkIn.alreadyTitle")}
           </h2>
           <p className="text-muted-foreground mb-6">
@@ -118,12 +118,12 @@ export default function DailyCheckInPage() {
       <div className="flex items-center gap-3">
         <button
           onClick={() => navigate(-1)}
-          className="p-2 rounded-lg hover:bg-muted text-muted-foreground"
+          className="p-2 rounded-md hover:bg-muted text-muted-foreground"
         >
           <ArrowLeft className="h-5 w-5" />
         </button>
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("wellness.checkIn.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("wellness.checkIn.title")}</h1>
           <p className="text-muted-foreground text-sm">
             {new Date().toLocaleDateString(undefined, {
               weekday: "long",
@@ -137,10 +137,10 @@ export default function DailyCheckInPage() {
 
       <form onSubmit={handleSubmit} className="space-y-8">
         {/* Mood Picker */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-2 mb-4">
             <Heart className="h-5 w-5 text-pink-500" />
-            <h3 className="text-lg font-semibold text-foreground">{t("wellness.checkIn.moodQuestion")}</h3>
+            <h3 className="text-base font-semibold text-foreground">{t("wellness.checkIn.moodQuestion")}</h3>
           </div>
           <div className="grid grid-cols-5 gap-3">
             {MOODS.map((m) => (
@@ -165,10 +165,10 @@ export default function DailyCheckInPage() {
         </div>
 
         {/* Energy Level */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center gap-2 mb-4">
             <Zap className="h-5 w-5 text-yellow-500" />
-            <h3 className="text-lg font-semibold text-foreground">{t("wellness.checkIn.energyLevel")}</h3>
+            <h3 className="text-base font-semibold text-foreground">{t("wellness.checkIn.energyLevel")}</h3>
           </div>
           <div className="flex items-center gap-4">
             <span className="text-sm text-muted-foreground w-8">{t("wellness.checkIn.low")}</span>
@@ -193,7 +193,7 @@ export default function DailyCheckInPage() {
         </div>
 
         {/* Sleep & Exercise */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="grid grid-cols-2 gap-6">
             <div>
               <div className="flex items-center gap-2 mb-3">
@@ -204,7 +204,7 @@ export default function DailyCheckInPage() {
                 type="number"
                 value={form.sleep_hours}
                 onChange={(e) => setForm({ ...form, sleep_hours: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("wellness.checkIn.sleepPlaceholder")}
                 step="0.5"
                 min="0"
@@ -220,7 +220,7 @@ export default function DailyCheckInPage() {
                 type="number"
                 value={form.exercise_minutes}
                 onChange={(e) => setForm({ ...form, exercise_minutes: e.target.value })}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("wellness.checkIn.exercisePlaceholder")}
                 min="0"
               />
@@ -229,7 +229,7 @@ export default function DailyCheckInPage() {
         </div>
 
         {/* Notes */}
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <label className="block text-sm font-semibold text-foreground mb-3">
             {t("wellness.checkIn.notesLabel")}
           </label>
@@ -237,7 +237,7 @@ export default function DailyCheckInPage() {
             value={form.notes}
             onChange={(e) => setForm({ ...form, notes: e.target.value })}
             rows={3}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
             placeholder={t("wellness.checkIn.notesPlaceholder")}
           />
         </div>
@@ -253,7 +253,7 @@ export default function DailyCheckInPage() {
         <button
           type="submit"
           disabled={!form.mood || mutation.isPending}
-          className="w-full py-3 bg-green-600 text-white rounded-xl hover:bg-green-700 transition-colors text-sm font-semibold disabled:opacity-50"
+          className="w-full py-3 bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors text-[13px] font-semibold disabled:opacity-50"
         >
           {mutation.isPending ? t("wellness.checkIn.submitting") : t("wellness.checkIn.submit")}
         </button>

--- a/packages/client/src/pages/wellness/MyWellnessPage.tsx
+++ b/packages/client/src/pages/wellness/MyWellnessPage.tsx
@@ -156,19 +156,19 @@ export default function MyWellnessPage() {
     return (
       <div className="space-y-8">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("myWellness.header.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myWellness.header.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("myWellness.header.subtitle")}</p>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="bg-card rounded-xl border border-border p-4 text-center animate-pulse">
+            <div key={i} className="bg-card rounded-lg border border-border p-4 text-center animate-pulse">
               <div className="h-6 w-6 bg-muted rounded mx-auto mb-2" />
               <div className="h-7 w-10 bg-muted rounded mx-auto mb-1" />
               <div className="h-3 w-16 bg-muted rounded mx-auto" />
             </div>
           ))}
         </div>
-        <div className="bg-card rounded-xl border border-border p-6 animate-pulse">
+        <div className="bg-card rounded-lg border border-border p-4 animate-pulse">
           <div className="h-5 w-32 bg-muted rounded mb-4" />
           <div className="h-4 w-full bg-muted rounded mb-2" />
           <div className="h-4 w-3/4 bg-muted rounded" />
@@ -181,10 +181,10 @@ export default function MyWellnessPage() {
     return (
       <div className="space-y-8">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("myWellness.header.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myWellness.header.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("myWellness.header.subtitle")}</p>
         </div>
-        <div className="bg-card rounded-xl border border-border p-8 text-center">
+        <div className="bg-card rounded-lg border border-border p-8 text-center">
           <p className="text-muted-foreground">{t("myWellness.error.loadFailed")}</p>
         </div>
       </div>
@@ -200,7 +200,7 @@ export default function MyWellnessPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("myWellness.header.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("myWellness.header.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("myWellness.header.subtitle")}</p>
         </div>
         <Link
@@ -213,32 +213,32 @@ export default function MyWellnessPage() {
 
       {/* Quick Stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <div className="bg-card rounded-xl border border-border p-4 text-center">
+        <div className="bg-card rounded-lg border border-border p-4 text-center">
           <Flame className="h-6 w-6 text-orange-500 mx-auto mb-1" />
-          <p className="text-2xl font-bold text-foreground">{s.checkin_streak || 0}</p>
+          <p className="text-2xl font-semibold tabular-nums text-foreground">{s.checkin_streak || 0}</p>
           <p className="text-xs text-muted-foreground">{t("myWellness.stats.dayStreak")}</p>
         </div>
-        <div className="bg-card rounded-xl border border-border p-4 text-center">
+        <div className="bg-card rounded-lg border border-border p-4 text-center">
           <Heart className="h-6 w-6 text-red-500 mx-auto mb-1" />
-          <p className="text-2xl font-bold text-foreground">{s.total_checkins || 0}</p>
+          <p className="text-2xl font-semibold tabular-nums text-foreground">{s.total_checkins || 0}</p>
           <p className="text-xs text-muted-foreground">{t("myWellness.stats.totalCheckIns")}</p>
         </div>
-        <div className="bg-card rounded-xl border border-border p-4 text-center">
+        <div className="bg-card rounded-lg border border-border p-4 text-center">
           <Zap className="h-6 w-6 text-yellow-500 mx-auto mb-1" />
-          <p className="text-2xl font-bold text-foreground">{s.avg_energy_level || "---"}</p>
+          <p className="text-2xl font-semibold tabular-nums text-foreground">{s.avg_energy_level || "---"}</p>
           <p className="text-xs text-muted-foreground">{t("myWellness.stats.avgEnergy")}</p>
         </div>
-        <div className="bg-card rounded-xl border border-border p-4 text-center">
+        <div className="bg-card rounded-lg border border-border p-4 text-center">
           <Trophy className="h-6 w-6 text-amber-500 mx-auto mb-1" />
-          <p className="text-2xl font-bold text-foreground">{s.completed_goals_count || 0}</p>
+          <p className="text-2xl font-semibold tabular-nums text-foreground">{s.completed_goals_count || 0}</p>
           <p className="text-xs text-muted-foreground">{t("myWellness.stats.goalsDone")}</p>
         </div>
       </div>
 
       {/* Mood Trend */}
       {s.mood_trend && s.mood_trend.length > 0 && (
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">{t("myWellness.moodTrend.title")}</h3>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-base font-semibold text-foreground mb-4">{t("myWellness.moodTrend.title")}</h3>
           <div className="flex gap-2 overflow-x-auto pb-2">
             {[...s.mood_trend].reverse().map((day: any, idx: number) => (
               <div
@@ -266,9 +266,9 @@ export default function MyWellnessPage() {
       )}
 
       {/* Goals */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-foreground">{t("myWellness.goals.title")}</h3>
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.goals.title")}</h3>
           <button
             onClick={() => setShowGoalForm(true)}
             className="flex items-center gap-1 text-sm text-brand-600 dark:text-brand-400 hover:text-brand-700 font-medium"
@@ -295,7 +295,7 @@ export default function MyWellnessPage() {
                       <Target className="h-5 w-5 text-brand-500" />
                       <span className="font-medium text-foreground">{goal.title}</span>
                       <span
-                        className={`text-xs px-2 py-0.5 rounded-full ${
+                        className={`text-[11px] px-2 py-0.5 rounded-md ${
                           goal.status === "completed"
                             ? "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300"
                             : goal.status === "abandoned"
@@ -359,10 +359,10 @@ export default function MyWellnessPage() {
             : ep.enrollment_status !== "completed"
         );
         return (
-        <div className="bg-card rounded-xl border border-border p-6">
+        <div className="bg-card rounded-lg border border-border p-4">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-foreground">{t("myWellness.programs.title")}</h3>
-            <div className="flex gap-1 bg-muted rounded-lg p-1">
+            <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.programs.title")}</h3>
+            <div className="flex gap-1 bg-muted rounded-md p-1">
               <button
                 onClick={() => setProgramsTab("active")}
                 className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
@@ -405,7 +405,7 @@ export default function MyWellnessPage() {
                     </p>
                   </div>
                   <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${
+                    className={`text-[11px] px-2 py-0.5 rounded-md ${
                       ep.enrollment_status === "completed"
                         ? "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300"
                         : "bg-blue-100 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300"
@@ -445,17 +445,17 @@ export default function MyWellnessPage() {
 
       {/* Recent Check-ins */}
       {checkIns.length > 0 && (
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">{t("myWellness.checkIns.title")}</h3>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("myWellness.checkIns.title")}</h3>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left py-2 text-muted-foreground font-medium">{t("myWellness.checkIns.colDate")}</th>
-                  <th className="text-center py-2 text-muted-foreground font-medium">{t("myWellness.checkIns.colMood")}</th>
-                  <th className="text-center py-2 text-muted-foreground font-medium">{t("myWellness.checkIns.colEnergy")}</th>
-                  <th className="text-center py-2 text-muted-foreground font-medium">{t("myWellness.checkIns.colSleep")}</th>
-                  <th className="text-center py-2 text-muted-foreground font-medium">{t("myWellness.checkIns.colExercise")}</th>
+                  <th className="text-left py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.checkIns.colDate")}</th>
+                  <th className="text-center py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.checkIns.colMood")}</th>
+                  <th className="text-center py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.checkIns.colEnergy")}</th>
+                  <th className="text-center py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.checkIns.colSleep")}</th>
+                  <th className="text-center py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("myWellness.checkIns.colExercise")}</th>
                 </tr>
               </thead>
               <tbody>
@@ -477,7 +477,7 @@ export default function MyWellnessPage() {
                           <Zap
                             key={n}
                             className={`h-3 w-3 ${
-                              n <= ci.energy_level ? "text-yellow-500" : "text-gray-200 dark:text-slate-700"
+                              n <= ci.energy_level ? "text-yellow-500" : "text-muted-foreground/30"
                             }`}
                           />
                         ))}
@@ -513,7 +513,7 @@ export default function MyWellnessPage() {
       {showGoalForm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div className="fixed inset-0 bg-black/50" onClick={() => setShowGoalForm(false)} />
-          <div className="relative bg-card rounded-xl shadow-xl p-6 w-full max-w-lg">
+          <div className="relative bg-card rounded-lg shadow-xl p-6 w-full max-w-lg">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-lg font-semibold text-foreground">{t("myWellness.goalModal.title")}</h2>
               <button onClick={() => setShowGoalForm(false)} className="text-muted-foreground hover:text-muted-foreground">
@@ -528,7 +528,7 @@ export default function MyWellnessPage() {
                   value={goalForm.title}
                   onChange={(e) => setGoalForm({ ...goalForm, title: e.target.value })}
                   required
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder={t("myWellness.goalModal.placeholderTitle")}
                 />
               </div>
@@ -545,7 +545,7 @@ export default function MyWellnessPage() {
                         unit: gt?.unit || goalForm.unit,
                       });
                     }}
-                    className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card"
+                    className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card"
                   >
                     {GOAL_TYPES.map((gt) => (
                       <option key={gt.value} value={gt.value}>
@@ -559,7 +559,7 @@ export default function MyWellnessPage() {
                   <select
                     value={goalForm.frequency}
                     onChange={(e) => setGoalForm({ ...goalForm, frequency: e.target.value })}
-                    className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card"
+                    className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card"
                   >
                     <option value="daily">{t("myWellness.goalFrequency.daily")}</option>
                     <option value="weekly">{t("myWellness.goalFrequency.weekly")}</option>
@@ -576,7 +576,7 @@ export default function MyWellnessPage() {
                     onChange={(e) => setGoalForm({ ...goalForm, target_value: e.target.value })}
                     required
                     min="1"
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                     placeholder={t("myWellness.goalModal.placeholderTargetValue")}
                   />
                 </div>
@@ -587,7 +587,7 @@ export default function MyWellnessPage() {
                     value={goalForm.unit}
                     onChange={(e) => setGoalForm({ ...goalForm, unit: e.target.value })}
                     required
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                     placeholder={t("myWellness.goalModal.placeholderUnit")}
                   />
                 </div>
@@ -600,7 +600,7 @@ export default function MyWellnessPage() {
                     value={goalForm.start_date}
                     onChange={(e) => setGoalForm({ ...goalForm, start_date: e.target.value })}
                     required
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   />
                 </div>
                 <div>
@@ -610,7 +610,7 @@ export default function MyWellnessPage() {
                     value={goalForm.end_date}
                     onChange={(e) => setGoalForm({ ...goalForm, end_date: e.target.value })}
                     min={goalForm.start_date || undefined}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   />
                 </div>
               </div>
@@ -623,7 +623,7 @@ export default function MyWellnessPage() {
                 <button
                   type="button"
                   onClick={() => setShowGoalForm(false)}
-                  className="px-4 py-2 text-muted-foreground hover:bg-muted rounded-lg text-sm"
+                  className="px-4 py-2 text-muted-foreground hover:bg-muted rounded-md text-[13px]"
                 >
                   {t("myWellness.goalModal.cancel")}
                 </button>
@@ -646,7 +646,7 @@ export default function MyWellnessPage() {
           the update. */}
       {progressTarget !== null && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-          <div className="w-full max-w-md rounded-xl bg-card p-6 shadow-xl">
+          <div className="w-full max-w-md rounded-lg bg-card p-4 shadow-xl">
             <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
               <ArrowUpRight className="h-5 w-5 text-brand-600 dark:text-brand-400" />
               {t("myWellness.progressModal.title")}

--- a/packages/client/src/pages/wellness/WellnessDashboardPage.tsx
+++ b/packages/client/src/pages/wellness/WellnessDashboardPage.tsx
@@ -120,7 +120,7 @@ export default function WellnessDashboardPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("wellnessDashboard.header.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("wellnessDashboard.header.title")}</h1>
           <p className="text-muted-foreground mt-1">
             {t("wellnessDashboard.header.subtitle")}
           </p>
@@ -135,14 +135,14 @@ export default function WellnessDashboardPage() {
 
       {/* KPI Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <Link to="/wellness" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/wellness" className="block text-left w-full bg-card rounded-lg border border-border p-5 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
               <Heart className="h-5 w-5 text-green-600 dark:text-green-400" />
             </div>
             <div>
               <p className="text-sm text-muted-foreground">{t("wellnessDashboard.kpi.wellnessScore")}</p>
-              <p className="text-2xl font-bold text-foreground">
+              <p className="text-2xl font-semibold tabular-nums text-foreground">
                 {d.wellness_score !== null
                   ? t("wellnessDashboard.kpi.wellnessScoreValue", { score: d.wellness_score })
                   : t("wellnessDashboard.kpi.valueEmpty")}
@@ -150,38 +150,38 @@ export default function WellnessDashboardPage() {
             </div>
           </div>
         </Link>
-        <Link to="/wellness" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/wellness" className="block text-left w-full bg-card rounded-lg border border-border p-5 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
               <TrendingUp className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             </div>
             <div>
               <p className="text-sm text-muted-foreground">{t("wellnessDashboard.kpi.activePrograms")}</p>
-              <p className="text-2xl font-bold text-foreground">{d.active_programs || 0}</p>
+              <p className="text-2xl font-semibold tabular-nums text-foreground">{d.active_programs || 0}</p>
             </div>
           </div>
           <p className="text-xs text-muted-foreground">{t("wellnessDashboard.kpi.totalPrograms", { count: d.total_programs || 0 })}</p>
         </Link>
-        <Link to="/wellness" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/wellness" className="block text-left w-full bg-card rounded-lg border border-border p-5 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-purple-100 dark:bg-purple-950/40 flex items-center justify-center">
               <Users className="h-5 w-5 text-purple-600 dark:text-purple-400" />
             </div>
             <div>
               <p className="text-sm text-muted-foreground">{t("wellnessDashboard.kpi.activeParticipants")}</p>
-              <p className="text-2xl font-bold text-foreground">{d.active_participants || 0}</p>
+              <p className="text-2xl font-semibold tabular-nums text-foreground">{d.active_participants || 0}</p>
             </div>
           </div>
           <p className="text-xs text-muted-foreground">{t("wellnessDashboard.kpi.checkins30d", { count: d.checkin_count_30d || 0 })}</p>
         </Link>
-        <Link to="/wellness" className="block text-left w-full bg-card rounded-xl border border-border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/wellness" className="block text-left w-full bg-card rounded-lg border border-border p-5 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
-            <div className="h-10 w-10 rounded-lg bg-amber-100 dark:bg-amber-950/40 flex items-center justify-center">
+            <div className="h-10 w-10 rounded-md bg-amber-100 dark:bg-amber-950/40 flex items-center justify-center">
               <Trophy className="h-5 w-5 text-amber-600 dark:text-amber-400" />
             </div>
             <div>
               <p className="text-sm text-muted-foreground">{t("wellnessDashboard.kpi.goalCompletion")}</p>
-              <p className="text-2xl font-bold text-foreground">{t("wellnessDashboard.kpi.goalCompletionValue", { rate: d.goal_completion_rate || 0 })}</p>
+              <p className="text-2xl font-semibold tabular-nums text-foreground">{t("wellnessDashboard.kpi.goalCompletionValue", { rate: d.goal_completion_rate || 0 })}</p>
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
@@ -192,8 +192,8 @@ export default function WellnessDashboardPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Mood Distribution */}
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">{t("wellnessDashboard.mood.title")}</h3>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-base font-semibold text-foreground mb-4">{t("wellnessDashboard.mood.title")}</h3>
           {moodTotal === 0 ? (
             <p className="text-sm text-muted-foreground">{t("wellnessDashboard.mood.noData")}</p>
           ) : (
@@ -223,16 +223,16 @@ export default function WellnessDashboardPage() {
         </div>
 
         {/* Avg Stats */}
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">{t("wellnessDashboard.metrics.title")}</h3>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-base font-semibold text-foreground mb-4">{t("wellnessDashboard.metrics.title")}</h3>
           <div className="space-y-6">
             <div className="flex items-center gap-4">
-              <div className="h-12 w-12 rounded-lg bg-yellow-100 dark:bg-yellow-950/40 flex items-center justify-center">
+              <div className="h-12 w-12 rounded-md bg-yellow-100 dark:bg-yellow-950/40 flex items-center justify-center">
                 <Zap className="h-6 w-6 text-yellow-600 dark:text-yellow-400" />
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">{t("wellnessDashboard.metrics.avgEnergyLevel")}</p>
-                <p className="text-xl font-bold text-foreground">
+                <p className="text-xl font-semibold tabular-nums text-foreground">
                   {d.avg_energy_level !== null
                     ? t("wellnessDashboard.metrics.avgEnergyLevelValue", { value: d.avg_energy_level })
                     : t("wellnessDashboard.kpi.valueEmpty")}
@@ -240,12 +240,12 @@ export default function WellnessDashboardPage() {
               </div>
             </div>
             <div className="flex items-center gap-4">
-              <div className="h-12 w-12 rounded-lg bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
+              <div className="h-12 w-12 rounded-md bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
                 <Dumbbell className="h-6 w-6 text-green-600 dark:text-green-400" />
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">{t("wellnessDashboard.metrics.avgExerciseMinutes")}</p>
-                <p className="text-xl font-bold text-foreground">
+                <p className="text-xl font-semibold tabular-nums text-foreground">
                   {d.avg_exercise_minutes !== null
                     ? t("wellnessDashboard.metrics.avgExerciseMinutesValue", { value: d.avg_exercise_minutes })
                     : t("wellnessDashboard.kpi.valueEmpty")}
@@ -253,12 +253,12 @@ export default function WellnessDashboardPage() {
               </div>
             </div>
             <div className="flex items-center gap-4">
-              <div className="h-12 w-12 rounded-lg bg-indigo-100 dark:bg-indigo-950/40 flex items-center justify-center">
+              <div className="h-12 w-12 rounded-md bg-indigo-100 dark:bg-indigo-950/40 flex items-center justify-center">
                 <Target className="h-6 w-6 text-indigo-600 dark:text-indigo-400" />
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">{t("wellnessDashboard.metrics.totalEnrollments")}</p>
-                <p className="text-xl font-bold text-foreground">{d.total_enrollments || 0}</p>
+                <p className="text-xl font-semibold tabular-nums text-foreground">{d.total_enrollments || 0}</p>
                 <p className="text-xs text-muted-foreground">{t("wellnessDashboard.metrics.completedEnrollments", { count: d.completed_enrollments || 0 })}</p>
               </div>
             </div>
@@ -268,41 +268,41 @@ export default function WellnessDashboardPage() {
 
       {/* Top Programs */}
       {d.top_programs && d.top_programs.length > 0 && (
-        <div className="bg-card rounded-xl border border-border p-6">
-          <h3 className="text-lg font-semibold text-foreground mb-4">{t("wellnessDashboard.topPrograms.title")}</h3>
+        <div className="bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("wellnessDashboard.topPrograms.title")}</h3>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border">
-                  <th className="text-left py-2 text-muted-foreground font-medium">{t("wellnessDashboard.topPrograms.colProgram")}</th>
-                  <th className="text-left py-2 text-muted-foreground font-medium">{t("wellnessDashboard.topPrograms.colType")}</th>
-                  <th className="text-right py-2 text-muted-foreground font-medium">{t("wellnessDashboard.topPrograms.colEnrolled")}</th>
-                  <th className="text-right py-2 text-muted-foreground font-medium">{t("wellnessDashboard.topPrograms.colPoints")}</th>
-                  <th className="text-center py-2 text-muted-foreground font-medium">{t("wellnessDashboard.topPrograms.colStatus")}</th>
+                  <th className="text-left py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("wellnessDashboard.topPrograms.colProgram")}</th>
+                  <th className="text-left py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("wellnessDashboard.topPrograms.colType")}</th>
+                  <th className="text-right py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("wellnessDashboard.topPrograms.colEnrolled")}</th>
+                  <th className="text-right py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("wellnessDashboard.topPrograms.colPoints")}</th>
+                  <th className="text-center py-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("wellnessDashboard.topPrograms.colStatus")}</th>
                 </tr>
               </thead>
               <tbody>
                 {d.top_programs.map((p: any) => (
-                  <tr key={p.id} className="border-b border-border hover:bg-muted transition-colors">
-                    <td className="py-3 font-medium text-foreground">
+                  <tr key={p.id} className="border-b border-border hover:bg-muted/50 transition-colors">
+                    <td className="py-2.5 font-medium text-foreground">
                       <Link to="/wellness" className="text-brand-600 dark:text-brand-400 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-500 rounded">
                         {p.title}
                       </Link>
                     </td>
-                    <td className="py-3 text-muted-foreground">{t(`wellnessDashboard.programType.${p.program_type}`, { defaultValue: p.program_type })}</td>
-                    <td className="py-3 text-right text-muted-foreground">
+                    <td className="py-2.5 text-muted-foreground">{t(`wellnessDashboard.programType.${p.program_type}`, { defaultValue: p.program_type })}</td>
+                    <td className="py-2.5 text-right text-muted-foreground">
                       {p.max_participants
                         ? t("wellnessDashboard.topPrograms.enrolledOfMax", { enrolled: p.enrolled_count, max: p.max_participants })
                         : p.enrolled_count}
                     </td>
-                    <td className="py-3 text-right text-amber-600 dark:text-amber-400 font-medium">
+                    <td className="py-2.5 text-right text-amber-600 dark:text-amber-400 font-medium">
                       {p.points_reward > 0
                         ? t("wellnessDashboard.topPrograms.pointsReward", { points: p.points_reward })
                         : t("wellnessDashboard.topPrograms.pointsEmpty")}
                     </td>
-                    <td className="py-3 text-center">
+                    <td className="py-2.5 text-center">
                       <span
-                        className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                        className={`px-2 py-0.5 rounded-md text-[11px] font-medium ${
                           p.is_active
                             ? "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300"
                             : "bg-muted text-muted-foreground"
@@ -323,7 +323,7 @@ export default function WellnessDashboardPage() {
       {showCreate && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div className="fixed inset-0 bg-black/50" onClick={() => setShowCreate(false)} />
-          <div className="relative bg-card rounded-xl shadow-xl p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
+          <div className="relative bg-card rounded-lg shadow-xl p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-lg font-semibold text-foreground">{t("wellnessDashboard.modal.title")}</h2>
               <button onClick={() => setShowCreate(false)} className="text-muted-foreground hover:text-foreground">
@@ -338,7 +338,7 @@ export default function WellnessDashboardPage() {
                   value={form.title}
                   onChange={(e) => setForm({ ...form, title: e.target.value })}
                   required
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder={t("wellnessDashboard.modal.titlePlaceholder")}
                 />
               </div>
@@ -348,7 +348,7 @@ export default function WellnessDashboardPage() {
                   value={form.description}
                   onChange={(e) => setForm({ ...form, description: e.target.value })}
                   rows={3}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   placeholder={t("wellnessDashboard.modal.descriptionPlaceholder")}
                 />
               </div>
@@ -358,7 +358,7 @@ export default function WellnessDashboardPage() {
                   <select
                     value={form.program_type}
                     onChange={(e) => setForm({ ...form, program_type: e.target.value })}
-                    className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card"
+                    className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card"
                   >
                     {PROGRAM_TYPES.map((pt) => (
                       <option key={pt} value={pt}>
@@ -373,7 +373,7 @@ export default function WellnessDashboardPage() {
                     type="number"
                     value={form.max_participants}
                     onChange={(e) => setForm({ ...form, max_participants: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                     placeholder={t("wellnessDashboard.modal.maxParticipantsPlaceholder")}
                     min="1"
                   />
@@ -386,7 +386,7 @@ export default function WellnessDashboardPage() {
                     type="date"
                     value={form.start_date}
                     onChange={(e) => setForm({ ...form, start_date: e.target.value })}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   />
                 </div>
                 <div>
@@ -396,7 +396,7 @@ export default function WellnessDashboardPage() {
                     value={form.end_date}
                     onChange={(e) => setForm({ ...form, end_date: e.target.value })}
                     min={form.start_date || undefined}
-                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                    className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   />
                 </div>
               </div>
@@ -406,7 +406,7 @@ export default function WellnessDashboardPage() {
                   type="number"
                   value={form.points_reward}
                   onChange={(e) => setForm({ ...form, points_reward: e.target.value })}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                   min="0"
                 />
               </div>
@@ -419,7 +419,7 @@ export default function WellnessDashboardPage() {
                 <button
                   type="button"
                   onClick={() => setShowCreate(false)}
-                  className="px-4 py-2 text-muted-foreground hover:bg-muted rounded-lg text-sm"
+                  className="px-4 py-2 text-muted-foreground hover:bg-muted rounded-md text-[13px]"
                 >
                   {t("wellnessDashboard.modal.cancel")}
                 </button>

--- a/packages/client/src/pages/wellness/WellnessPage.tsx
+++ b/packages/client/src/pages/wellness/WellnessPage.tsx
@@ -89,7 +89,7 @@ export default function WellnessPage() {
     <div className="max-w-7xl mx-auto space-y-8">
       {enrollMessage && (
         <div
-          className={`p-3 rounded-lg border text-sm ${
+          className={`p-3 rounded-md border text-sm ${
             enrollMessage.type === "success"
               ? "bg-green-50 dark:bg-green-950/40 border-green-200 dark:border-green-900 text-green-700 dark:text-green-300"
               : "bg-red-50 dark:bg-red-950/40 border-red-200 dark:border-red-900 text-red-700 dark:text-red-300"
@@ -101,7 +101,7 @@ export default function WellnessPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("wellnessPage.header.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("wellnessPage.header.title")}</h1>
           <p className="text-muted-foreground mt-1">
             {t("wellnessPage.header.subtitle")}
           </p>
@@ -130,15 +130,15 @@ export default function WellnessPage() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
           <Link
             to="/wellness/check-in"
-            className="block text-left w-full bg-card rounded-xl border border-border p-4 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
+              <div className="h-10 w-10 rounded-md bg-green-100 dark:bg-green-950/40 flex items-center justify-center">
                 <Heart className="h-5 w-5 text-green-600 dark:text-green-400" />
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">{t("wellnessPage.stats.checkInStreak")}</p>
-                <p className="text-xl font-bold text-foreground">
+                <p className="text-xl font-semibold tabular-nums text-foreground">
                   {t("wellnessPage.stats.checkInStreakValue", { count: summaryData.checkin_streak })}
                 </p>
               </div>
@@ -146,38 +146,38 @@ export default function WellnessPage() {
           </Link>
           <Link
             to="/wellness/my"
-            className="block text-left w-full bg-card rounded-xl border border-border p-4 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
+              <div className="h-10 w-10 rounded-md bg-blue-100 dark:bg-blue-950/40 flex items-center justify-center">
                 <Dumbbell className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">{t("wellnessPage.stats.activePrograms")}</p>
-                <p className="text-xl font-bold text-foreground">{summaryData.enrolled_programs?.length || 0}</p>
+                <p className="text-xl font-semibold tabular-nums text-foreground">{summaryData.enrolled_programs?.length || 0}</p>
               </div>
             </div>
           </Link>
           <Link
             to="/wellness/my"
-            className="block text-left w-full bg-card rounded-xl border border-border p-4 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-950/40 flex items-center justify-center">
+              <div className="h-10 w-10 rounded-md bg-purple-100 dark:bg-purple-950/40 flex items-center justify-center">
                 <Trophy className="h-5 w-5 text-purple-600 dark:text-purple-400" />
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">{t("wellnessPage.stats.goalsCompleted")}</p>
-                <p className="text-xl font-bold text-foreground">{summaryData.completed_goals_count || 0}</p>
+                <p className="text-xl font-semibold tabular-nums text-foreground">{summaryData.completed_goals_count || 0}</p>
               </div>
             </div>
           </Link>
           <Link
             to="/wellness/check-in"
-            className="block text-left w-full bg-card rounded-xl border border-border p-4 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <div className="flex items-center gap-3">
-              <div className="h-10 w-10 rounded-lg bg-amber-100 dark:bg-amber-950/40 flex items-center justify-center">
+              <div className="h-10 w-10 rounded-md bg-amber-100 dark:bg-amber-950/40 flex items-center justify-center">
                 <Sparkles className="h-5 w-5 text-amber-600 dark:text-amber-400" />
               </div>
               <div>
@@ -197,7 +197,7 @@ export default function WellnessPage() {
             setTypeFilter(e.target.value);
             setPage(1);
           }}
-          className="px-3 py-2 border border-border rounded-lg text-sm bg-card"
+          className="px-3 py-2 border border-border rounded-md text-[13px] bg-card"
         >
           <option value="">{t("wellnessPage.filter.allTypes")}</option>
           {Object.entries(PROGRAM_TYPE_CONFIG).map(([key, { label }]) => (
@@ -215,7 +215,7 @@ export default function WellnessPage() {
       {isLoading ? (
         <div className="text-center py-12 text-muted-foreground">{t("wellnessPage.list.loading")}</div>
       ) : programs.length === 0 ? (
-        <div className="text-center py-12 bg-card rounded-xl border border-border">
+        <div className="text-center py-12 bg-card rounded-lg border border-border">
           <Heart className="h-12 w-12 text-muted-foreground/50 mx-auto mb-3" />
           <p className="text-muted-foreground">{t("wellnessPage.list.empty")}</p>
         </div>
@@ -230,25 +230,25 @@ export default function WellnessPage() {
             return (
               <div
                 key={program.id}
-                className="bg-card rounded-xl border border-border p-6 hover:shadow-md transition-shadow"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start justify-between mb-4">
                   <div className="flex items-center gap-3">
-                    <div className={`h-10 w-10 rounded-lg ${boxBgClasses} flex items-center justify-center`}>
+                    <div className={`h-10 w-10 rounded-md ${boxBgClasses} flex items-center justify-center`}>
                       <Icon className={`h-5 w-5 ${iconTextClasses}`} />
                     </div>
-                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${cfg.color}`}>
+                    <span className={`px-2 py-0.5 rounded-md text-[11px] font-medium ${cfg.color}`}>
                       {t(`wellnessPage.programType.${program.program_type}`, { defaultValue: cfg.label })}
                     </span>
                   </div>
                   {program.points_reward > 0 && (
-                    <span className="text-xs font-medium text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 rounded-full">
+                    <span className="text-[11px] tabular-nums font-medium text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/40 px-2 py-0.5 rounded-md">
                       {t("wellnessPage.card.pointsReward", { count: program.points_reward })}
                     </span>
                   )}
                 </div>
 
-                <h3 className="text-lg font-semibold text-foreground mb-2">{program.title}</h3>
+                <h3 className="text-base font-semibold text-foreground mb-2">{program.title}</h3>
                 {program.description && (
                   <p className="text-sm text-muted-foreground mb-4 line-clamp-2">{program.description}</p>
                 )}
@@ -271,7 +271,7 @@ export default function WellnessPage() {
                 {enrolledProgramIds.has(program.id) ? (
                   <button
                     disabled
-                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-900 rounded-lg text-sm font-medium cursor-not-allowed"
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-900 rounded-md text-[13px] font-medium cursor-not-allowed"
                   >
                     {t("wellnessPage.card.enrolledButton")}
                   </button>


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) to the **Wellness + Events** modules — **PR 2 of 3** for the Engagement area.

**Pages (9):** Daily Check-In, My Wellness, Wellness Dashboard, Wellness (programs) · Event Dashboard, Event Detail, Events List, Holidays, My Events.

- Compact headers; `rounded-lg` cards / `rounded-md` controls; `text-[11px]` uppercase table + panel headers; `px-4 py-2.5` dense rows/list items; `tabular-nums` on streaks / scores / RSVP + attendee counts / dates; KPI stat tiles; `rounded-md` status / type / category pills.
- **Preserved as chrome/decoration:** modal titles keep `text-lg`, modal padding unchanged; mood emoji + mood-scale colors, wellness progress-bar tracks/fills, energy toggle tiles, event/program category color maps, delete-dialog icon circles, and streak visuals all untouched.

**Fixes:** migrated the one stray raw gray (My Wellness empty energy-meter icons: `text-gray-200` → `text-muted-foreground/30`), and added missing `dark:border` siblings to the Holidays mandatory/optional badge borders (`border-rose-200` / `border-amber-200`) for dark-mode parity. No dark-mode text-contrast bugs in this batch.

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.

Next: PR 3 = Forum + Surveys (final engagement PR).