### PR TITLE
UI density uplift: Access pages (Modules, Roles, Users)

### DIFF
--- a/packages/client/src/pages/modules/ModuleAccessPage.tsx
+++ b/packages/client/src/pages/modules/ModuleAccessPage.tsx
@@ -179,10 +179,10 @@ export default function ModuleAccessPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t('modulesAccess.title')}</h1>
-          <p className="text-muted-foreground mt-1">{t('modulesAccess.subtitle')}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('modulesAccess.title')}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t('modulesAccess.subtitle')}</p>
         </div>
-        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+        <div className="flex items-center gap-4 text-[13px] text-muted-foreground">
           <span className="flex items-center gap-1.5"><Package className="h-4 w-4" /> {t('modulesAccess.modulesCount', { count: subscribedModules.length })}</span>
           <span>{t('modulesAccess.employeesCount', { count: users.length })}</span>
           <span>{t('modulesAccess.seatsAssignedCount', { count: totalEnabled })}</span>
@@ -201,7 +201,7 @@ export default function ModuleAccessPage() {
             return (
               <div
                 key={m.id}
-                className={`bg-card rounded-xl border p-3 ${
+                className={`bg-card rounded-lg border p-3 ${
                   isFilteredOnThis ? "border-brand-400 ring-1 ring-brand-200" : "border-border"
                 }`}
               >
@@ -221,9 +221,9 @@ export default function ModuleAccessPage() {
                 >
                   <div className="flex items-center gap-2 mb-2">
                     <span className={`w-2 h-2 rounded-full ${used > 0 ? "bg-green-500" : "bg-muted"}`} />
-                    <span className="text-xs font-medium text-muted-foreground truncate">{m.name.replace(/^EMP\s+/i, "")}</span>
+                    <span className="text-[11px] font-medium text-muted-foreground truncate">{m.name.replace(/^EMP\s+/i, "")}</span>
                   </div>
-                  <div className="text-lg font-bold text-foreground">{used}<span className="text-sm font-normal text-muted-foreground">/{total}</span></div>
+                  <div className="text-lg font-bold text-foreground tabular-nums">{used}<span className="text-[13px] font-normal text-muted-foreground">/{total}</span></div>
                   <div className="w-full bg-muted rounded-full h-1.5 mt-1">
                     <div className="bg-brand-500 h-1.5 rounded-full transition-all" style={{ width: `${pct}%` }} />
                   </div>
@@ -232,7 +232,7 @@ export default function ModuleAccessPage() {
                   <button
                     onClick={() => setConfirmAllAction({ moduleId: m.id, moduleName: m.name, action: "enable" })}
                     disabled={enableModuleAll.isPending || disableModuleAll.isPending}
-                    className="flex-1 text-xs py-1.5 px-2 rounded bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 hover:bg-brand-100 dark:hover:bg-brand-900/50 font-medium disabled:opacity-50 transition-colors"
+                    className="flex-1 text-[11px] py-1.5 px-2 rounded bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 hover:bg-brand-100 dark:hover:bg-brand-900/50 font-medium disabled:opacity-50 transition-colors"
                   >
                     Enable All
                   </button>
@@ -244,7 +244,7 @@ export default function ModuleAccessPage() {
                         ? "Payroll is enabled for every employee by default. To remove it, cancel the subscription in Settings → Subscriptions."
                         : undefined
                     }
-                    className={`flex-1 text-xs py-1.5 px-2 rounded bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/50 font-medium disabled:opacity-50 transition-colors ${
+                    className={`flex-1 text-[11px] py-1.5 px-2 rounded bg-red-50 dark:bg-red-950/40 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/50 font-medium disabled:opacity-50 transition-colors ${
                       m.slug === "emp-payroll" ? "cursor-not-allowed" : ""
                     }`}
                   >
@@ -259,7 +259,7 @@ export default function ModuleAccessPage() {
 
       {/* Sync Alert */}
       {syncAlert && (
-        <div className={`mb-4 px-4 py-3 rounded-lg text-sm flex items-center gap-2 ${
+        <div className={`mb-4 px-4 py-3 rounded-md text-[13px] flex items-center gap-2 ${
           syncAlert.type === "success" ? "bg-green-50 dark:bg-green-950/40 text-green-800 dark:text-green-200 border border-green-200 dark:border-green-900"
             : syncAlert.type === "warning" ? "bg-amber-50 dark:bg-amber-950/40 text-amber-800 dark:text-amber-200 border border-amber-200 dark:border-amber-900"
             : "bg-red-50 dark:bg-red-950/40 text-red-800 dark:text-red-200 border border-red-200 dark:border-red-900"
@@ -278,7 +278,7 @@ export default function ModuleAccessPage() {
             type="text"
             value={search}
             onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-            className="bg-card text-foreground w-full pl-10 pr-4 py-2.5 border border-border rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+            className="bg-card text-foreground w-full pl-10 pr-4 py-2.5 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
             placeholder={t('modulesAccess.searchPlaceholder')}
           />
         </div>
@@ -287,7 +287,7 @@ export default function ModuleAccessPage() {
           <select
             value={filterModule}
             onChange={(e) => { setFilterModule(e.target.value); setPage(1); }}
-            className="bg-card text-foreground px-3 py-2.5 border border-border rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+            className="bg-card text-foreground px-3 py-2.5 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
           >
             <option value="all">{t('modulesAccess.allEmployees')}</option>
             <optgroup label={t('modulesAccess.enabledFor')}>
@@ -314,20 +314,20 @@ export default function ModuleAccessPage() {
               </div>
               <div>
                 <h3 className="text-lg font-semibold text-foreground">{t('modulesAccess.confirm.title')}</h3>
-                <p className="text-xs text-muted-foreground">{t('modulesAccess.confirm.subtitle')}</p>
+                <p className="text-[11px] text-muted-foreground">{t('modulesAccess.confirm.subtitle')}</p>
               </div>
             </div>
-            <p className="text-sm text-muted-foreground mb-6"
+            <p className="text-[13px] text-muted-foreground mb-6"
                dangerouslySetInnerHTML={{
                  __html: t('modulesAccess.confirm.message', { user: confirmAction.userName, module: confirmAction.moduleName })
                }}
             />
             <div className="flex justify-end gap-3">
-              <button onClick={() => setConfirmAction(null)} className="px-4 py-2 text-sm font-medium text-muted-foreground border border-border rounded-lg hover:bg-muted">{t('modulesAccess.confirm.cancel')}</button>
+              <button onClick={() => setConfirmAction(null)} className="px-4 py-2 text-[13px] font-medium text-muted-foreground border border-border rounded-md hover:bg-muted">{t('modulesAccess.confirm.cancel')}</button>
               <button
                 onClick={() => disableModule.mutate({ module_id: confirmAction.moduleId, user_id: confirmAction.userId })}
                 disabled={disableModule.isPending}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
+                className="px-4 py-2 text-[13px] font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50"
               >
                 {disableModule.isPending ? t('modulesAccess.confirm.removing') : t('modulesAccess.confirm.remove')}
               </button>
@@ -348,17 +348,17 @@ export default function ModuleAccessPage() {
                 <h3 className="text-lg font-semibold text-foreground">
                   {confirmAllAction.action === "enable" ? "Enable for All Employees" : "Disable for All Employees"}
                 </h3>
-                <p className="text-xs text-muted-foreground">
+                <p className="text-[11px] text-muted-foreground">
                   {confirmAllAction.action === "enable" ? "This will enable access for all employees" : "This will remove access from all employees"}
                 </p>
               </div>
             </div>
-            <p className="text-sm text-muted-foreground mb-6">
+            <p className="text-[13px] text-muted-foreground mb-6">
               Are you sure you want to <strong>{confirmAllAction.action}</strong> <strong>{confirmAllAction.moduleName}</strong> for{" "}
               <strong>all employees</strong>?
             </p>
             <div className="flex justify-end gap-3">
-              <button onClick={() => setConfirmAllAction(null)} className="px-4 py-2 text-sm font-medium text-muted-foreground border border-border rounded-lg hover:bg-muted">Cancel</button>
+              <button onClick={() => setConfirmAllAction(null)} className="px-4 py-2 text-[13px] font-medium text-muted-foreground border border-border rounded-md hover:bg-muted">Cancel</button>
               <button
                 onClick={() => {
                   if (confirmAllAction.action === "enable") {
@@ -368,7 +368,7 @@ export default function ModuleAccessPage() {
                   }
                 }}
                 disabled={enableModuleAll.isPending || disableModuleAll.isPending}
-                className={`px-4 py-2 text-sm font-medium text-white rounded-lg disabled:opacity-50 ${
+                className={`px-4 py-2 text-[13px] font-medium text-white rounded-md disabled:opacity-50 ${
                   confirmAllAction.action === "enable"
                     ? "bg-brand-600 hover:bg-brand-700"
                     : "bg-red-600 hover:bg-red-700"
@@ -384,21 +384,21 @@ export default function ModuleAccessPage() {
       )}
 
       {/* Table */}
-      <div className="bg-card rounded-xl border border-border overflow-x-auto">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto">
         <table className="min-w-full">
           <thead className="bg-muted border-b border-border">
             <tr>
               {/* #1416 — z-index keeps the sticky Employee column above
                    horizontally scrolled toggle cells so they don't overlap. */}
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3 sticky left-0 z-20 bg-muted min-w-[220px] shadow-[1px_0_0_0_rgba(0,0,0,0.05)]">{t('modulesAccess.table.employee')}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-4 py-3">{t('modulesAccess.table.role')}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-4 py-3">{t('modulesAccess.table.designation')}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5 sticky left-0 z-20 bg-muted min-w-[220px] shadow-[1px_0_0_0_rgba(0,0,0,0.05)]">{t('modulesAccess.table.employee')}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('modulesAccess.table.role')}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('modulesAccess.table.designation')}</th>
               {subscribedModules.map((m: any) => (
-                <th key={m.id} className="text-center text-xs font-medium text-muted-foreground uppercase px-3 py-3 min-w-[90px]">
+                <th key={m.id} className="text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5 min-w-[90px]">
                   {m.slug.replace("emp-", "").charAt(0).toUpperCase() + m.slug.replace("emp-", "").slice(1)}
                 </th>
               ))}
-              <th className="text-center text-xs font-medium text-muted-foreground uppercase px-4 py-3">{t('modulesAccess.table.modules')}</th>
+              <th className="text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{t('modulesAccess.table.modules')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -419,21 +419,21 @@ export default function ModuleAccessPage() {
                 const enabledCount = user.modules?.length || 0;
                 return (
                   <tr key={user.id} className="hover:bg-muted">
-                    <td className="px-6 py-3 sticky left-0 z-10 bg-card shadow-[1px_0_0_0_rgba(0,0,0,0.05)]">
+                    <td className="px-4 py-2.5 sticky left-0 z-10 bg-card shadow-[1px_0_0_0_rgba(0,0,0,0.05)]">
                       <div className="flex items-center gap-3">
-                        <div className="h-8 w-8 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center text-xs font-semibold text-brand-700 dark:text-brand-300 flex-shrink-0">
+                        <div className="h-8 w-8 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center text-[11px] font-semibold text-brand-700 dark:text-brand-300 flex-shrink-0">
                           {user.first_name?.[0]}{user.last_name?.[0]}
                         </div>
                         <div className="min-w-0">
-                          <p className="text-sm font-medium text-foreground truncate">{user.first_name} {user.last_name}</p>
-                          <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+                          <p className="text-[13px] font-medium text-foreground truncate">{user.first_name} {user.last_name}</p>
+                          <p className="text-[11px] text-muted-foreground truncate">{user.email}</p>
                         </div>
                       </div>
                     </td>
-                    <td className="px-4 py-3">
-                      <span className="text-xs px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-medium">{user.role ? (t(`roles.${user.role}`) !== `roles.${user.role}` ? t(`roles.${user.role}`) : user.role.replace(/_/g, " ")) : ""}</span>
+                    <td className="px-4 py-2.5">
+                      <span className="text-[11px] px-2 py-0.5 rounded-md bg-muted text-muted-foreground font-medium">{user.role ? (t(`roles.${user.role}`) !== `roles.${user.role}` ? t(`roles.${user.role}`) : user.role.replace(/_/g, " ")) : ""}</span>
                     </td>
-                    <td className="px-4 py-3 text-xs text-muted-foreground truncate max-w-[120px]">{user.designation || "-"}</td>
+                    <td className="px-4 py-2.5 text-[11px] text-muted-foreground truncate max-w-[120px]">{user.designation || "-"}</td>
                     {subscribedModules.map((m: any) => {
                       const isEnabled = user.modules?.some((um: any) => um.module_id === m.id);
                       // Policy: once EmpMonitor is enabled for an org_admin,
@@ -459,7 +459,7 @@ export default function ModuleAccessPage() {
                           ? "Payroll is enabled for every employee by default. To remove it, cancel the subscription in Settings → Subscriptions."
                           : undefined;
                       return (
-                        <td key={m.id} className="px-3 py-3 text-center">
+                        <td key={m.id} className="px-4 py-2.5 text-center">
                           <button
                             onClick={() =>
                               handleToggle(
@@ -492,8 +492,8 @@ export default function ModuleAccessPage() {
                         </td>
                       );
                     })}
-                    <td className="px-4 py-3 text-center">
-                      <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${enabledCount > 0 ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300" : "bg-muted text-muted-foreground"}`}>
+                    <td className="px-4 py-2.5 text-center">
+                      <span className={`text-[11px] font-medium px-2 py-0.5 rounded-md tabular-nums ${enabledCount > 0 ? "bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300" : "bg-muted text-muted-foreground"}`}>
                         {enabledCount}/{subscribedModules.length}
                       </span>
                     </td>
@@ -507,21 +507,21 @@ export default function ModuleAccessPage() {
         {/* Pagination */}
         {totalPages > 1 && (
           <div className="flex items-center justify-between px-6 py-3 border-t border-border bg-muted">
-            <p className="text-sm text-muted-foreground">
+            <p className="text-[13px] text-muted-foreground tabular-nums">
               {t('modulesAccess.pagination.showing', { from: (page - 1) * PAGE_SIZE + 1, to: Math.min(page * PAGE_SIZE, totalUsers), total: totalUsers })}
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="flex items-center gap-1 px-3 py-1.5 text-sm border border-border rounded-lg disabled:opacity-50 hover:bg-card"
+                className="flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-card"
               >
                 <ChevronLeft className="h-4 w-4" /> {t('modulesAccess.pagination.previous')}
               </button>
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages}
-                className="flex items-center gap-1 px-3 py-1.5 text-sm border border-border rounded-lg disabled:opacity-50 hover:bg-card"
+                className="flex items-center gap-1 px-3 py-1.5 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-card"
               >
                 {t('modulesAccess.pagination.next')} <ChevronRight className="h-4 w-4" />
               </button>

--- a/packages/client/src/pages/modules/ModulesPage.tsx
+++ b/packages/client/src/pages/modules/ModulesPage.tsx
@@ -116,7 +116,7 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
         <div className="flex items-center justify-between p-6 border-b border-border">
           <div>
             <h2 className="text-xl font-bold text-foreground">Subscribe to {module.name}</h2>
-            <p className="text-sm text-muted-foreground mt-1">Configure your subscription</p>
+            <p className="text-[13px] text-muted-foreground mt-1">Configure your subscription</p>
           </div>
           <button onClick={onClose} className="text-muted-foreground hover:text-muted-foreground">
             <X className="h-5 w-5" />
@@ -126,15 +126,15 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
         <div className="p-6 space-y-6">
           {/* Plan Tier Selection */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-muted-foreground mb-3">
               <CreditCard className="h-4 w-4" /> Select Plan
             </label>
             {pricingQ.isLoading ? (
-              <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+              <div className="flex items-center justify-center py-6 text-[13px] text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Loading plans...
               </div>
             ) : tiers.length === 0 ? (
-              <div className="rounded-xl border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/40 p-3 text-sm text-amber-800 dark:text-amber-200">
+              <div className="rounded-xl border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/40 p-3 text-[13px] text-amber-800 dark:text-amber-200">
                 No plans are currently published for this currency. Contact your administrator.
               </div>
             ) : (
@@ -145,15 +145,15 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
                     <button
                       key={plan.slug}
                       onClick={() => setPlanTier(plan.slug)}
-                      className={`p-3 rounded-xl border-2 text-left transition-all ${
+                      className={`p-3 rounded-lg border-2 text-left transition-all ${
                         isSelected
                           ? "border-brand-500 bg-brand-50 dark:bg-brand-950/40 ring-1 ring-brand-200"
                           : "border-border hover:border-brand-300 dark:hover:border-brand-800"
                       }`}
                     >
-                      <div className="font-semibold text-sm text-foreground">{plan.name}</div>
-                      <div className="text-xs text-muted-foreground mt-1">{plan.description}</div>
-                      <div className="text-sm font-bold text-brand-600 dark:text-brand-400 mt-2">
+                      <div className="font-semibold text-[13px] text-foreground">{plan.name}</div>
+                      <div className="text-[11px] text-muted-foreground mt-1">{plan.description}</div>
+                      <div className="text-[13px] font-bold text-brand-600 dark:text-brand-400 mt-2 tabular-nums">
                         {plan.price_per_seat != null
                           ? `${formatMoney(plan.price_per_seat, currency)}/seat/mo`
                           : "Not available"}
@@ -167,7 +167,7 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
 
           {/* Number of Seats */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-muted-foreground mb-3">
               <Users className="h-4 w-4" /> Number of Seats (Licenses)
             </label>
             <div className="flex items-center gap-4">
@@ -185,15 +185,15 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
                 max={10000}
                 value={totalSeats}
                 onChange={e => setTotalSeats(Math.max(1, Number(e.target.value)))}
-                className="bg-card text-foreground w-20 px-3 py-2 border border-border rounded-lg text-center text-sm font-medium focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                className="bg-card text-foreground w-20 px-3 py-2 border border-border rounded-md text-center text-[13px] font-medium focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
               />
             </div>
-            <p className="text-xs text-muted-foreground mt-1">Each seat allows one employee to access this module</p>
+            <p className="text-[11px] text-muted-foreground mt-1">Each seat allows one employee to access this module</p>
           </div>
 
           {/* Billing Cycle */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-3">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-muted-foreground mb-3">
               <Calendar className="h-4 w-4" /> Billing Cycle
             </label>
             <div className={`grid gap-3`} style={{ gridTemplateColumns: `repeat(${Math.max(1, Math.min(cycles.length, 4))}, minmax(0, 1fr))` }}>
@@ -203,15 +203,15 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
                   <button
                     key={cycle.cycle}
                     onClick={() => setBillingCycle(cycle.cycle)}
-                    className={`p-3 rounded-xl border-2 text-center transition-all ${
+                    className={`p-3 rounded-lg border-2 text-center transition-all ${
                       isSelected
                         ? "border-brand-500 bg-brand-50 dark:bg-brand-950/40 ring-1 ring-brand-200"
                         : "border-border hover:border-brand-300 dark:hover:border-brand-800"
                     }`}
                   >
-                    <div className="font-semibold text-sm text-foreground">{cycle.label}</div>
+                    <div className="font-semibold text-[13px] text-foreground">{cycle.label}</div>
                     {Number(cycle.discount_pct) > 0 && (
-                      <div className="text-xs text-green-600 dark:text-green-400 font-medium mt-1">
+                      <div className="text-[11px] text-green-600 dark:text-green-400 font-medium mt-1">
                         Save {Number(cycle.discount_pct)}%
                       </div>
                     )}
@@ -223,29 +223,29 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
 
           {/* Price Summary */}
           <div className="bg-muted rounded-xl p-4 space-y-2">
-            <div className="flex justify-between text-sm text-muted-foreground">
+            <div className="flex justify-between text-[13px] text-muted-foreground">
               <span>Plan</span>
               <span className="font-medium">{selectedTier?.name || "—"}</span>
             </div>
-            <div className="flex justify-between text-sm text-muted-foreground">
+            <div className="flex justify-between text-[13px] text-muted-foreground">
               <span>Price per seat</span>
-              <span>{formatMoney(monthlyPerSeat, currency)}/mo</span>
+              <span className="tabular-nums">{formatMoney(monthlyPerSeat, currency)}/mo</span>
             </div>
-            <div className="flex justify-between text-sm text-muted-foreground">
+            <div className="flex justify-between text-[13px] text-muted-foreground">
               <span>Seats</span>
-              <span>{totalSeats} users</span>
+              <span className="tabular-nums">{totalSeats} users</span>
             </div>
-            <div className="flex justify-between text-sm text-muted-foreground">
+            <div className="flex justify-between text-[13px] text-muted-foreground">
               <span>Billing cycle</span>
               <span>{selectedCycle?.label || "—"}</span>
             </div>
             {selectedCycle && Number(selectedCycle.discount_pct) > 0 && (
-              <div className="flex justify-between text-sm text-green-600 dark:text-green-400">
+              <div className="flex justify-between text-[13px] text-green-600 dark:text-green-400">
                 <span>Discount</span>
-                <span>-{Number(selectedCycle.discount_pct)}%</span>
+                <span className="tabular-nums">-{Number(selectedCycle.discount_pct)}%</span>
               </div>
             )}
-            <div className="border-t border-border pt-2 mt-2 flex justify-between text-lg font-bold text-foreground">
+            <div className="border-t border-border pt-2 mt-2 flex justify-between text-lg font-bold text-foreground tabular-nums">
               <span>Total</span>
               <span>
                 {formatMoney(totalAmount, currency)}
@@ -263,13 +263,13 @@ function SubscribeModal({ module, onClose, onSubscribe, isLoading }: SubscribeMo
 
         {/* Footer */}
         <div className="flex items-center justify-between p-6 border-t border-border bg-muted rounded-b-2xl">
-          <button onClick={onClose} className="text-sm text-muted-foreground hover:text-foreground">
+          <button onClick={onClose} className="text-[13px] text-muted-foreground hover:text-foreground">
             Cancel
           </button>
           <button
             onClick={handleSubmit}
             disabled={isLoading}
-            className="flex items-center gap-2 bg-brand-600 text-white px-6 py-2.5 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
+            className="flex items-center gap-2 bg-brand-600 text-white px-6 py-2.5 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
           >
             {isLoading
               ? "Subscribing..."
@@ -349,12 +349,12 @@ export default function ModulesPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t('modulesPage.title')}</h1>
-        <p className="text-muted-foreground mt-1">{t('modulesPage.subtitle')}</p>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('modulesPage.title')}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{t('modulesPage.subtitle')}</p>
       </div>
 
       {toast && (
-        <div className="fixed bottom-6 right-6 z-50 bg-green-600 text-white px-5 py-3 rounded-xl shadow-lg text-sm font-medium flex items-center gap-2">
+        <div className="fixed bottom-6 right-6 z-50 bg-green-600 text-white px-5 py-3 rounded-xl shadow-lg text-[13px] font-medium flex items-center gap-2">
           <Check className="h-4 w-4" />
           {toast}
         </div>
@@ -370,14 +370,14 @@ export default function ModulesPage() {
       )}
 
       {/* EMP AI Banner */}
-      <div className="bg-gradient-to-r from-purple-600 to-indigo-600 rounded-xl p-6 mb-8 text-white">
+      <div className="bg-gradient-to-r from-purple-600 to-indigo-600 rounded-lg p-4 mb-8 text-white">
         <div className="flex items-center gap-4">
           <div className="h-12 w-12 rounded-xl bg-white/20 flex items-center justify-center">
             <Sparkles className="h-6 w-6 text-white" />
           </div>
           <div>
             <h2 className="text-lg font-bold">{t('modulesPage.aiBannerTitle')}</h2>
-            <p className="text-purple-100 text-sm mt-1">
+            <p className="text-purple-100 text-[13px] mt-1">
               {t('modulesPage.aiBannerDesc')}
             </p>
           </div>
@@ -402,7 +402,7 @@ export default function ModulesPage() {
           return (
             <div
               key={mod.id}
-              className={`bg-card rounded-xl border p-6 transition-colors ${
+              className={`bg-card rounded-lg border p-4 transition-colors ${
                 isHRMS
                   ? "border-brand-300 dark:border-brand-800 bg-brand-50/30 dark:bg-brand-950/20 ring-1 ring-brand-100 dark:ring-brand-900"
                   : "border-border hover:border-brand-300 dark:hover:border-brand-800"
@@ -422,21 +422,21 @@ export default function ModulesPage() {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1 flex-wrap">
                     <h3 className="font-semibold text-foreground text-lg">{displayName}</h3>
-                    <span className="text-xs text-muted-foreground">{mod.slug}</span>
+                    <span className="text-[11px] text-muted-foreground">{mod.slug}</span>
                     {isHRMS && (
-                      <span className="text-xs bg-brand-100 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 px-2 py-0.5 rounded-full font-medium">
+                      <span className="text-[11px] bg-brand-100 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300 px-2 py-0.5 rounded-md font-medium">
                         {t('modulesPage.coreIncludedFree')}
                       </span>
                     )}
                     {!!mod.has_free_tier && !isHRMS && (
-                      <span className="text-xs bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-full">{t('modulesPage.freeTier')}</span>
+                      <span className="text-[11px] bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-md">{t('modulesPage.freeTier')}</span>
                     )}
                     {!mod.is_active && (
-                      <span className="text-xs bg-muted text-muted-foreground px-2 py-0.5 rounded-full">{t('modulesPage.comingSoon')}</span>
+                      <span className="text-[11px] bg-muted text-muted-foreground px-2 py-0.5 rounded-md">{t('modulesPage.comingSoon')}</span>
                     )}
                   </div>
 
-                  <p className="text-sm text-muted-foreground leading-relaxed">
+                  <p className="text-[13px] text-muted-foreground leading-relaxed">
                     {isExpanded ? displayDescription : descPreview}
                     {!isExpanded && hasMore && "..."}
                   </p>
@@ -450,7 +450,7 @@ export default function ModulesPage() {
                   {isSubscribed && activeSub && (
                     <Link
                       to={`/users?module=${mod.slug}`}
-                      className="mt-3 inline-flex items-center gap-2 text-xs font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 hover:underline"
+                      className="mt-3 inline-flex items-center gap-2 text-[11px] font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 hover:underline"
                     >
                       <Users className="h-3.5 w-3.5" />
                       {t('modulesPage.seatsAssigned', { used: activeSub.used_seats, total: activeSub.total_seats })}
@@ -460,7 +460,7 @@ export default function ModulesPage() {
                   {hasMore && (
                     <button
                       onClick={() => setExpandedId(isExpanded ? null : mod.id)}
-                      className="text-xs text-brand-600 dark:text-brand-400 hover:text-brand-700 font-medium mt-2 flex items-center gap-0.5"
+                      className="text-[11px] text-brand-600 dark:text-brand-400 hover:text-brand-700 font-medium mt-2 flex items-center gap-0.5"
                     >
                       {isExpanded ? (
                         <>{t('dashboard.showLess')} <ChevronUp className="h-3 w-3" /></>
@@ -473,28 +473,28 @@ export default function ModulesPage() {
 
                 <div className="flex-shrink-0 ml-4">
                   {isHRMS ? (
-                    <span className="flex items-center gap-1.5 text-sm font-medium text-brand-600 dark:text-brand-400">
+                    <span className="flex items-center gap-1.5 text-[13px] font-medium text-brand-600 dark:text-brand-400">
                       <Check className="h-4 w-4" /> {t('modulesPage.active')}
                     </span>
                   ) : isSubscribed ? (
                     <div className="flex flex-col items-end gap-2">
-                      <span className="flex items-center gap-1.5 text-sm font-medium text-green-600 dark:text-green-400">
+                      <span className="flex items-center gap-1.5 text-[13px] font-medium text-green-600 dark:text-green-400">
                         <Check className="h-4 w-4" /> {t('modulesPage.subscribed')}
                       </span>
                       {canManageSubscriptions && (
                         confirmUnsubscribe === mod.id ? (
                           <div className="flex items-center gap-2">
-                            <span className="text-xs text-muted-foreground">{t('modulesPage.areYouSure')}</span>
+                            <span className="text-[11px] text-muted-foreground">{t('modulesPage.areYouSure')}</span>
                             <button
                               onClick={() => handleUnsubscribe(mod.id)}
                               disabled={cancelSub.isPending}
-                              className="text-xs bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700 disabled:opacity-50"
+                              className="text-[11px] bg-red-600 text-white px-2 py-1 rounded hover:bg-red-700 disabled:opacity-50"
                             >
                               {cancelSub.isPending ? t('modulesPage.cancelling') : t('modulesPage.yesCancel')}
                             </button>
                             <button
                               onClick={() => setConfirmUnsubscribe(null)}
-                              className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+                              className="text-[11px] text-muted-foreground hover:text-foreground px-2 py-1"
                             >
                               {t('common.no')}
                             </button>
@@ -502,7 +502,7 @@ export default function ModulesPage() {
                         ) : (
                           <button
                             onClick={() => setConfirmUnsubscribe(mod.id)}
-                            className="text-xs text-red-500 hover:text-red-700 font-medium"
+                            className="text-[11px] text-red-500 hover:text-red-700 font-medium"
                           >
                             {t('modulesPage.unsubscribe')}
                           </button>
@@ -513,13 +513,13 @@ export default function ModulesPage() {
                     <button
                       onClick={() => setSubscribeModule(mod)}
                       disabled={!mod.is_active}
-                      className="flex items-center gap-1.5 text-sm font-medium bg-brand-600 text-white px-4 py-2 rounded-lg hover:bg-brand-700 disabled:opacity-50 transition-colors"
+                      className="flex items-center gap-1.5 text-[13px] font-medium bg-brand-600 text-white px-4 py-2 rounded-md hover:bg-brand-700 disabled:opacity-50 transition-colors"
                     >
                       <Plus className="h-4 w-4" />
                       {t('modulesPage.subscribe')}
                     </button>
                   ) : (
-                    <span className="text-xs text-muted-foreground">{t('modulesPage.notSubscribed')}</span>
+                    <span className="text-[11px] text-muted-foreground">{t('modulesPage.notSubscribed')}</span>
                   )}
                 </div>
               </div>

--- a/packages/client/src/pages/roles/RolesPage.tsx
+++ b/packages/client/src/pages/roles/RolesPage.tsx
@@ -112,16 +112,16 @@ export default function RolesPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground flex items-center gap-2">
             <Shield className="h-6 w-6 text-brand-600 dark:text-brand-400" />
             {tx("title")}
           </h1>
-          <p className="text-muted-foreground mt-1">{tx("subtitle")}</p>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{tx("subtitle")}</p>
         </div>
         <button
           type="button"
           onClick={() => setEditing({ role: null, mode: "create" })}
-          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700"
+          className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700"
         >
           <Plus className="h-4 w-4" /> {tx("newCustomRole")}
         </button>
@@ -134,13 +134,13 @@ export default function RolesPage() {
         subtitle={tx("systemRolesSubtitle") as string}
       />
       {isLoading ? (
-        <div className="flex items-center gap-2 text-muted-foreground text-sm py-6">
+        <div className="flex items-center gap-2 text-muted-foreground text-[13px] py-6">
           <Loader2 className="h-4 w-4 animate-spin" /> {tx("loadingRoles")}
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-8">
           {systemRoles.length === 0 && (
-            <p className="text-sm text-muted-foreground col-span-2">
+            <p className="text-[13px] text-muted-foreground col-span-2">
               {tx("noSystemRoles")}
             </p>
           )}
@@ -165,7 +165,7 @@ export default function RolesPage() {
         subtitle={tx("customRolesSubtitle") as string}
       />
       {customRoles.length === 0 ? (
-        <div className="border border-dashed border-border rounded-lg p-6 text-center text-sm text-muted-foreground">
+        <div className="border border-dashed border-border rounded-lg p-4 text-center text-[13px] text-muted-foreground">
           {tx("noCustomRolesPrefix")}{" "}
           <button
             onClick={() => setEditing({ role: null, mode: "create" })}
@@ -229,10 +229,10 @@ function SectionHeader({
 }) {
   return (
     <div className="mb-3">
-      <h2 className="text-sm font-semibold text-muted-foreground flex items-center gap-2">
+      <h2 className="text-[13px] font-semibold text-muted-foreground flex items-center gap-2">
         {icon} {title}
       </h2>
-      <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>
+      <p className="text-[11px] text-muted-foreground mt-0.5 tabular-nums">{subtitle}</p>
     </div>
   );
 }
@@ -264,7 +264,7 @@ function RoleCard({
   const isSystem = role.type === 0;
 
   return (
-    <div className="border border-border rounded-xl bg-card p-4 hover:border-brand-500 dark:hover:border-brand-400 transition-colors">
+    <div className="border border-border rounded-lg bg-card p-4 hover:border-brand-500 dark:hover:border-brand-400 transition-colors duration-150">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
@@ -284,9 +284,9 @@ function RoleCard({
             )}
           </div>
           {displayDescription && (
-            <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{displayDescription}</p>
+            <p className="text-[11px] text-muted-foreground mt-1 line-clamp-2">{displayDescription}</p>
           )}
-          <p className="text-xs text-muted-foreground mt-2">
+          <p className="text-[11px] text-muted-foreground mt-2 tabular-nums">
             {tx("permissionsCount", { count: role.permissions.length })}
           </p>
         </div>
@@ -436,7 +436,7 @@ function RoleBuilderModal({
                   ? tx("editSystemRoleTitle")
                   : tx("editRoleTitle")}
             </h2>
-            <p className="text-xs text-muted-foreground mt-0.5">
+            <p className="text-[11px] text-muted-foreground mt-0.5 tabular-nums">
               {tx("permissionsSelected", { selected: selectedCount, total: totalCount })}
             </p>
           </div>
@@ -454,10 +454,10 @@ function RoleBuilderModal({
           {/* Name + description */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
                 {tx("roleNameLabel")}
                 {isSystemRole && (
-                  <span className="text-xs font-normal text-muted-foreground ml-2">{tx("roleNameLocked")}</span>
+                  <span className="text-[11px] font-normal text-muted-foreground ml-2">{tx("roleNameLocked")}</span>
                 )}
               </label>
               <input
@@ -470,21 +470,21 @@ function RoleBuilderModal({
                 onChange={(e) => setName(e.target.value)}
                 disabled={isSystemRole}
                 placeholder={tx("roleNamePlaceholder") as string}
-                className={`w-full border border-border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 ${
+                className={`w-full border border-border rounded-md px-3 py-2 text-[13px] focus:ring-2 focus:ring-brand-500 ${
                   isSystemRole ? "bg-muted text-muted-foreground cursor-not-allowed" : "bg-card text-foreground"
                 }`}
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">
-                {tx("descriptionLabel")} <span className="text-xs font-normal text-muted-foreground">{tx("descriptionOptional")}</span>
+              <label className="block text-[13px] font-medium text-muted-foreground mb-1">
+                {tx("descriptionLabel")} <span className="text-[11px] font-normal text-muted-foreground">{tx("descriptionOptional")}</span>
               </label>
               <input
                 type="text"
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder={tx("descriptionPlaceholder") as string}
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                className="w-full border border-border rounded-md px-3 py-2 text-[13px] focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
               />
             </div>
           </div>
@@ -497,14 +497,14 @@ function RoleBuilderModal({
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder={tx("searchPermissionsPlaceholder") as string}
-              className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-brand-500"
+              className="bg-card text-foreground w-full pl-10 pr-4 py-2 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500"
             />
           </div>
 
           {/* Permission groups */}
           <div className="border border-border rounded-lg divide-y divide-border">
             {filteredGroups.length === 0 && (
-              <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+              <div className="px-4 py-6 text-center text-[13px] text-muted-foreground">
                 {tx("noPermissionsMatch", { query: search })}
               </div>
             )}
@@ -530,8 +530,8 @@ function RoleBuilderModal({
                       onChange={() => toggleGroup(perms)}
                       className="accent-brand-600"
                     />
-                    <span className="font-medium text-sm text-foreground flex-1">{group}</span>
-                    <span className="text-xs text-muted-foreground">
+                    <span className="font-medium text-[13px] text-foreground flex-1">{group}</span>
+                    <span className="text-[11px] text-muted-foreground tabular-nums">
                       {groupSelectedCount} / {perms.length}
                     </span>
                   </div>
@@ -550,7 +550,7 @@ function RoleBuilderModal({
                           />
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-2">
-                              <span className="text-sm text-foreground">{p.label}</span>
+                              <span className="text-[13px] text-foreground">{p.label}</span>
                               <span className="text-[10px] font-mono text-muted-foreground">{p.key}</span>
                               {p.scope && (
                                 <span
@@ -566,7 +566,7 @@ function RoleBuilderModal({
                                 </span>
                               )}
                             </div>
-                            <p className="text-xs text-muted-foreground">{p.description}</p>
+                            <p className="text-[11px] text-muted-foreground">{p.description}</p>
                           </div>
                         </label>
                       ))}
@@ -581,13 +581,13 @@ function RoleBuilderModal({
         {/* Footer */}
         <div className="border-t border-border px-6 py-3 flex items-center justify-between gap-3">
           {mutation.isError && (
-            <span className="text-xs text-red-600 dark:text-red-400">{extractApiError(mutation.error)}</span>
+            <span className="text-[11px] text-red-600 dark:text-red-400">{extractApiError(mutation.error)}</span>
           )}
           <div className="ml-auto flex items-center gap-2">
             <button
               type="button"
               onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-muted-foreground border border-border rounded-lg hover:bg-muted"
+              className="px-4 py-2 text-[13px] font-medium text-muted-foreground border border-border rounded-md hover:bg-muted"
             >
               {t("common.cancel")}
             </button>
@@ -595,7 +595,7 @@ function RoleBuilderModal({
               type="button"
               onClick={handleSave}
               disabled={!name.trim() || mutation.isPending}
-              className="px-4 py-2 text-sm font-medium text-white bg-brand-600 rounded-lg hover:bg-brand-700 disabled:opacity-50 flex items-center gap-2"
+              className="px-4 py-2 text-[13px] font-medium text-white bg-brand-600 rounded-md hover:bg-brand-700 disabled:opacity-50 flex items-center gap-2"
             >
               {mutation.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -651,14 +651,14 @@ function ConfirmDialog({
             </div>
             <h3 className="text-lg font-semibold text-foreground">{title}</h3>
           </div>
-          <p className="text-sm text-muted-foreground">{body}</p>
-          {error && <p className="text-sm text-red-600 dark:text-red-400 mt-3">{error}</p>}
+          <p className="text-[13px] text-muted-foreground">{body}</p>
+          {error && <p className="text-[13px] text-red-600 dark:text-red-400 mt-3">{error}</p>}
         </div>
         <div className="flex justify-end gap-2 px-6 py-3 border-t border-border">
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-sm font-medium text-muted-foreground border border-border rounded-lg hover:bg-muted"
+            className="px-4 py-2 text-[13px] font-medium text-muted-foreground border border-border rounded-md hover:bg-muted"
           >
             {t("common.cancel")}
           </button>
@@ -666,7 +666,7 @@ function ConfirmDialog({
             type="button"
             onClick={onConfirm}
             disabled={isPending}
-            className={`px-4 py-2 text-sm font-medium text-white rounded-lg disabled:opacity-50 flex items-center gap-2 ${
+            className={`px-4 py-2 text-[13px] font-medium text-white rounded-md disabled:opacity-50 flex items-center gap-2 ${
               isReset ? "bg-amber-600 hover:bg-amber-700" : "bg-red-600 hover:bg-red-700"
             }`}
           >

--- a/packages/client/src/pages/users/UsersPage.tsx
+++ b/packages/client/src/pages/users/UsersPage.tsx
@@ -569,19 +569,19 @@ export default function UsersPage() {
     <div>
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-8">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Users</h1>
-          <p className="text-gray-500 mt-1">Manage your organization's team members.</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">Users</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">Manage your organization's team members.</p>
         </div>
         <div className="flex items-center gap-3">
           <button
             onClick={() => setShowCsvImport(true)}
-            className="flex items-center gap-2 border border-gray-300 text-gray-700 px-4 py-2.5 rounded-lg text-sm font-medium hover:bg-gray-50"
+            className="flex items-center gap-2 border border-border text-foreground px-4 py-2.5 rounded-md text-[13px] font-medium hover:bg-muted transition-colors"
           >
             <FileSpreadsheet className="h-4 w-4" /> Import Users
           </button>
           <button
             onClick={() => setShowInvite(!showInvite)}
-            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-brand-700 shadow-sm shadow-brand-200 transition-all"
+            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2.5 rounded-md text-[13px] font-semibold hover:bg-brand-700 shadow-sm shadow-brand-200 transition-all"
           >
             <UserPlus className="h-5 w-5" /> Invite Employee
           </button>
@@ -593,17 +593,17 @@ export default function UsersPage() {
 
       {/* Invite form */}
       {showInvite && (
-        <form onSubmit={handleInvite} className="bg-white rounded-xl border border-gray-200 p-6 mb-6 space-y-4">
+        <form onSubmit={handleInvite} className="bg-card rounded-lg border border-border p-4 mb-6 space-y-4">
           <div className="flex items-end gap-4">
             <div className="flex-1">
-              <label className="block text-sm font-medium text-gray-700 mb-1">Email *</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Email *</label>
               <input type="email" value={inviteEmail} onChange={(e) => setInviteEmail(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="colleague@company.com" required />
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground" placeholder="colleague@company.com" required />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Role</label>
               <select value={inviteRole} onChange={(e) => setInviteRole(e.target.value)}
-                className="px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                className="px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground">
                 <option value="employee">Employee</option>
                 <option value="manager">Manager</option>
                 <option value="hr_admin">HR Admin</option>
@@ -611,43 +611,43 @@ export default function UsersPage() {
               </select>
             </div>
             <button type="button" onClick={() => setShowAdvancedInvite(!showAdvancedInvite)}
-              className="text-sm text-brand-600 hover:underline whitespace-nowrap pb-2">
+              className="text-[13px] text-brand-600 hover:underline whitespace-nowrap pb-2">
               {showAdvancedInvite ? "Less options" : "More options"}
             </button>
             <button type="submit" disabled={inviteUser.isPending}
-              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50">
+              className="flex items-center gap-2 bg-brand-600 text-white px-4 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50">
               <Mail className="h-4 w-4" /> Send Invite
             </button>
           </div>
           {showAdvancedInvite && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 pt-2 border-t border-gray-100">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 pt-2 border-t border-border">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">First Name</label>
+                <label className="block text-[13px] font-medium text-foreground mb-1">First Name</label>
                 <input type="text" value={inviteFirstName} onChange={(e) => setInviteFirstName(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="John" />
+                  className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground" placeholder="John" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Last Name</label>
+                <label className="block text-[13px] font-medium text-foreground mb-1">Last Name</label>
                 <input type="text" value={inviteLastName} onChange={(e) => setInviteLastName(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="Doe" />
+                  className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground" placeholder="Doe" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Designation</label>
+                <label className="block text-[13px] font-medium text-foreground mb-1">Designation</label>
                 <input type="text" value={inviteDesignation} onChange={(e) => setInviteDesignation(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" placeholder="Software Engineer" />
+                  className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground" placeholder="Software Engineer" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Department</label>
+                <label className="block text-[13px] font-medium text-foreground mb-1">Department</label>
                 <select value={inviteDeptId} onChange={(e) => setInviteDeptId(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                  className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground">
                   <option value="">Select department</option>
                   {departments.map((d: any) => <option key={d.id} value={d.id}>{d.name}</option>)}
                 </select>
               </div>
               <div className="col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">Reporting Manager</label>
+                <label className="block text-[13px] font-medium text-foreground mb-1">Reporting Manager</label>
                 <select value={inviteManagerId} onChange={(e) => setInviteManagerId(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+                  className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground">
                   <option value="">No manager (top level)</option>
                   {(allUsersData?.data || []).map((u: any) => (
                     <option key={u.id} value={u.id}>{u.first_name} {u.last_name} — {u.designation || u.role}</option>
@@ -657,42 +657,42 @@ export default function UsersPage() {
             </div>
           )}
           {inviteError && (
-            <p className="text-sm text-red-600 mt-2">{inviteError}</p>
+            <p className="text-[13px] text-red-600 dark:text-red-400 mt-2">{inviteError}</p>
           )}
         </form>
       )}
 
       {/* Search */}
       <div className="relative mb-4">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <input
           type="text"
           value={search}
           onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-          className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg text-sm"
+          className="w-full pl-10 pr-4 py-2 border border-border rounded-md text-[13px] bg-card text-foreground"
           placeholder="Search by name, email, or employee code..."
         />
       </div>
 
       {/* Pending Invitations */}
       {invitations.length > 0 && (
-        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-4">
-          <h3 className="text-sm font-semibold text-amber-800 mb-2">Pending Invitations ({invitations.length})</h3>
+        <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg p-4 mb-4">
+          <h3 className="text-[13px] font-semibold text-amber-800 dark:text-amber-200 mb-2 tabular-nums">Pending Invitations ({invitations.length})</h3>
           <div className="space-y-2">
             {invitations.map((inv: any) => (
-              <div key={inv.id} className="flex items-center justify-between bg-white rounded-lg px-4 py-2 border border-amber-100">
+              <div key={inv.id} className="flex items-center justify-between bg-card rounded-md px-4 py-2 border border-amber-100 dark:border-amber-900/60">
                 <div className="flex items-center gap-3">
-                  <div className="h-8 w-8 rounded-full bg-amber-100 flex items-center justify-center text-sm font-semibold text-amber-700">
+                  <div className="h-8 w-8 rounded-full bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center text-[13px] font-semibold text-amber-700 dark:text-amber-300">
                     <Mail className="h-4 w-4" />
                   </div>
                   <div>
-                    <span className="text-sm font-medium text-gray-900">{inv.email}</span>
-                    <span className="text-xs text-gray-500 ml-2 capitalize">{(inv.role || "employee").replace(/_/g, " ")}</span>
+                    <span className="text-[13px] font-medium text-foreground">{inv.email}</span>
+                    <span className="text-[11px] text-muted-foreground ml-2 capitalize">{(inv.role || "employee").replace(/_/g, " ")}</span>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-xs bg-amber-100 text-amber-700 px-2 py-1 rounded-full font-medium">Pending</span>
-                  <span className="text-xs text-gray-400">
+                  <span className="text-[11px] bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 px-2 py-1 rounded-md font-medium">Pending</span>
+                  <span className="text-[11px] text-muted-foreground tabular-nums">
                     Invited {inv.created_at ? new Date(inv.created_at).toLocaleDateString() : ""}
                   </span>
                 </div>
@@ -703,39 +703,39 @@ export default function UsersPage() {
       )}
 
       {/* Users table */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
+          <thead className="bg-muted border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Name</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Email</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Role</th>
-              <th className="text-left text-xs font-medium text-gray-500 uppercase px-6 py-3">Status</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Name</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Email</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Role</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">Status</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {isLoading ? (
-              <tr><td colSpan={4} className="px-6 py-8 text-center text-gray-400">Loading...</td></tr>
+              <tr><td colSpan={4} className="px-4 py-8 text-center text-[13px] text-muted-foreground">Loading...</td></tr>
             ) : users.length === 0 ? (
-              <tr><td colSpan={4} className="px-6 py-8 text-center text-gray-400">No users found</td></tr>
+              <tr><td colSpan={4} className="px-4 py-8 text-center text-[13px] text-muted-foreground">No users found</td></tr>
             ) : (
               users.map((u: any) => (
-                <tr key={u.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4">
+                <tr key={u.id} className="hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-2.5">
                     <div className="flex items-center gap-3">
-                      <div className="h-8 w-8 rounded-full bg-brand-100 flex items-center justify-center text-sm font-semibold text-brand-700">
+                      <div className="h-8 w-8 rounded-full bg-brand-100 dark:bg-brand-950/40 flex items-center justify-center text-[13px] font-semibold text-brand-700 dark:text-brand-300">
                         {u.first_name?.[0]}{u.last_name?.[0]}
                       </div>
-                      <span className="text-sm font-medium text-gray-900">{u.first_name || ""} {u.last_name || ""}</span>
+                      <span className="text-[13px] font-medium text-foreground">{u.first_name || ""} {u.last_name || ""}</span>
                     </div>
                   </td>
-                  <td className="px-6 py-4 text-sm text-gray-500">{u.email}</td>
-                  <td className="px-6 py-4">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{u.email}</td>
+                  <td className="px-4 py-2.5">
                     {isOrgAdmin && u.id !== user?.id ? (
                       <select
                         value={u.role}
                         onChange={(e) => updateRoleMut.mutate({ userId: u.id, role: e.target.value })}
-                        className="text-xs border border-gray-200 rounded-full px-2 py-1 bg-gray-50 text-gray-700 capitalize cursor-pointer hover:bg-gray-100"
+                        className="text-[11px] border border-border rounded-md px-2 py-1 bg-muted text-foreground capitalize cursor-pointer hover:bg-muted-foreground/10"
                         disabled={updateRoleMut.isPending}
                       >
                         <option value="employee">Employee</option>
@@ -744,14 +744,14 @@ export default function UsersPage() {
                         <option value="org_admin">Org Admin</option>
                       </select>
                     ) : (
-                      <span className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded-full capitalize">
+                      <span className="text-[11px] bg-muted text-muted-foreground px-2 py-1 rounded-md capitalize">
                         {u.role.replace(/_/g, " ")}
                       </span>
                     )}
                   </td>
-                  <td className="px-6 py-4">
-                    <span className={`text-xs px-2 py-1 rounded-full font-medium ${
-                      u.status === 1 ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"
+                  <td className="px-4 py-2.5">
+                    <span className={`text-[11px] px-2 py-1 rounded-md font-medium ${
+                      u.status === 1 ? "bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300" : "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300"
                     }`}>
                       {u.status === 1 ? "Active" : "Inactive"}
                     </span>
@@ -764,22 +764,22 @@ export default function UsersPage() {
 
         {/* Pagination */}
         {meta && meta.total_pages > 1 && (
-          <div className="flex items-center justify-between px-6 py-3 border-t border-gray-200">
-            <p className="text-sm text-gray-500">
+          <div className="flex items-center justify-between px-4 py-2.5 border-t border-border">
+            <p className="text-[13px] text-muted-foreground tabular-nums">
               Page {meta.page} of {meta.total_pages} ({meta.total} total)
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page === 1}
-                className="px-3 py-1 text-sm border border-gray-300 rounded-lg disabled:opacity-50"
+                className="px-3 py-1 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
               >
                 Previous
               </button>
               <button
                 onClick={() => setPage((p) => p + 1)}
                 disabled={page >= meta.total_pages}
-                className="px-3 py-1 text-sm border border-gray-300 rounded-lg disabled:opacity-50"
+                className="px-3 py-1 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted transition-colors"
               >
                 Next
               </button>


### PR DESCRIPTION
Applies the enterprise density guide (`docs/UI-UPLIFT-GUIDE.md`) to the **Access** module. Surface-only — no logic changes.

**Pages**
- `ModulesPage.tsx` (marketplace / subscribe cards)
- `ModuleAccessPage.tsx` (per-employee module seat grid)
- `RolesPage.tsx` (roles + permission matrix)
- `UsersPage.tsx` (user directory + invite + CSV import)

**Changes**
- `rounded-xl` cards → `rounded-lg`; `rounded-lg` controls → `rounded-md`
- status / role / count pills `rounded-full` → `rounded-md` (avatars, toggle knobs, progress tracks, status dots kept round)
- page titles `text-2xl font-bold` → `text-xl font-semibold tracking-tight`
- table headers → `[11px]` uppercase tracking-wider; cells `px-6 py-4`/`py-3` → `px-4 py-2.5`
- body `text-sm` → `[13px]`, `text-xs` → `[11px]`; `tabular-nums` on counts / dates / money
- row hovers → `hover:bg-muted/50 transition-colors`

**Dark-mode fix (UsersPage was light-only)**
- migrated raw `gray-*` / `bg-white` → semantic tokens (`bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`)
- added `dark:` siblings on status/role pills, the initials avatar, and the Pending Invitations card

**Verification**
- className-only diff (173 insertions = 173 deletions)
- `tsc --noEmit`: 0 errors
- client `npm run build`: passes