### PR TITLE
ui: enterprise-density uplift for Forum + Surveys (engagement 3/3, 9 pages)

### DIFF
--- a/packages/client/src/pages/forum/CategoryPostsPage.tsx
+++ b/packages/client/src/pages/forum/CategoryPostsPage.tsx
@@ -75,7 +75,7 @@ export default function CategoryPostsPage() {
       <div className="flex items-center gap-3 mb-6">
         <Link
           to="/forum"
-          className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-muted-foreground transition-colors"
+          className="p-2 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowLeft className="h-5 w-5" />
         </Link>
@@ -85,7 +85,7 @@ export default function CategoryPostsPage() {
               <span className="text-2xl">{category.icon}</span>
             )}
             <div>
-              <h1 className="text-2xl font-bold text-foreground">
+              <h1 className="text-xl font-semibold tracking-tight text-foreground">
                 {category?.name || t("categoryPosts.header.defaultCategoryName")}
               </h1>
               {category?.description && (
@@ -96,7 +96,7 @@ export default function CategoryPostsPage() {
         </div>
         <Link
           to={`/forum/new?category=${id}`}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 transition-colors"
         >
           <Plus className="h-4 w-4" /> {t("categoryPosts.header.newPost")}
         </Link>
@@ -109,7 +109,7 @@ export default function CategoryPostsPage() {
           <select
             value={postType}
             onChange={(e) => { setPostType(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-1.5 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground px-3 py-1.5 border border-border rounded-md text-[13px]"
           >
             <option value="">{t("categoryPosts.filters.allTypes")}</option>
             <option value="discussion">{t("categoryPosts.filters.discussions")}</option>
@@ -119,7 +119,7 @@ export default function CategoryPostsPage() {
           </select>
         </div>
 
-        <div className="flex gap-1 bg-muted rounded-lg p-1">
+        <div className="flex gap-1 bg-muted rounded-md p-1">
           {[
             { key: "recent", labelKey: "categoryPosts.sort.recent" },
             { key: "popular", labelKey: "categoryPosts.sort.popular" },
@@ -144,11 +144,11 @@ export default function CategoryPostsPage() {
       {/* Posts */}
       <div className="space-y-3">
         {isLoading ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-[13px] text-muted-foreground">
             {t("categoryPosts.list.loading")}
           </div>
         ) : posts.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-[13px] text-muted-foreground">
             {t("categoryPosts.list.empty")}
           </div>
         ) : (
@@ -159,7 +159,7 @@ export default function CategoryPostsPage() {
               <Link
                 key={post.id}
                 to={`/forum/post/${post.id}`}
-                className="block bg-card rounded-xl border border-border p-5 hover:shadow-md hover:border-brand-200 dark:hover:border-brand-900 transition-all"
+                className="block bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start gap-4">
                   <div className="h-10 w-10 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center flex-shrink-0">
@@ -171,7 +171,7 @@ export default function CategoryPostsPage() {
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${typeConfig.color}`}>
+                      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-md ${typeConfig.color}`}>
                         <TypeIcon className="h-3 w-3" />
                         {t(typeConfig.labelKey)}
                       </span>
@@ -187,12 +187,12 @@ export default function CategoryPostsPage() {
                       )}
                     </div>
 
-                    <h3 className="text-sm font-semibold text-foreground mb-1">{post.title}</h3>
-                    <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
+                    <h3 className="text-[13px] font-semibold text-foreground mb-1">{post.title}</h3>
+                    <p className="text-[11px] text-muted-foreground line-clamp-2 mb-2">
                       {post.content?.replace(/<[^>]*>/g, "").slice(0, 200)}
                     </p>
 
-                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                    <div className="flex items-center gap-4 text-[11px] tabular-nums text-muted-foreground">
                       <span>{post.author_first_name} {post.author_last_name}</span>
                       <span>{timeAgo(post.created_at, t)}</span>
                       <span className="flex items-center gap-1"><Eye className="h-3 w-3" /> {post.view_count}</span>
@@ -210,7 +210,7 @@ export default function CategoryPostsPage() {
       {/* Pagination */}
       {meta && meta.total_pages > 1 && (
         <div className="flex items-center justify-between mt-6">
-          <p className="text-sm text-muted-foreground">
+          <p className="text-[13px] tabular-nums text-muted-foreground">
             {t("categoryPosts.pagination.pageInfo", {
               page: meta.page,
               totalPages: meta.total_pages,
@@ -221,14 +221,14 @@ export default function CategoryPostsPage() {
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
             >
               {t("categoryPosts.pagination.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
             >
               {t("categoryPosts.pagination.next")}
             </button>

--- a/packages/client/src/pages/forum/CreatePostPage.tsx
+++ b/packages/client/src/pages/forum/CreatePostPage.tsx
@@ -54,26 +54,26 @@ export default function CreatePostPage() {
       <div className="flex items-center gap-3 mb-6">
         <button
           onClick={() => navigate(-1)}
-          className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-muted-foreground transition-colors"
+          className="p-2 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
         >
           <ArrowLeft className="h-5 w-5" />
         </button>
-        <h1 className="text-2xl font-bold text-foreground">{t("forum.create.title")}</h1>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("forum.create.title")}</h1>
       </div>
 
       <form
         onSubmit={handleSubmit}
-        className="bg-card rounded-xl border border-border p-6 space-y-5"
+        className="bg-card rounded-lg border border-border p-4 space-y-5"
       >
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">
+            <label className="block text-[13px] font-medium text-muted-foreground mb-1">
               {t("forum.create.category")} <span className="text-red-500">*</span>
             </label>
             <select
               value={categoryId}
               onChange={(e) => setCategoryId(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               required
             >
               <option value="">{t("forum.create.selectCategory")}</option>
@@ -89,13 +89,13 @@ export default function CreatePostPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">
+            <label className="block text-[13px] font-medium text-muted-foreground mb-1">
               {t("forum.create.postType")}
             </label>
             <select
               value={postType}
               onChange={(e) => setPostType(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
             >
               <option value="discussion">{t("forum.page.postType.discussion")}</option>
               <option value="question">{t("forum.page.postType.question")}</option>
@@ -106,14 +106,14 @@ export default function CreatePostPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">
             {t("forum.create.fieldTitle")} <span className="text-red-500">*</span>
           </label>
           <input
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
             placeholder={t("forum.create.titlePlaceholder")}
             maxLength={255}
             required
@@ -121,13 +121,13 @@ export default function CreatePostPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">
             {t("forum.create.content")} <span className="text-red-500">*</span>
           </label>
           <textarea
             value={content}
             onChange={(e) => setContent(e.target.value)}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[200px] resize-y"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[200px] resize-y"
             placeholder={
               postType === "question"
                 ? t("forum.create.contentPlaceholderQuestion")
@@ -140,14 +140,14 @@ export default function CreatePostPage() {
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">
             {t("forum.create.tags")} <span className="text-xs text-muted-foreground">{t("forum.create.tagsHint")}</span>
           </label>
           <input
             type="text"
             value={tagsInput}
             onChange={(e) => setTagsInput(e.target.value)}
-            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
             placeholder={t("forum.create.tagsPlaceholder")}
           />
           {tagsInput && (
@@ -159,7 +159,7 @@ export default function CreatePostPage() {
                 .map((tag) => (
                   <span
                     key={tag}
-                    className="bg-muted text-muted-foreground px-2 py-0.5 rounded text-xs"
+                    className="bg-muted text-muted-foreground px-2 py-0.5 rounded-md text-[11px]"
                   >
                     #{tag}
                   </span>
@@ -169,7 +169,7 @@ export default function CreatePostPage() {
         </div>
 
         {createPost.isError && (
-          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 text-red-700 dark:text-red-300 text-sm rounded-lg px-4 py-3">
+          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 text-red-700 dark:text-red-300 text-[13px] rounded-md px-4 py-3">
             {t("forum.create.error")}
           </div>
         )}
@@ -178,14 +178,14 @@ export default function CreatePostPage() {
           <button
             type="button"
             onClick={() => navigate(-1)}
-            className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+            className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted transition-colors"
           >
             {t("forum.create.cancel")}
           </button>
           <button
             type="submit"
             disabled={createPost.isPending}
-            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 transition-colors disabled:opacity-50"
           >
             <Send className="h-4 w-4" />
             {createPost.isPending ? t("forum.create.publishing") : t("forum.create.publish")}

--- a/packages/client/src/pages/forum/ForumPage.tsx
+++ b/packages/client/src/pages/forum/ForumPage.tsx
@@ -84,9 +84,9 @@ export default function ForumPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("forum.page.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("forum.page.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("forum.page.subtitle")}</p>
         </div>
         <div className="flex gap-3">
@@ -108,16 +108,16 @@ export default function ForumPage() {
       </div>
 
       {/* Category Grid */}
-      <div className="mb-8">
-        <h2 className="text-lg font-semibold text-foreground mb-4">{t("forum.page.categories")}</h2>
+      <div className="mb-6">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("forum.page.categories")}</h2>
         {loadingCats ? (
           <div className="text-muted-foreground text-sm">{t("forum.page.loadingCategories")}</div>
         ) : catsError ? (
-          <div className="bg-card rounded-xl border border-red-200 dark:border-red-900 p-6 text-center text-red-500 dark:text-red-400 text-sm">
+          <div className="bg-card rounded-lg border border-red-200 dark:border-red-900 p-4 text-center text-red-500 dark:text-red-400 text-[13px]">
             {t("forum.page.categoriesError")}
           </div>
         ) : !categories || categories.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-6 text-center text-muted-foreground text-sm">
+          <div className="bg-card rounded-lg border border-border p-4 text-center text-[13px] text-muted-foreground">
             {t("forum.page.noCategories")} {isHR ? t("forum.page.noCategoriesHr") : t("forum.page.noCategoriesEmployee")}
           </div>
         ) : (
@@ -126,14 +126,14 @@ export default function ForumPage() {
               <Link
                 key={cat.id}
                 to={`/forum/category/${cat.id}`}
-                className="bg-card rounded-xl border border-border p-4 hover:shadow-md hover:border-brand-200 dark:hover:border-brand-900 transition-all group"
+                className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150 group"
               >
                 <div className="flex items-center gap-3 mb-2">
-                  <div className="h-10 w-10 rounded-lg bg-brand-50 dark:bg-brand-950/40 flex items-center justify-center text-brand-600 dark:text-brand-400 group-hover:bg-brand-100 dark:group-hover:bg-brand-950/40 transition-colors">
+                  <div className="h-10 w-10 rounded-md bg-brand-50 dark:bg-brand-950/40 flex items-center justify-center text-brand-600 dark:text-brand-400 group-hover:bg-brand-100 dark:group-hover:bg-brand-950/40 transition-colors">
                     <span className="text-lg">{cat.icon || "#"}</span>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <h3 className="text-sm font-semibold text-foreground truncate">{cat.name}</h3>
+                    <h3 className="text-[13px] font-semibold text-foreground truncate">{cat.name}</h3>
                     <p className="text-xs text-muted-foreground">{t("forum.page.postsCount", { count: cat.post_count || 0 })}</p>
                   </div>
                 </div>
@@ -155,10 +155,10 @@ export default function ForumPage() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t("forum.page.searchPlaceholder")}
-            className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-transparent"
+            className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500 focus:border-transparent"
           />
         </div>
-        <div className="flex gap-1 bg-muted rounded-lg p-1">
+        <div className="flex gap-1 bg-muted rounded-md p-1">
           {[
             { key: "recent", label: t("forum.page.sortRecent") },
             { key: "popular", label: t("forum.page.sortPopular") },
@@ -184,7 +184,7 @@ export default function ForumPage() {
         {loadingPosts ? (
           <div className="space-y-3">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="bg-card rounded-xl border border-border p-5 animate-pulse">
+              <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
                 <div className="flex items-start gap-4">
                   <div className="h-10 w-10 rounded-full bg-muted flex-shrink-0" />
                   <div className="flex-1">
@@ -200,19 +200,19 @@ export default function ForumPage() {
             ))}
           </div>
         ) : postsError ? (
-          <div className="bg-card rounded-xl border border-red-200 dark:border-red-900 p-8 text-center">
+          <div className="bg-card rounded-lg border border-red-200 dark:border-red-900 p-8 text-center">
             <AlertCircle className="h-10 w-10 text-red-400 mx-auto mb-3" />
             <p className="text-sm text-red-600 dark:text-red-400 font-medium mb-1">{t("forum.page.postsError")}</p>
             <p className="text-sm text-red-500 dark:text-red-400">{t("forum.page.tryRefresh")}</p>
           </div>
         ) : posts.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-12 text-center">
+          <div className="bg-card rounded-lg border border-border p-12 text-center">
             <MessagesSquare className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
-            <p className="text-lg font-medium text-muted-foreground mb-1">{t("forum.page.noPosts")}</p>
+            <p className="text-base font-medium text-muted-foreground mb-1">{t("forum.page.noPosts")}</p>
             <p className="text-sm text-muted-foreground mb-4">{t("forum.page.beFirst")}</p>
             <Link
               to="/forum/new"
-              className="inline-flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+              className="inline-flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 transition-colors"
             >
               <Plus className="h-4 w-4" /> {t("forum.page.startDiscussion")}
             </Link>
@@ -225,7 +225,7 @@ export default function ForumPage() {
               <Link
                 key={post.id}
                 to={`/forum/post/${post.id}`}
-                className="block bg-card rounded-xl border border-border p-5 hover:shadow-md hover:border-brand-200 dark:hover:border-brand-900 transition-all"
+                className="block bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150"
               >
                 <div className="flex items-start gap-4">
                   {/* Author avatar */}
@@ -238,7 +238,7 @@ export default function ForumPage() {
 
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1 flex-wrap">
-                      <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${typeConfig.color}`}>
+                      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-md ${typeConfig.color}`}>
                         <TypeIcon className="h-3 w-3" />
                         {t(`forum.page.postType.${post.post_type}`, { defaultValue: post.post_type })}
                       </span>
@@ -255,13 +255,13 @@ export default function ForumPage() {
                       <span className="text-xs text-muted-foreground">{post.category_name}</span>
                     </div>
 
-                    <h3 className="text-sm font-semibold text-foreground mb-1">{post.title}</h3>
+                    <h3 className="text-[13px] font-semibold text-foreground mb-1">{post.title}</h3>
 
                     <p className="text-xs text-muted-foreground line-clamp-2 mb-2">
                       {post.content?.replace(/<[^>]*>/g, "").slice(0, 200)}
                     </p>
 
-                    <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                    <div className="flex items-center gap-4 text-[11px] tabular-nums text-muted-foreground">
                       <span>
                         {post.author_first_name} {post.author_last_name}
                       </span>
@@ -288,7 +288,7 @@ export default function ForumPage() {
                             .map((tag: string) => (
                               <span
                                 key={tag}
-                                className="bg-muted text-muted-foreground px-1.5 py-0.5 rounded text-xs"
+                                className="bg-muted text-muted-foreground px-1.5 py-0.5 rounded-md text-[11px]"
                               >
                                 #{tag}
                               </span>

--- a/packages/client/src/pages/forum/PostDetailPage.tsx
+++ b/packages/client/src/pages/forum/PostDetailPage.tsx
@@ -173,7 +173,7 @@ export default function PostDetailPage() {
                 </span>
                 <span className="text-xs text-muted-foreground">{timeAgo(reply.created_at, t)}</span>
                 {Boolean(reply.is_accepted) && (
-                  <span className="inline-flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded-full">
+                  <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950/40 px-2 py-0.5 rounded-md">
                     <CheckCircle2 className="h-3 w-3" /> {t("postDetail.reply.acceptedAnswer")}
                   </span>
                 )}
@@ -246,7 +246,7 @@ export default function PostDetailPage() {
       <div className="flex items-center gap-3 mb-6">
         <button
           onClick={() => navigate(-1)}
-          className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-muted-foreground transition-colors"
+          className="p-2 rounded-md hover:bg-muted text-muted-foreground hover:text-muted-foreground transition-colors"
         >
           <ArrowLeft className="h-5 w-5" />
         </button>
@@ -259,7 +259,7 @@ export default function PostDetailPage() {
       </div>
 
       {/* Post */}
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex items-start gap-4">
           <div className="h-12 w-12 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center flex-shrink-0">
             <span className="text-base font-semibold text-brand-700 dark:text-brand-300">
@@ -270,7 +270,7 @@ export default function PostDetailPage() {
 
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-2 flex-wrap">
-              <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${typeConfig.color}`}>
+              <span className={`inline-flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-md ${typeConfig.color}`}>
                 <TypeIcon className="h-3 w-3" />
                 {t(`postDetail.${typeConfig.labelKey}`)}
               </span>
@@ -286,7 +286,7 @@ export default function PostDetailPage() {
               )}
             </div>
 
-            <h1 className="text-xl font-bold text-foreground mb-1">{post.title}</h1>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground mb-1">{post.title}</h1>
 
             <div className="flex items-center gap-3 text-xs text-muted-foreground mb-4">
               <span className="font-medium text-muted-foreground">
@@ -372,8 +372,8 @@ export default function PostDetailPage() {
       </div>
 
       {/* Replies */}
-      <div className="bg-card rounded-xl border border-border p-6">
-        <h2 className="text-lg font-semibold text-foreground mb-2">
+      <div className="bg-card rounded-lg border border-border p-4">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2">
           {t("postDetail.replies.heading", { count: replies.length })}
         </h2>
 
@@ -416,14 +416,14 @@ export default function PostDetailPage() {
                   value={replyContent}
                   onChange={(e) => setReplyContent(e.target.value)}
                   placeholder={t("postDetail.form.placeholder")}
-                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[80px] focus:ring-2 focus:ring-brand-500 focus:border-transparent resize-y"
+                  className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[80px] focus:ring-2 focus:ring-brand-500 focus:border-transparent resize-y"
                   required
                 />
                 <div className="flex justify-end mt-2">
                   <button
                     type="submit"
                     disabled={submitReply.isPending || !replyContent.trim()}
-                    className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                    className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
                   >
                     <Send className="h-4 w-4" />
                     {submitReply.isPending ? t("postDetail.form.posting") : t("postDetail.form.submit")}

--- a/packages/client/src/pages/surveys/SurveyBuilderPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyBuilderPage.tsx
@@ -215,11 +215,11 @@ export default function SurveyBuilderPage() {
   return (
     <div className="max-w-4xl mx-auto">
       <div className="flex items-center gap-3 mb-8">
-        <button onClick={() => navigate("/surveys/list")} className="p-2 rounded-lg hover:bg-muted text-muted-foreground">
+        <button onClick={() => navigate("/surveys/list")} className="p-2 rounded-md hover:bg-muted text-muted-foreground">
           <ArrowLeft className="h-5 w-5" />
         </button>
         <div>
-          <h1 className="text-2xl font-bold text-foreground">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">
             {editId ? t("surveyBuilder.header.editTitle") : t("surveyBuilder.header.createTitle")}
           </h1>
           <p className="text-muted-foreground mt-0.5">{t("surveyBuilder.header.subtitle")}</p>
@@ -227,38 +227,38 @@ export default function SurveyBuilderPage() {
       </div>
 
       {/* Survey Details */}
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
-        <h2 className="text-lg font-semibold text-foreground mb-4">{t("surveyBuilder.details.heading")}</h2>
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyBuilder.details.heading")}</h2>
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.titleLabel")}</label>
+            <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.titleLabel")}</label>
             <input
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               placeholder={t("surveyBuilder.details.titlePlaceholder")}
               required
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.descriptionLabel")}</label>
+            <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.descriptionLabel")}</label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[80px]"
+              className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[80px]"
               placeholder={t("surveyBuilder.details.descriptionPlaceholder")}
             />
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.typeLabel")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.typeLabel")}</label>
               <select
                 value={type}
                 onChange={(e) => setType(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 {SURVEY_TYPES.map((st) => (
                   <option key={st.value} value={st.value}>{t(`surveyBuilder.${st.labelKey}`, { defaultValue: st.labelDefault })}</option>
@@ -267,11 +267,11 @@ export default function SurveyBuilderPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.targetAudienceLabel")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.targetAudienceLabel")}</label>
               <select
                 value={targetType}
                 onChange={(e) => setTargetType(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="all">{t("surveyBuilder.target.all")}</option>
                 <option value="department">{t("surveyBuilder.target.department")}</option>
@@ -281,11 +281,11 @@ export default function SurveyBuilderPage() {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.recurrenceLabel")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.recurrenceLabel")}</label>
               <select
                 value={recurrence}
                 onChange={(e) => setRecurrence(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               >
                 <option value="none">{t("surveyBuilder.recurrence.none")}</option>
                 <option value="weekly">{t("surveyBuilder.recurrence.weekly")}</option>
@@ -301,24 +301,24 @@ export default function SurveyBuilderPage() {
                 labels now say "Start Date & Time" and there's a helper line
                 under each input making the expectation explicit. */}
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.startDateLabel")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.startDateLabel")}</label>
               <input
                 type="datetime-local"
                 value={startDate}
                 onChange={(e) => setStartDate(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
               <p className="text-xs text-muted-foreground mt-1">{t("surveyBuilder.details.dateTimeHelper")}</p>
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.endDateLabel")}</label>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">{t("surveyBuilder.details.endDateLabel")}</label>
               <input
                 type="datetime-local"
                 value={endDate}
                 onChange={(e) => setEndDate(e.target.value)}
                 min={startDate || undefined}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
               <p className="text-xs text-muted-foreground mt-1">{t("surveyBuilder.details.dateTimeHelper")}</p>
             </div>
@@ -340,9 +340,9 @@ export default function SurveyBuilderPage() {
       </div>
 
       {/* Questions Builder */}
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-foreground">{t("surveyBuilder.questions.heading")}</h2>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t("surveyBuilder.questions.heading")}</h2>
           <button
             onClick={addQuestion}
             className="flex items-center gap-1.5 text-sm font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300"
@@ -364,7 +364,7 @@ export default function SurveyBuilderPage() {
                   >
                     <GripVertical className="h-4 w-4" />
                   </button>
-                  <span className="text-xs text-muted-foreground font-mono">{idx + 1}</span>
+                  <span className="text-xs text-muted-foreground font-mono tabular-nums">{idx + 1}</span>
                 </div>
 
                 <div className="flex-1 space-y-3">
@@ -373,7 +373,7 @@ export default function SurveyBuilderPage() {
                       type="text"
                       value={q.question_text}
                       onChange={(e) => updateQuestion(idx, "question_text", e.target.value)}
-                      className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                      className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                       placeholder={t("surveyBuilder.questions.textPlaceholder")}
                     />
                   </div>
@@ -384,7 +384,7 @@ export default function SurveyBuilderPage() {
                       <select
                         value={q.question_type}
                         onChange={(e) => updateQuestion(idx, "question_type", e.target.value)}
-                        className="bg-card text-foreground w-full px-3 py-1.5 border border-border rounded-lg text-sm"
+                        className="bg-card text-foreground w-full px-3 py-1.5 border border-border rounded-md text-[13px]"
                       >
                         {QUESTION_TYPES.map((qt) => (
                           <option key={qt.value} value={qt.value}>{t(`surveyBuilder.${qt.labelKey}`, { defaultValue: qt.labelDefault })}</option>
@@ -417,7 +417,7 @@ export default function SurveyBuilderPage() {
                           const opts = e.target.value.split("\n");
                           updateQuestion(idx, "options", opts.length > 0 ? opts : null);
                         }}
-                        className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[60px]"
+                        className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[60px]"
                         placeholder={t("surveyBuilder.questions.optionsPlaceholder")}
                       />
                     </div>
@@ -448,21 +448,21 @@ export default function SurveyBuilderPage() {
       <div className="flex items-center justify-end gap-3 pb-8">
         <button
           onClick={() => navigate("/surveys/list")}
-          className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+          className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
         >
           {t("surveyBuilder.actions.cancel")}
         </button>
         <button
           onClick={handleSaveDraft}
           disabled={isPending || !title.trim()}
-          className="flex items-center gap-2 px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted disabled:opacity-50"
+          className="flex items-center gap-2 px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted disabled:opacity-50"
         >
           <Save className="h-4 w-4" /> {t("surveyBuilder.actions.saveDraft")}
         </button>
         <button
           onClick={handlePublish}
           disabled={isPending || !title.trim() || questions.every((q) => !q.question_text.trim())}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
         >
           <Play className="h-4 w-4" /> {t("surveyBuilder.actions.savePublish")}
         </button>
@@ -572,7 +572,7 @@ function QuestionPreview({ question }: { question: Question }) {
         <p className="text-sm text-muted-foreground mb-2">{question_text}</p>
         <textarea
           disabled
-          className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card min-h-[60px]"
+          className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card min-h-[60px]"
           placeholder={t("surveyBuilder.preview.textPlaceholder")}
         />
       </div>

--- a/packages/client/src/pages/surveys/SurveyDashboardPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyDashboardPage.tsx
@@ -8,15 +8,15 @@ function StatCard({ label, value, icon: Icon, color, to }: { label: string; valu
   return (
     <Link
       to={to}
-      className="block text-left w-full bg-card rounded-xl border border-border p-6 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+      className="block text-left w-full bg-card rounded-lg border border-border p-4 transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
     >
       <div className="flex items-center gap-4">
-        <div className={`h-12 w-12 rounded-lg flex items-center justify-center ${color}`}>
+        <div className={`h-8 w-8 rounded-md flex items-center justify-center ${color}`}>
           <Icon className="h-6 w-6" />
         </div>
         <div>
           <p className="text-sm text-muted-foreground">{label}</p>
-          <p className="text-2xl font-bold text-foreground">{value}</p>
+          <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{value}</p>
         </div>
       </div>
     </Link>
@@ -27,8 +27,8 @@ function ENPSGauge({ score }: { score: number | null }) {
   const { t } = useTranslation();
   if (score === null) {
     return (
-      <div className="bg-card rounded-xl border border-border p-6">
-        <h3 className="text-sm font-semibold text-muted-foreground mb-4">{t("surveyDashboard.enpsScore")}</h3>
+      <div className="bg-card rounded-lg border border-border p-4">
+        <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyDashboard.enpsScore")}</h3>
         <p className="text-muted-foreground text-sm">{t("surveyDashboard.noEnps")}</p>
       </div>
     );
@@ -46,10 +46,10 @@ function ENPSGauge({ score }: { score: number | null }) {
           : t("surveyDashboard.enpsNeedsImprovement");
 
   return (
-    <div className="bg-card rounded-xl border border-border p-6">
-      <h3 className="text-sm font-semibold text-muted-foreground mb-4">{t("surveyDashboard.enpsScore")}</h3>
+    <div className="bg-card rounded-lg border border-border p-4">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyDashboard.enpsScore")}</h3>
       <div className={`inline-flex items-center gap-3 px-4 py-3 rounded-lg ${bgColor}`}>
-        <span className={`text-4xl font-bold ${color}`}>{score}</span>
+        <span className={`text-4xl font-semibold tabular-nums ${color}`}>{score}</span>
         <div>
           <p className={`text-sm font-medium ${color}`}>{label}</p>
           <p className="text-xs text-muted-foreground">{t("surveyDashboard.enpsRange")}</p>
@@ -94,14 +94,14 @@ export default function SurveyDashboardPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("surveyDashboard.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("surveyDashboard.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("surveyDashboard.subtitle")}</p>
         </div>
         <Link
           to="/surveys/builder"
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <ClipboardList className="h-4 w-4" /> {t("surveyDashboard.createSurvey")}
         </Link>
@@ -123,8 +123,8 @@ export default function SurveyDashboardPage() {
         <div className="lg:col-span-1">
           <ENPSGauge score={d.enps_score} />
         </div>
-        <div className="lg:col-span-1 bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4">{t("surveyDashboard.statusBreakdown")}</h3>
+        <div className="lg:col-span-1 bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyDashboard.statusBreakdown")}</h3>
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -146,8 +146,8 @@ export default function SurveyDashboardPage() {
             </div>
           </div>
         </div>
-        <div className="lg:col-span-1 bg-card rounded-xl border border-border p-6">
-          <h3 className="text-sm font-semibold text-muted-foreground mb-4">{t("surveyDashboard.organization")}</h3>
+        <div className="lg:col-span-1 bg-card rounded-lg border border-border p-4">
+          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyDashboard.organization")}</h3>
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">{t("surveyDashboard.totalEmployees")}</span>
@@ -162,7 +162,7 @@ export default function SurveyDashboardPage() {
       </div>
 
       {/* Recent Surveys Table */}
-      <div className="bg-card rounded-xl border border-border">
+      <div className="bg-card rounded-lg border border-border">
         <div className="px-6 py-4 border-b border-border flex items-center justify-between">
           <h3 className="text-sm font-semibold text-foreground">{t("surveyDashboard.recentSurveys")}</h3>
           <Link to="/surveys/list" className="text-xs text-brand-600 dark:text-brand-400 hover:underline">
@@ -173,33 +173,33 @@ export default function SurveyDashboardPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-border">
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyDashboard.colTitle")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyDashboard.colType")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyDashboard.colStatus")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyDashboard.colResponses")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyDashboard.colCreated")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyDashboard.colTitle")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyDashboard.colType")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyDashboard.colStatus")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyDashboard.colResponses")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyDashboard.colCreated")}</th>
               </tr>
             </thead>
             <tbody>
               {(d.recent_surveys || []).map((s: any) => (
-                <tr key={s.id} className="border-b border-border hover:bg-muted">
-                  <td className="px-6 py-3">
+                <tr key={s.id} className="border-b border-border hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-2.5">
                     <Link to={`/surveys/${s.id}/results`} className="text-brand-600 dark:text-brand-400 hover:underline font-medium">
                       {s.title}
                     </Link>
                   </td>
-                  <td className="px-6 py-3">
-                    <span className={`inline-flex text-xs font-medium px-2 py-0.5 rounded-full ${TYPE_BADGE[s.type] || TYPE_BADGE.custom}`}>
+                  <td className="px-4 py-2.5">
+                    <span className={`inline-flex text-[11px] font-medium px-2 py-0.5 rounded-md ${TYPE_BADGE[s.type] || TYPE_BADGE.custom}`}>
                       {t(`surveyDashboard.type.${s.type}`, { defaultValue: s.type })}
                     </span>
                   </td>
-                  <td className="px-6 py-3">
-                    <span className={`inline-flex text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_BADGE[s.status] || STATUS_BADGE.draft}`}>
+                  <td className="px-4 py-2.5">
+                    <span className={`inline-flex text-[11px] font-medium px-2 py-0.5 rounded-md ${STATUS_BADGE[s.status] || STATUS_BADGE.draft}`}>
                       {t(`surveyDashboard.status.${s.status}`, { defaultValue: s.status })}
                     </span>
                   </td>
-                  <td className="px-6 py-3 text-muted-foreground">{s.response_count}</td>
-                  <td className="px-6 py-3 text-muted-foreground">
+                  <td className="px-4 py-2.5 text-muted-foreground">{s.response_count}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground">
                     {new Date(s.created_at).toLocaleDateString()}
                   </td>
                 </tr>

--- a/packages/client/src/pages/surveys/SurveyListPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyListPage.tsx
@@ -81,14 +81,14 @@ export default function SurveyListPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("surveys.list.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("surveys.list.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("surveys.list.subtitle")}</p>
         </div>
         <Link
           to="/surveys/builder"
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {t("surveys.list.new")}
         </Link>
@@ -99,7 +99,7 @@ export default function SurveyListPage() {
         <select
           value={statusFilter}
           onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-          className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+          className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
         >
           <option value="">{t("surveys.list.allStatuses")}</option>
           <option value="draft">{t("surveys.list.status.draft")}</option>
@@ -110,7 +110,7 @@ export default function SurveyListPage() {
         <select
           value={typeFilter}
           onChange={(e) => { setTypeFilter(e.target.value); setPage(1); }}
-          className="bg-card text-foreground px-3 py-2 border border-border rounded-lg text-sm"
+          className="bg-card text-foreground px-3 py-2 border border-border rounded-md text-[13px]"
         >
           <option value="">{t("surveys.list.allTypes")}</option>
           <option value="pulse">{t("surveys.list.type.pulse")}</option>
@@ -123,18 +123,18 @@ export default function SurveyListPage() {
       </div>
 
       {/* Table */}
-      <div className="bg-card rounded-xl border border-border overflow-hidden">
+      <div className="bg-card rounded-lg border border-border overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full text-sm">
+          <table className="w-full text-[13px]">
             <thead>
               <tr className="border-b border-border bg-muted">
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colTitle")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colType")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colStatus")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colAnonymous")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colResponses")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colDates")}</th>
-                <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveys.list.colActions")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colTitle")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colType")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colStatus")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colAnonymous")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colResponses")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colDates")}</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveys.list.colActions")}</th>
               </tr>
             </thead>
             <tbody>
@@ -150,33 +150,33 @@ export default function SurveyListPage() {
                 </tr>
               ) : (
                 surveys.map((s: any) => (
-                  <tr key={s.id} className="border-b border-border hover:bg-muted">
-                    <td className="px-6 py-4">
+                  <tr key={s.id} className="border-b border-border hover:bg-muted/50 transition-colors">
+                    <td className="px-4 py-2.5">
                       <p className="font-medium text-foreground">{s.title}</p>
                       {s.description && (
                         <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{s.description}</p>
                       )}
                     </td>
-                    <td className="px-6 py-4">
-                      <span className={`inline-flex text-xs font-medium px-2 py-0.5 rounded-full ${TYPE_BADGE[s.type] || TYPE_BADGE.custom}`}>
+                    <td className="px-4 py-2.5">
+                      <span className={`inline-flex text-[11px] font-medium px-2 py-0.5 rounded-md ${TYPE_BADGE[s.type] || TYPE_BADGE.custom}`}>
                         {t(`surveys.list.type.${s.type}`, { defaultValue: s.type })}
                       </span>
                     </td>
-                    <td className="px-6 py-4">
-                      <span className={`inline-flex text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_BADGE[s.status] || STATUS_BADGE.draft}`}>
+                    <td className="px-4 py-2.5">
+                      <span className={`inline-flex text-[11px] font-medium px-2 py-0.5 rounded-md ${STATUS_BADGE[s.status] || STATUS_BADGE.draft}`}>
                         {t(`surveys.list.status.${s.status}`, { defaultValue: s.status })}
                       </span>
                     </td>
-                    <td className="px-6 py-4 text-muted-foreground">
+                    <td className="px-4 py-2.5 text-muted-foreground">
                       {s.is_anonymous ? t("surveys.list.yes") : t("surveys.list.no")}
                     </td>
-                    <td className="px-6 py-4 text-muted-foreground">{s.response_count}</td>
-                    <td className="px-6 py-4 text-xs text-muted-foreground">
+                    <td className="px-4 py-2.5 text-muted-foreground">{s.response_count}</td>
+                    <td className="px-4 py-2.5 text-xs text-muted-foreground">
                       {s.start_date && <div>{t("surveys.list.start", { date: new Date(s.start_date).toLocaleDateString() })}</div>}
                       {s.end_date && <div>{t("surveys.list.end", { date: new Date(s.end_date).toLocaleDateString() })}</div>}
                       {!s.start_date && !s.end_date && <span>-</span>}
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       <div className="flex items-center gap-1">
                         {s.status === "draft" && (
                           <>
@@ -258,21 +258,21 @@ export default function SurveyListPage() {
         <div className="flex items-center justify-between mt-6">
           {/* #1533 — Show the per-page count alongside the total so admins can
               tell at a glance how many surveys are in view, not just the total. */}
-          <p className="text-sm text-muted-foreground">
+          <p className="text-[13px] tabular-nums text-muted-foreground">
             {t("surveys.list.showing", { shown: surveys.length, total: meta.total, page: meta.page, total_pages: meta.total_pages })}
           </p>
           <div className="flex gap-2">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("surveys.list.previous")}
             </button>
             <button
               onClick={() => setPage((p) => p + 1)}
               disabled={page >= meta.total_pages}
-              className="bg-card text-foreground px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50"
+              className="bg-card text-foreground px-3 py-1.5 text-[13px] border border-border rounded-md hover:bg-muted transition-colors disabled:opacity-50"
             >
               {t("surveys.list.next")}
             </button>

--- a/packages/client/src/pages/surveys/SurveyRespondPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyRespondPage.tsx
@@ -47,17 +47,17 @@ export default function SurveyRespondPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t("surveyRespond.title")}</h1>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("surveyRespond.title")}</h1>
         <p className="text-muted-foreground mt-1">{t("surveyRespond.subtitle")}</p>
       </div>
 
       {/* Pending Surveys */}
       <div className="mb-8">
-        <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+        <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
           <Clock className="h-5 w-5 text-orange-500" />
           {t("surveyRespond.pending")}
           {pendingSurveys.length > 0 && (
-            <span className="bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300 text-xs font-medium px-2 py-0.5 rounded-full">
+            <span className="bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300 text-[11px] font-semibold px-2 py-0.5 rounded-md">
               {pendingSurveys.length}
             </span>
           )}
@@ -66,7 +66,7 @@ export default function SurveyRespondPage() {
         {isLoading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {[1, 2].map((i) => (
-              <div key={i} className="bg-card rounded-xl border border-border p-6 animate-pulse">
+              <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
                 <div className="flex items-center gap-2 mb-3">
                   <div className="h-5 w-16 bg-muted rounded-full" />
                 </div>
@@ -77,7 +77,7 @@ export default function SurveyRespondPage() {
             ))}
           </div>
         ) : pendingSurveys.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-12 text-center">
+          <div className="bg-card rounded-lg border border-border p-12 text-center">
             <ClipboardList className="h-12 w-12 mx-auto mb-4 text-muted-foreground/50" />
             <p className="text-lg font-medium text-muted-foreground mb-1">{t("surveyRespond.noActive")}</p>
             <p className="text-sm text-muted-foreground">{t("surveyRespond.noActiveHint")}</p>
@@ -85,11 +85,11 @@ export default function SurveyRespondPage() {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {pendingSurveys.map((s: any) => (
-              <div key={s.id} className="bg-card rounded-xl border border-border p-6 hover:shadow-md transition-shadow">
+              <div key={s.id} className="bg-card rounded-lg border border-border p-4 hover:border-brand-400 transition-colors duration-150">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-2">
-                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                      <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-md ${
                         s.type === "enps" ? "bg-indigo-100 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300" :
                         s.type === "pulse" ? "bg-purple-100 dark:bg-purple-950/40 text-purple-700 dark:text-purple-300" :
                         s.type === "engagement" ? "bg-teal-100 dark:bg-teal-950/40 text-teal-700 dark:text-teal-300" :
@@ -114,7 +114,7 @@ export default function SurveyRespondPage() {
                 </div>
                 <button
                   onClick={() => setSelectedSurveyId(s.id)}
-                  className="mt-4 w-full flex items-center justify-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+                  className="mt-4 w-full flex items-center justify-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
                 >
                   <Send className="h-4 w-4" /> {t("surveyRespond.takeSurvey")}
                 </button>
@@ -127,11 +127,11 @@ export default function SurveyRespondPage() {
       {/* Completed Surveys */}
       {completedSurveys.length > 0 && (
         <div className="mb-8">
-          <h2 className="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4 flex items-center gap-2">
             <CheckCircle className="h-5 w-5 text-green-500" />
             {t("surveyRespond.completed")}
           </h2>
-          <div className="bg-card rounded-xl border border-border overflow-hidden">
+          <div className="bg-card rounded-lg border border-border overflow-hidden">
             {completedSurveys.map((s: any) => (
               <div key={s.id} className="flex items-center justify-between px-6 py-4 border-b border-border last:border-0">
                 <div>
@@ -150,26 +150,26 @@ export default function SurveyRespondPage() {
       {/* My Past Responses */}
       {myResponses && myResponses.length > 0 && (
         <div>
-          <h2 className="text-lg font-semibold text-foreground mb-4">{t("surveyRespond.responseHistory")}</h2>
-          <div className="bg-card rounded-xl border border-border overflow-hidden">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyRespond.responseHistory")}</h2>
+          <div className="bg-card rounded-lg border border-border overflow-hidden">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border bg-muted">
-                  <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyRespond.colSurvey")}</th>
-                  <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyRespond.colType")}</th>
-                  <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyRespond.colSubmitted")}</th>
-                  <th className="text-left px-6 py-3 text-xs font-medium text-muted-foreground uppercase">{t("surveyRespond.colAnonymous")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyRespond.colSurvey")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyRespond.colType")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyRespond.colSubmitted")}</th>
+                  <th className="text-left px-4 py-2.5 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("surveyRespond.colAnonymous")}</th>
                 </tr>
               </thead>
               <tbody>
                 {myResponses.map((r: any) => (
                   <tr key={r.response_id} className="border-b border-border">
-                    <td className="px-6 py-3 text-muted-foreground">{r.title}</td>
-                    <td className="px-6 py-3 text-muted-foreground">{surveyTypeLabel(r.type, t)}</td>
-                    <td className="px-6 py-3 text-muted-foreground">
+                    <td className="px-4 py-2.5 text-muted-foreground">{r.title}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground">{surveyTypeLabel(r.type, t)}</td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
                       {new Date(r.submitted_at).toLocaleDateString()}
                     </td>
-                    <td className="px-6 py-3 text-muted-foreground">
+                    <td className="px-4 py-2.5 text-muted-foreground">
                       {r.is_anonymous ? t("surveyRespond.yes") : t("surveyRespond.no")}
                     </td>
                   </tr>
@@ -238,7 +238,7 @@ function SurveyFillForm({
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <CheckCircle className="h-16 w-16 text-green-500 mb-4" />
-        <h2 className="text-xl font-bold text-foreground mb-2">{t("surveyRespond.thankYou")}</h2>
+        <h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">{t("surveyRespond.thankYou")}</h2>
         <p className="text-muted-foreground">{t("surveyRespond.submittedSuccess")}</p>
       </div>
     );
@@ -257,9 +257,9 @@ function SurveyFillForm({
         &larr; {t("surveyRespond.backToSurveys")}
       </button>
 
-      <div className="bg-card rounded-xl border border-border p-6 mb-6">
+      <div className="bg-card rounded-lg border border-border p-4 mb-6">
         <div className="flex items-center gap-2 mb-2">
-          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+          <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-md ${
             survey.type === "enps" ? "bg-indigo-100 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300" :
             survey.type === "pulse" ? "bg-purple-100 dark:bg-purple-950/40 text-purple-700 dark:text-purple-300" :
             "bg-muted text-muted-foreground"
@@ -270,7 +270,7 @@ function SurveyFillForm({
             <span className="text-xs text-muted-foreground">{t("surveyRespond.responsesAnonymous")}</span>
           )}
         </div>
-        <h1 className="text-xl font-bold text-foreground">{survey.title}</h1>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{survey.title}</h1>
         {survey.description && (
           <p className="text-muted-foreground mt-2">{survey.description}</p>
         )}
@@ -279,9 +279,9 @@ function SurveyFillForm({
       {/* Questions */}
       <div className="space-y-4">
         {questions.map((q: any, idx: number) => (
-          <div key={q.id} className="bg-card rounded-xl border border-border p-6">
+          <div key={q.id} className="bg-card rounded-lg border border-border p-4">
             <div className="flex items-start gap-3">
-              <span className="text-sm font-mono text-muted-foreground mt-0.5">{idx + 1}.</span>
+              <span className="text-[13px] tabular-nums font-mono text-muted-foreground mt-0.5">{idx + 1}.</span>
               <div className="flex-1">
                 <p className="text-sm font-medium text-foreground mb-3">
                   {q.question_text}
@@ -302,14 +302,14 @@ function SurveyFillForm({
       <div className="flex items-center justify-end gap-3 mt-6 pb-8">
         <button
           onClick={onBack}
-          className="px-4 py-2 text-sm border border-border rounded-lg text-muted-foreground hover:bg-muted"
+          className="px-4 py-2 text-[13px] border border-border rounded-md text-muted-foreground hover:bg-muted"
         >
           {t("surveyRespond.cancel")}
         </button>
         <button
           onClick={handleSubmit}
           disabled={submitMutation.isPending}
-          className="flex items-center gap-2 bg-brand-600 text-white px-6 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+          className="flex items-center gap-2 bg-brand-600 text-white px-6 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
         >
           <Send className="h-4 w-4" /> {t("surveyRespond.submitResponse")}
         </button>
@@ -463,7 +463,7 @@ function QuestionInput({
       <textarea
         value={value?.text_value || ""}
         onChange={(e) => onChange({ text_value: e.target.value })}
-        className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm min-h-[80px]"
+        className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px] min-h-[80px]"
         placeholder={t("surveyRespond.textPlaceholder")}
       />
     );

--- a/packages/client/src/pages/surveys/SurveyResultsPage.tsx
+++ b/packages/client/src/pages/surveys/SurveyResultsPage.tsx
@@ -49,13 +49,13 @@ export default function SurveyResultsPage() {
   return (
     <div className="max-w-4xl mx-auto">
       <div className="flex items-center gap-3 mb-6">
-        <Link to="/surveys/list" className="p-2 rounded-lg hover:bg-muted text-muted-foreground">
+        <Link to="/surveys/list" className="p-2 rounded-md hover:bg-muted text-muted-foreground">
           <ArrowLeft className="h-5 w-5" />
         </Link>
         <div className="flex-1">
-          <h1 className="text-2xl font-bold text-foreground">{data.title}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{data.title}</h1>
           <div className="flex items-center gap-3 mt-1">
-            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-md ${
               data.status === "active" ? "bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300" :
               data.status === "closed" ? "bg-blue-100 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300" :
               "bg-muted text-muted-foreground"
@@ -67,7 +67,7 @@ export default function SurveyResultsPage() {
         </div>
         <button
           onClick={exportCSV}
-          className="flex items-center gap-2 px-3 py-2 border border-border rounded-lg text-sm text-muted-foreground hover:bg-muted"
+          className="flex items-center gap-2 px-3 py-2 border border-border rounded-md text-[13px] text-muted-foreground hover:bg-muted"
         >
           <Download className="h-4 w-4" /> {t("surveyResults.actions.exportCsv")}
         </button>
@@ -83,15 +83,15 @@ export default function SurveyResultsPage() {
               ?.scrollIntoView({ behavior: "smooth", block: "start" })
           }
           aria-label={t("surveyResults.a11y.jumpToPerQuestion")}
-          className="bg-card rounded-xl border border-border p-5 text-left transition hover:border-brand-400 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="bg-card rounded-lg border border-border p-4 text-left transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-md bg-blue-100 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 flex items-center justify-center">
               <Users className="h-5 w-5" />
             </div>
             <div>
               <p className="text-xs text-muted-foreground">{t("surveyResults.summary.totalResponses")}</p>
-              <p className="text-xl font-bold text-foreground">{data.response_count}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{data.response_count}</p>
             </div>
           </div>
         </button>
@@ -104,15 +104,15 @@ export default function SurveyResultsPage() {
               ?.scrollIntoView({ behavior: "smooth", block: "start" })
           }
           aria-label={t("surveyResults.a11y.jumpToQuestionsBreakdown")}
-          className="bg-card rounded-xl border border-border p-5 text-left transition hover:border-brand-400 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+          className="bg-card rounded-lg border border-border p-4 text-left transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
         >
           <div className="flex items-center gap-3">
-            <div className="h-10 w-10 rounded-lg bg-purple-100 dark:bg-purple-950/40 text-purple-600 dark:text-purple-400 flex items-center justify-center">
+            <div className="h-8 w-8 rounded-md bg-purple-100 dark:bg-purple-950/40 text-purple-600 dark:text-purple-400 flex items-center justify-center">
               <BarChart3 className="h-5 w-5" />
             </div>
             <div>
               <p className="text-xs text-muted-foreground">{t("surveyResults.summary.questions")}</p>
-              <p className="text-xl font-bold text-foreground">{data.questions.length}</p>
+              <p className="text-2xl font-semibold tabular-nums leading-none text-foreground">{data.questions.length}</p>
             </div>
           </div>
         </button>
@@ -126,13 +126,13 @@ export default function SurveyResultsPage() {
                 ?.scrollIntoView({ behavior: "smooth", block: "start" })
             }
             aria-label={t("surveyResults.a11y.jumpToEnpsBreakdown")}
-            className="bg-card rounded-xl border border-border p-5 text-left transition hover:border-brand-400 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="bg-card rounded-lg border border-border p-4 text-left transition-colors duration-150 hover:border-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <div className="flex items-center gap-3">
-              <div className={`h-10 w-10 rounded-lg flex items-center justify-center ${
+              <div className={`h-8 w-8 rounded-md flex items-center justify-center ${
                 data.overall_enps.score >= 0 ? "bg-green-100 dark:bg-green-950/40 text-green-600 dark:text-green-400" : "bg-red-100 dark:bg-red-950/40 text-red-600 dark:text-red-400"
               }`}>
-                <span className="text-lg font-bold">{data.overall_enps.score >= 0 ? "+" : ""}{data.overall_enps.score}</span>
+                <span className="text-lg font-semibold tabular-nums">{data.overall_enps.score >= 0 ? "+" : ""}{data.overall_enps.score}</span>
               </div>
               <div>
                 <p className="text-xs text-muted-foreground">{t("surveyResults.summary.enpsScore")}</p>
@@ -147,16 +147,16 @@ export default function SurveyResultsPage() {
 
       {/* eNPS Breakdown */}
       {data.overall_enps && (
-        <div id="enps-breakdown" className="bg-card rounded-xl border border-border p-6 mb-6 scroll-mt-4">
-          <h2 className="text-lg font-semibold text-foreground mb-4">{t("surveyResults.enps.breakdownTitle")}</h2>
+        <div id="enps-breakdown" className="bg-card rounded-lg border border-border p-4 mb-6 scroll-mt-4">
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-4">{t("surveyResults.enps.breakdownTitle")}</h2>
           <div className="grid grid-cols-3 gap-4">
             <div className="text-center p-4 bg-green-50 dark:bg-green-950/40 rounded-lg">
-              <p className="text-2xl font-bold text-green-600 dark:text-green-400">{data.overall_enps.promoters}</p>
+              <p className="text-2xl font-semibold tabular-nums text-green-600 dark:text-green-400">{data.overall_enps.promoters}</p>
               <p className="text-sm text-green-700 dark:text-green-300 font-medium">{t("surveyResults.enps.promoters")}</p>
               <p className="text-xs text-green-600 dark:text-green-400">{data.overall_enps.promoter_pct}%</p>
             </div>
             <div className="text-center p-4 bg-yellow-50 dark:bg-yellow-950/40 rounded-lg">
-              <p className="text-2xl font-bold text-yellow-600 dark:text-yellow-400">{data.overall_enps.passives}</p>
+              <p className="text-2xl font-semibold tabular-nums text-yellow-600 dark:text-yellow-400">{data.overall_enps.passives}</p>
               <p className="text-sm text-yellow-700 dark:text-yellow-300 font-medium">{t("surveyResults.enps.passives")}</p>
               <p className="text-xs text-yellow-600 dark:text-yellow-400">
                 {data.overall_enps.total > 0
@@ -165,7 +165,7 @@ export default function SurveyResultsPage() {
               </p>
             </div>
             <div className="text-center p-4 bg-red-50 dark:bg-red-950/40 rounded-lg">
-              <p className="text-2xl font-bold text-red-600 dark:text-red-400">{data.overall_enps.detractors}</p>
+              <p className="text-2xl font-semibold tabular-nums text-red-600 dark:text-red-400">{data.overall_enps.detractors}</p>
               <p className="text-sm text-red-700 dark:text-red-300 font-medium">{t("surveyResults.enps.detractors")}</p>
               <p className="text-xs text-red-600 dark:text-red-400">{data.overall_enps.detractor_pct}%</p>
             </div>
@@ -205,9 +205,9 @@ export default function SurveyResultsPage() {
       {/* Per-Question Results */}
       <div id="per-question-results" className="space-y-4 pb-8 scroll-mt-4">
         {data.questions.map((q: any, idx: number) => (
-          <div key={q.question_id} className="bg-card rounded-xl border border-border p-6">
+          <div key={q.question_id} className="bg-card rounded-lg border border-border p-4">
             <div className="flex items-start gap-3 mb-4">
-              <span className="text-sm font-mono text-muted-foreground">{idx + 1}.</span>
+              <span className="text-[13px] tabular-nums font-mono text-muted-foreground">{idx + 1}.</span>
               <div className="flex-1">
                 <p className="font-medium text-foreground">{q.question_text}</p>
                 <p className="text-xs text-muted-foreground mt-0.5">


### PR DESCRIPTION
Applies the page-uplift UI guide (docs/UI-UPLIFT-GUIDE.md, PR #2243) to the **Forum + Surveys** modules — **PR 3 of 3** (final) for the Engagement area.

**Pages (9):** Forum, Category Posts, Create Post, Post Detail · Survey Dashboard, Survey List, Survey Builder, Survey Respond, Survey Results.

- Compact headers; `rounded-lg` cards / `rounded-md` controls; `text-[11px]` uppercase table + panel headers; `px-4 py-2.5` dense rows; `tabular-nums` on view/like/reply counts, response counts, ratings, eNPS scores, dates and percentages; KPI stat tiles; `rounded-md` post-type / survey-status pills.
- **Preserved as chrome/decoration:** survey question rating circles, radio/option answer buttons, the anonymity toggle knob (`after:bg-white`), eNPS + results chart/bar colors and their `rounded-full` tracks, forum author avatars, and post-type / survey category color maps — all untouched; modal/dialog titles keep `text-lg`.

No dark-mode bugs or raw-gray migrations needed in this batch — the whole module already uses semantic tokens with paired `dark:` variants.

Surface-only — no data, query, or logic changes. tsc clean, build passes. Light + dark verified.

**This completes the Engagement area** (PRs #2260, #2261, and this one = 27 pages across 6 sub-modules).