### PR TITLE
UI density uplift: Config & Settings pages

### DIFF
--- a/packages/client/src/pages/account/ChangePasswordPage.tsx
+++ b/packages/client/src/pages/account/ChangePasswordPage.tsx
@@ -15,8 +15,8 @@ export default function ChangePasswordPage() {
   return (
     <div className="max-w-3xl">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-foreground">{t("accountSecurity.title")}</h1>
-        <p className="text-muted-foreground mt-1">{t("accountSecurity.subtitle")}</p>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("accountSecurity.title")}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{t("accountSecurity.subtitle")}</p>
       </div>
       <ChangePasswordCard />
     </div>

--- a/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
+++ b/packages/client/src/pages/custom-fields/CustomFieldsSettingsPage.tsx
@@ -256,7 +256,7 @@ export default function CustomFieldsSettingsPage() {
     <div>
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("customFieldsSettings.page.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("customFieldsSettings.page.title")}</h1>
           <p className="text-sm text-muted-foreground mt-1">
             {t("customFieldsSettings.page.subtitle")}
           </p>
@@ -267,7 +267,7 @@ export default function CustomFieldsSettingsPage() {
               resetForm();
               setShowForm(true);
             }}
-            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 transition-colors"
+            className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 transition-colors"
           >
             <Plus className="h-4 w-4" />
             {t("customFieldsSettings.actions.addField")}
@@ -301,10 +301,10 @@ export default function CustomFieldsSettingsPage() {
       {showForm && (
         <div
           ref={formRef}
-          className="bg-card rounded-xl border border-border p-6 mb-6 scroll-mt-4"
+          className="bg-card rounded-lg border border-border p-4 mb-6 scroll-mt-4"
         >
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-foreground">
+            <h2 className="text-base font-semibold text-foreground">
               {editingId ? t("customFieldsSettings.form.editTitle") : t("customFieldsSettings.form.newTitle")}
             </h2>
             <div className="flex items-center gap-2">
@@ -338,7 +338,7 @@ export default function CustomFieldsSettingsPage() {
                     setForm({ ...form, field_name: e.target.value })
                   }
                   placeholder={t("customFieldsSettings.form.fieldNamePlaceholder")}
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                   required
                 />
               </div>
@@ -353,7 +353,7 @@ export default function CustomFieldsSettingsPage() {
                   onChange={(e) =>
                     setForm({ ...form, field_type: e.target.value, options: [] })
                   }
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                 >
                   {FIELD_TYPES.map(({ value, label }) => (
                     <option key={value} value={value}>
@@ -375,7 +375,7 @@ export default function CustomFieldsSettingsPage() {
                     setForm({ ...form, section: e.target.value })
                   }
                   placeholder={t("customFieldsSettings.form.sectionPlaceholder")}
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                 />
               </div>
 
@@ -390,7 +390,7 @@ export default function CustomFieldsSettingsPage() {
                   onChange={(e) =>
                     setForm({ ...form, placeholder: e.target.value })
                   }
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                 />
               </div>
 
@@ -405,7 +405,7 @@ export default function CustomFieldsSettingsPage() {
                   onChange={(e) =>
                     setForm({ ...form, default_value: e.target.value })
                   }
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                 />
               </div>
 
@@ -421,7 +421,7 @@ export default function CustomFieldsSettingsPage() {
                     setForm({ ...form, validation_regex: e.target.value })
                   }
                   placeholder="^[A-Z]{2}\d{4}$"
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                 />
               </div>
 
@@ -438,7 +438,7 @@ export default function CustomFieldsSettingsPage() {
                       onChange={(e) =>
                         setForm({ ...form, min_value: e.target.value })
                       }
-                      className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                      className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                     />
                   </div>
                   <div>
@@ -451,7 +451,7 @@ export default function CustomFieldsSettingsPage() {
                       onChange={(e) =>
                         setForm({ ...form, max_value: e.target.value })
                       }
-                      className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                      className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                     />
                   </div>
                 </>
@@ -469,7 +469,7 @@ export default function CustomFieldsSettingsPage() {
                   setForm({ ...form, help_text: e.target.value })
                 }
                 rows={2}
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                 placeholder={t("customFieldsSettings.form.helpTextPlaceholder")}
               />
             </div>
@@ -492,12 +492,12 @@ export default function CustomFieldsSettingsPage() {
                       }
                     }}
                     placeholder={t("customFieldsSettings.form.optionInputPlaceholder")}
-                    className="flex-1 border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                    className="flex-1 border border-border rounded-md px-3 py-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
                   />
                   <button
                     type="button"
                     onClick={addOption}
-                    className="px-3 py-2 bg-muted text-foreground rounded-lg text-sm hover:bg-muted-foreground/10 transition-colors"
+                    className="px-3 py-2 bg-muted text-foreground rounded-md text-[13px] hover:bg-muted-foreground/10 transition-colors"
                   >
                     {t("customFieldsSettings.form.addOption")}
                   </button>
@@ -507,7 +507,7 @@ export default function CustomFieldsSettingsPage() {
                     {form.options.map((opt, idx) => (
                       <span
                         key={idx}
-                        className="inline-flex items-center gap-1 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 px-2.5 py-1 rounded-full text-sm"
+                        className="inline-flex items-center gap-1 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 px-2.5 py-1 rounded-md text-[13px]"
                       >
                         {opt}
                         <button
@@ -595,7 +595,7 @@ export default function CustomFieldsSettingsPage() {
               <button
                 type="submit"
                 disabled={createMutation.isPending || updateMutation.isPending}
-                className="bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 transition-colors disabled:opacity-50"
+                className="bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 transition-colors disabled:opacity-50"
               >
                 {createMutation.isPending || updateMutation.isPending
                   ? t("customFieldsSettings.form.saving")
@@ -617,7 +617,7 @@ export default function CustomFieldsSettingsPage() {
       {isLoading ? (
         <div className="text-center py-10 text-muted-foreground">{t("customFieldsSettings.list.loading")}</div>
       ) : fields.length === 0 ? (
-        <div className="bg-card rounded-xl border border-border p-10 text-center">
+        <div className="bg-card rounded-lg border border-border p-10 text-center">
           <p className="text-muted-foreground">
             {t("customFieldsSettings.list.emptyTitle", {
               name:
@@ -636,7 +636,7 @@ export default function CustomFieldsSettingsPage() {
       ) : (
         Object.entries(sections).map(([sectionName, sectionFields]) => (
           <div key={sectionName} className="mb-6">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-3">
+            <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">
               {sectionName}
             </h3>
             {/*
@@ -644,34 +644,34 @@ export default function CustomFieldsSettingsPage() {
               table keep the action column (edit/delete icons) reachable on
               narrow widths instead of clipping them off-screen.
             */}
-            <div className="bg-card rounded-xl border border-border overflow-x-auto">
+            <div className="bg-card rounded-lg border border-border overflow-x-auto">
               <table className="w-full min-w-[720px]">
                 <thead className="bg-muted">
                   <tr>
                     <th className="w-10" />
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-4 py-3">
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
                       {t("customFieldsSettings.table.fieldName")}
                     </th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-4 py-3">
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
                       {t("customFieldsSettings.table.key")}
                     </th>
-                    <th className="text-left text-xs font-medium text-muted-foreground uppercase px-4 py-3">
+                    <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
                       {t("customFieldsSettings.table.type")}
                     </th>
-                    <th className="text-center text-xs font-medium text-muted-foreground uppercase px-4 py-3">
+                    <th className="text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
                       {t("customFieldsSettings.table.required")}
                     </th>
-                    <th className="text-center text-xs font-medium text-muted-foreground uppercase px-4 py-3">
+                    <th className="text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
                       {t("customFieldsSettings.table.searchable")}
                     </th>
-                    <th className="text-right text-xs font-medium text-muted-foreground uppercase px-4 py-3">
+                    <th className="text-right text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">
                       {t("customFieldsSettings.table.actions")}
                     </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border">
                   {sectionFields.map((field) => (
-                    <tr key={field.id} className="hover:bg-muted">
+                    <tr key={field.id} className="hover:bg-muted/50 transition-colors">
                       <td className="px-2">
                         <div className="flex flex-col items-center gap-0.5">
                           <button
@@ -689,20 +689,20 @@ export default function CustomFieldsSettingsPage() {
                           </button>
                         </div>
                       </td>
-                      <td className="px-4 py-3">
-                        <div className="text-sm font-medium text-foreground">
+                      <td className="px-4 py-2.5">
+                        <div className="text-[13px] font-medium text-foreground">
                           {field.field_name}
                         </div>
                         {field.help_text && (
-                          <div className="text-xs text-muted-foreground mt-0.5">
+                          <div className="text-[11px] text-muted-foreground mt-0.5">
                             {field.help_text}
                           </div>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground font-mono">
+                      <td className="px-4 py-2.5 text-[13px] text-muted-foreground font-mono tabular-nums">
                         {field.field_key}
                       </td>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-2.5">
                         <span className="inline-block bg-muted text-muted-foreground px-2 py-0.5 rounded text-xs font-medium">
                           {t(`customFieldsSettings.fieldType.${field.field_type}`, { defaultValue: field.field_type })}
                         </span>
@@ -712,7 +712,7 @@ export default function CustomFieldsSettingsPage() {
                           </span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-center">
+                      <td className="px-4 py-2.5 text-center">
                         {field.is_required ? (
                           <span className="text-green-600 dark:text-green-400 text-xs font-medium">
                             {t("customFieldsSettings.table.yes")}
@@ -721,7 +721,7 @@ export default function CustomFieldsSettingsPage() {
                           <span className="text-muted-foreground/50 text-xs">{t("customFieldsSettings.table.no")}</span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-center">
+                      <td className="px-4 py-2.5 text-center">
                         {field.is_searchable ? (
                           <span className="text-green-600 dark:text-green-400 text-xs font-medium">
                             {t("customFieldsSettings.table.yes")}
@@ -730,7 +730,7 @@ export default function CustomFieldsSettingsPage() {
                           <span className="text-muted-foreground/50 text-xs">{t("customFieldsSettings.table.no")}</span>
                         )}
                       </td>
-                      <td className="px-4 py-3 text-right whitespace-nowrap">
+                      <td className="px-4 py-2.5 text-right whitespace-nowrap">
                         <div className="flex items-center justify-end gap-1 flex-shrink-0">
                           <button
                             onClick={() => startEdit(field)}
@@ -782,7 +782,7 @@ export default function CustomFieldsSettingsPage() {
 function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
   const { t } = useTranslation();
   const commonClass =
-    "w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground";
+    "w-full border border-border rounded-md px-3 py-2 text-[13px] bg-card text-foreground";
 
   return (
     <div className="max-w-md">
@@ -849,7 +849,7 @@ function FieldPreview({ form }: { form: typeof INITIAL_FORM }) {
           ))}
         </select>
       ) : form.field_type === "multi_select" ? (
-        <div className="flex flex-wrap gap-2 p-2 border border-border rounded-lg bg-card min-h-[38px]">
+        <div className="flex flex-wrap gap-2 p-2 border border-border rounded-md bg-card min-h-[38px]">
           {form.options.length > 0 ? (
             form.options.map((opt, i) => (
               <span

--- a/packages/client/src/pages/policies/PoliciesPage.tsx
+++ b/packages/client/src/pages/policies/PoliciesPage.tsx
@@ -133,27 +133,27 @@ function EmployeePoliciesView() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t("policies.page.title")}</h1>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("policies.page.title")}</h1>
         <p className="text-muted-foreground mt-1">{t("policies.page.subtitleEmployee")}</p>
       </div>
 
       {pendingIds.size > 0 && (
-        <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-xl p-4 mb-6 text-sm text-amber-800 dark:text-amber-200">
+        <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg p-4 mb-6 text-sm text-amber-800 dark:text-amber-200">
           {t("policies.page.pendingBanner", { count: pendingIds.size })}
         </div>
       )}
 
       <div className="space-y-4">
         {isLoading ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">{t("policies.page.loading")}</div>
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">{t("policies.page.loading")}</div>
         ) : policies.length === 0 ? (
-          <div className="bg-card rounded-xl border border-border p-8 text-center text-muted-foreground">{t("policies.page.emptyEmployee")}</div>
+          <div className="bg-card rounded-lg border border-border p-8 text-center text-muted-foreground">{t("policies.page.emptyEmployee")}</div>
         ) : (
           policies.map((p: any) => {
             const isPending = pendingIds.has(p.id);
             const isOpen = expanded === p.id;
             return (
-              <div key={p.id} className="bg-card rounded-xl border border-border overflow-hidden">
+              <div key={p.id} className="bg-card rounded-lg border border-border overflow-hidden">
                 <button
                   onClick={() => setExpanded(isOpen ? null : p.id)}
                   className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-muted"
@@ -163,16 +163,16 @@ function EmployeePoliciesView() {
                     <div>
                       <span className="text-sm font-semibold text-foreground">{policyTitle(p, untitled)}</span>
                       {p.category && (
-                        <span className="ml-2 text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full">{p.category}</span>
+                        <span className="ml-2 text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-md">{p.category}</span>
                       )}
                       <span className="ml-2 text-xs text-muted-foreground">v{p.version}</span>
                     </div>
                   </div>
                   <div className="flex items-center gap-3">
                     {isPending ? (
-                      <span className="text-xs bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 px-2 py-1 rounded-full font-medium">{t("policies.page.pending")}</span>
+                      <span className="text-[11px] bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 px-2 py-0.5 rounded-md font-medium">{t("policies.page.pending")}</span>
                     ) : (
-                      <span className="text-xs bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-1 rounded-full font-medium">{t("policies.page.acknowledged")}</span>
+                      <span className="text-[11px] bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-md font-medium">{t("policies.page.acknowledged")}</span>
                     )}
                     {isOpen ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
                   </div>
@@ -193,7 +193,7 @@ function EmployeePoliciesView() {
                       <button
                         onClick={() => acknowledge.mutate(p.id)}
                         disabled={acknowledge.isPending}
-                        className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+                        className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
                       >
                         <Check className="h-4 w-4" /> {t("policies.page.acknowledgePolicy")}
                       </button>
@@ -323,9 +323,9 @@ function HRPoliciesView() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("policies.page.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("policies.page.title")}</h1>
           <p className="text-muted-foreground mt-1">{t("policies.page.subtitleHr")}</p>
         </div>
         <button
@@ -341,7 +341,7 @@ function HRPoliciesView() {
               setShowCreate(true);
             }
           }}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {t("policies.page.newPolicy")}
         </button>
@@ -349,13 +349,13 @@ function HRPoliciesView() {
 
       {/* Create / edit form */}
       {showCreate && (
-        <form onSubmit={handleSubmit} className="bg-card rounded-xl border border-border p-6 mb-6 space-y-4">
+        <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 mb-6 space-y-4">
           <div className="flex items-center justify-between">
             <h2 className="text-base font-semibold text-foreground">
               {editingId != null ? t("policies.page.editPolicy") : t("policies.page.createPolicy")}
             </h2>
             {editingId != null && (
-              <span className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 px-2 py-0.5 rounded-full">
+              <span className="text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 px-2 py-0.5 rounded-md">
                 {t("policies.page.editingHint")}
               </span>
             )}
@@ -367,7 +367,7 @@ function HRPoliciesView() {
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("policies.page.titlePlaceholder")}
                 required
               />
@@ -378,7 +378,7 @@ function HRPoliciesView() {
                 type="text"
                 value={category}
                 onChange={(e) => setCategory(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
                 placeholder={t("policies.page.categoryPlaceholder")}
               />
             </div>
@@ -388,7 +388,7 @@ function HRPoliciesView() {
                 type="date"
                 value={effectiveDate}
                 onChange={(e) => setEffectiveDate(e.target.value)}
-                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-lg text-sm"
+                className="bg-card text-foreground w-full px-3 py-2 border border-border rounded-md text-[13px]"
               />
             </div>
             <div className="col-span-2">
@@ -404,14 +404,14 @@ function HRPoliciesView() {
             <button
               type="button"
               onClick={resetForm}
-              className="px-4 py-2 text-sm border border-border rounded-lg hover:bg-muted"
+              className="px-4 py-2 text-[13px] border border-border rounded-md hover:bg-muted"
             >
               {t("policies.page.cancel")}
             </button>
             <button
               type="submit"
               disabled={isSavingPolicy || !title.trim() || isRichTextEmpty(content)}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {editingId != null ? (
                 <><Pencil className="h-4 w-4" /> {isSavingPolicy ? t("policies.page.saving") : t("policies.page.saveChanges")}</>
@@ -424,16 +424,16 @@ function HRPoliciesView() {
       )}
 
       {/* Policies table */}
-      <div className="bg-card rounded-xl border border-border overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
           <thead className="bg-muted border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("policies.page.colTitle")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("policies.page.colCategory")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("policies.page.colVersion")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("policies.page.colEffectiveDate")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("policies.page.colAcknowledgments")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{t("policies.page.colActions")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("policies.page.colTitle")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("policies.page.colCategory")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("policies.page.colVersion")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("policies.page.colEffectiveDate")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("policies.page.colAcknowledgments")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t("policies.page.colActions")}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -444,26 +444,26 @@ function HRPoliciesView() {
             ) : (
               policies.map((p: any) => (
                 <React.Fragment key={p.id}>
-                  <tr className="hover:bg-muted">
-                    <td className="px-6 py-4">
+                  <tr className="hover:bg-muted/50 transition-colors">
+                    <td className="px-4 py-2.5">
                       <div className="flex items-center gap-2">
                         <FileText className="h-4 w-4 text-brand-600 dark:text-brand-400" />
                         <span className="text-sm font-medium text-foreground">{policyTitle(p, untitled)}</span>
                       </div>
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       {p.category ? (
-                        <span className="text-xs bg-muted text-muted-foreground px-2 py-1 rounded-full">{p.category}</span>
+                        <span className="text-[11px] bg-muted text-muted-foreground px-2 py-0.5 rounded-md">{p.category}</span>
                       ) : (
                         <span className="text-xs text-muted-foreground">-</span>
                       )}
                     </td>
-                    <td className="px-6 py-4 text-sm text-muted-foreground">v{p.version}</td>
-                    <td className="px-6 py-4 text-sm text-muted-foreground">{p.effective_date || "-"}</td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5 text-sm text-muted-foreground">v{p.version}</td>
+                    <td className="px-4 py-2.5 text-sm text-muted-foreground">{p.effective_date || "-"}</td>
+                    <td className="px-4 py-2.5">
                       <span className="text-sm font-medium text-brand-700 dark:text-brand-300">{p.acknowledgment_count ?? 0}</span>
                     </td>
-                    <td className="px-6 py-4">
+                    <td className="px-4 py-2.5">
                       <div className="flex items-center gap-3">
                         <button
                           onClick={() => {
@@ -510,13 +510,13 @@ function HRPoliciesView() {
                   {viewContentFor === p.id && (
                     <tr>
                       <td colSpan={6} className="p-0">
-                        <div className="mx-4 my-2 bg-muted border border-border rounded-xl shadow-lg animate-in slide-in-from-top-2 duration-200">
+                        <div className="mx-4 my-2 bg-muted border border-border rounded-lg shadow-lg animate-in slide-in-from-top-2 duration-200">
                           <div className="flex items-center justify-between px-5 py-3 border-b border-border">
                             <div className="flex items-center gap-2">
                               <FileText className="h-4 w-4 text-brand-600 dark:text-brand-400" />
                               <h3 className="text-sm font-semibold text-foreground">{policyTitle(p, untitled)}</h3>
                               {p.category && (
-                                <span className="text-xs bg-card text-muted-foreground px-2 py-0.5 rounded-full border border-border">{p.category}</span>
+                                <span className="text-xs bg-card text-muted-foreground px-2 py-0.5 rounded-md border border-border">{p.category}</span>
                               )}
                               <span className="text-xs text-muted-foreground">v{p.version}</span>
                             </div>
@@ -547,7 +547,7 @@ function HRPoliciesView() {
                   {viewAckFor === p.id && (
                     <tr>
                       <td colSpan={6} className="p-0">
-                        <div className="mx-4 my-2 bg-muted border border-border rounded-xl shadow-lg animate-in slide-in-from-top-2 duration-200">
+                        <div className="mx-4 my-2 bg-muted border border-border rounded-lg shadow-lg animate-in slide-in-from-top-2 duration-200">
                           <div className="flex items-center justify-between px-5 py-3 border-b border-border">
                             <div className="flex items-center gap-2">
                               <Users className="h-4 w-4 text-muted-foreground" />
@@ -632,7 +632,7 @@ function HRPoliciesView() {
             onClick={() => setConfirmDeleteId(null)}
           >
             <div
-              className="w-full max-w-md rounded-xl bg-card shadow-xl"
+              className="w-full max-w-md rounded-lg bg-card shadow-xl"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="px-6 py-4 border-b border-border">
@@ -677,7 +677,7 @@ function HRPoliciesView() {
                     });
                   }}
                   disabled={deletePolicy.isPending}
-                  className="flex items-center gap-1 text-sm bg-red-600 text-white px-3 py-1.5 rounded-lg hover:bg-red-700 disabled:opacity-50"
+                  className="flex items-center gap-1 text-[13px] bg-red-600 text-white px-3 py-1.5 rounded-md hover:bg-red-700 disabled:opacity-50"
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                   {deletePolicy.isPending ? t("policies.page.deleting") : t("policies.page.delete")}

--- a/packages/client/src/pages/settings/SettingsPage.tsx
+++ b/packages/client/src/pages/settings/SettingsPage.tsx
@@ -66,16 +66,16 @@ export default function SettingsPage() {
 
   return (
     <div>
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t("settingsPage.header.title")}</h1>
-        <p className="text-muted-foreground mt-1">{t("settingsPage.header.subtitle")}</p>
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("settingsPage.header.title")}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{t("settingsPage.header.subtitle")}</p>
       </div>
 
       {/* Organization info */}
       {editingOrg ? (
         <OrgEditForm org={org} onClose={() => setEditingOrg(false)} />
       ) : (
-        <div className="bg-card rounded-xl border border-border p-6 mb-6">
+        <div className="bg-card rounded-lg border border-border p-4 mb-6">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
               <Building2 className="h-5 w-5 text-brand-600 dark:text-brand-400" />
@@ -194,7 +194,7 @@ function OrgEditForm({ org, onClose }: { org: any; onClose: () => void }) {
   ];
 
   return (
-    <form onSubmit={handleSubmit} className="bg-card rounded-xl border border-border p-6 mb-6">
+    <form onSubmit={handleSubmit} className="bg-card rounded-lg border border-border p-4 mb-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <Building2 className="h-5 w-5 text-brand-600 dark:text-brand-400" />
@@ -212,7 +212,7 @@ function OrgEditForm({ org, onClose }: { org: any; onClose: () => void }) {
               <select
                 value={form[key]}
                 onChange={(e) => setForm({ ...form, [key]: e.target.value })}
-                className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card"
+                className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card"
               >
                 <option value="">{t("settingsPage.form.selectTimezone")}</option>
                 {TIMEZONES.map((tz) => (
@@ -223,7 +223,7 @@ function OrgEditForm({ org, onClose }: { org: any; onClose: () => void }) {
               <select
                 value={form[key]}
                 onChange={(e) => setForm({ ...form, [key]: e.target.value })}
-                className="w-full px-3 py-2 border border-border rounded-lg text-sm bg-card"
+                className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card"
               >
                 <option value="">{t("settingsPage.form.selectCountry")}</option>
                 {COUNTRIES.map((c) => (
@@ -241,7 +241,7 @@ function OrgEditForm({ org, onClose }: { org: any; onClose: () => void }) {
                       setValidationErrors((prev) => { const next = { ...prev }; delete next[key]; return next; });
                     }
                   }}
-                  className={`w-full px-3 py-2 border rounded-lg text-sm ${validationErrors[key] ? "border-red-400" : "border-border"}`}
+                  className={`w-full px-3 py-2 border rounded-md text-[13px] ${validationErrors[key] ? "border-red-400" : "border-border"}`}
                 />
                 {validationErrors[key] && (
                   <p className="text-xs text-red-500 mt-1">{validationErrors[key]}</p>
@@ -255,14 +255,14 @@ function OrgEditForm({ org, onClose }: { org: any; onClose: () => void }) {
         <button
           type="button"
           onClick={onClose}
-          className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-lg hover:bg-muted"
+          className="px-4 py-2 text-sm text-muted-foreground border border-border rounded-md hover:bg-muted"
         >
           {t("settingsPage.actions.cancel")}
         </button>
         <button
           type="submit"
           disabled={updateOrg.isPending}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
         >
           <Save className="h-4 w-4" /> {t("settingsPage.actions.saveChanges")}
         </button>
@@ -351,7 +351,7 @@ function DepartmentsCard({ departments }: { departments: any[] }) {
   };
 
   return (
-    <div className="bg-card rounded-xl border border-border p-6">
+    <div className="bg-card rounded-lg border border-border p-4">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <Briefcase className="h-5 w-5 text-brand-600 dark:text-brand-400" />
@@ -379,13 +379,13 @@ function DepartmentsCard({ departments }: { departments: any[] }) {
               value={newName}
               onChange={(e) => { setNewName(e.target.value); setAddError(""); }}
               placeholder={t("settingsPage.departments.namePlaceholder")}
-              className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-lg text-sm"
+              className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-md text-sm"
               required
             />
             <button
               type="submit"
               disabled={addDept.isPending}
-              className="px-3 py-2 bg-brand-600 text-white rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+              className="px-3 py-2 bg-brand-600 text-white rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
             >
               {t("settingsPage.actions.add")}
             </button>
@@ -397,7 +397,7 @@ function DepartmentsCard({ departments }: { departments: any[] }) {
         {departments.map((d: any) => (
           <li
             key={d.id}
-            className="flex items-center justify-between px-3 py-2 bg-muted rounded-lg text-sm"
+            className="flex items-center justify-between px-3 py-2 bg-muted rounded-md text-[13px]"
           >
             {editId === d.id ? (
               <form
@@ -547,7 +547,7 @@ function LocationsCard({ locations }: { locations: any[] }) {
   };
 
   return (
-    <div className="bg-card rounded-xl border border-border p-6">
+    <div className="bg-card rounded-lg border border-border p-4">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <MapPin className="h-5 w-5 text-brand-600 dark:text-brand-400" />
@@ -582,13 +582,13 @@ function LocationsCard({ locations }: { locations: any[] }) {
             value={locForm.name}
             onChange={(e) => { setLocForm({ ...locForm, name: e.target.value }); setAddError(""); }}
             placeholder={t("settingsPage.locations.namePlaceholder")}
-            className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-lg text-sm"
+            className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-md text-sm"
             required
           />
           <select
             value={locForm.timezone}
             onChange={(e) => { setLocForm({ ...locForm, timezone: e.target.value }); setAddError(""); }}
-            className="flex-1 px-3 py-2 border border-border rounded-lg text-sm bg-card"
+            className="flex-1 px-3 py-2 border border-border rounded-md text-sm bg-card"
             required
             aria-required="true"
           >
@@ -600,7 +600,7 @@ function LocationsCard({ locations }: { locations: any[] }) {
           <button
             type="submit"
             disabled={addLoc.isPending}
-            className="px-3 py-2 bg-brand-600 text-white rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50"
+            className="px-3 py-2 bg-brand-600 text-white rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50"
           >
             {t("settingsPage.actions.add")}
           </button>
@@ -612,7 +612,7 @@ function LocationsCard({ locations }: { locations: any[] }) {
         {locations.map((l: any) => (
           <li
             key={l.id}
-            className="flex items-center justify-between px-3 py-2 bg-muted rounded-lg text-sm"
+            className="flex items-center justify-between px-3 py-2 bg-muted rounded-md text-[13px]"
           >
             {editId === l.id ? (
               <form


### PR DESCRIPTION
Applies the enterprise density guide (`docs/UI-UPLIFT-GUIDE.md`) to the **Config / Settings** module. Surface-only — no logic changes.

**Pages**
- `PoliciesPage.tsx`
- `SettingsPage.tsx`
- `CustomFieldsSettingsPage.tsx`
- `ChangePasswordPage.tsx`

**Changes**
- `rounded-xl` cards → `rounded-lg`; `rounded-lg` controls → `rounded-md`
- status / category / option pills `rounded-full` → `rounded-md` (avatars kept round)
- page titles `text-2xl font-bold` → `text-xl font-semibold tracking-tight`
- table headers → `[11px]` uppercase tracking-wider; cells `px-6 py-4` → `px-4 py-2.5`
- body `text-sm` → `[13px]`, `text-xs` → `[11px]`; `tabular-nums` on keys/dates/counts
- row hovers `hover:bg-muted` → `hover:bg-muted/50 transition-colors`
- **dark-mode fix:** amber editing-hint pill was missing `dark:border-amber-900`

**Verification**
- className-only diff (97 insertions = 97 deletions)
- `tsc --noEmit`: 0 errors
- client `npm run build`: passes