### PR TITLE
UI density uplift: Billing pages

### DIFF
--- a/packages/client/src/pages/billing/BillingPage.tsx
+++ b/packages/client/src/pages/billing/BillingPage.tsx
@@ -105,7 +105,7 @@ function StatusBadge({ status }: { status: string }) {
   const display = translatedStatus !== `common.${status}` ? translatedStatus : status;
   return (
     <span
-      className={`text-xs px-2 py-0.5 rounded-full font-medium capitalize ${statusColors[status] || "bg-muted text-muted-foreground"}`}
+      className={`text-[11px] px-2 py-0.5 rounded-md font-medium capitalize ${statusColors[status] || "bg-muted text-muted-foreground"}`}
     >
       {display}
     </span>
@@ -151,7 +151,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
         <div className="flex items-center justify-between p-6 border-b border-border">
           <div>
             <h2 className="text-lg font-bold text-foreground">{t('billing.editModal.title')}</h2>
-            <p className="text-sm text-muted-foreground">{moduleName}</p>
+            <p className="text-[13px] text-muted-foreground">{moduleName}</p>
           </div>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
             <X className="h-5 w-5" />
@@ -161,13 +161,13 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
         <div className="p-6 space-y-5">
           {/* Plan Tier */}
           <div>
-            <label className="text-sm font-medium text-muted-foreground mb-2 block">{t('billing.editModal.planTier')}</label>
+            <label className="text-[13px] font-medium text-muted-foreground mb-2 block">{t('billing.editModal.planTier')}</label>
             <div className="grid grid-cols-3 gap-2">
               {plans.map(plan => (
                 <button
                   key={plan.value}
                   onClick={() => setPlanTier(plan.value)}
-                  className={`py-2 px-3 rounded-lg border-2 text-sm font-medium transition-all ${
+                  className={`py-2 px-3 rounded-md border-2 text-[13px] font-medium transition-all ${
                     planTier === plan.value
                       ? "border-brand-500 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                       : "border-border text-muted-foreground hover:border-muted-foreground"
@@ -181,13 +181,13 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
 
           {/* Total Seats */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-2">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-muted-foreground mb-2">
               <Users className="h-4 w-4" /> {t('billing.editModal.totalSeats')}
             </label>
             <div className="flex items-center gap-3">
               <button
                 onClick={() => setTotalSeats(Math.max(1, totalSeats - 1))}
-                className="h-10 w-10 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:bg-muted"
+                className="h-10 w-10 rounded-md border border-border flex items-center justify-center text-muted-foreground hover:bg-muted"
               >
                 -
               </button>
@@ -197,26 +197,26 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
                 max={10000}
                 value={totalSeats}
                 onChange={e => setTotalSeats(Math.max(1, Number(e.target.value)))}
-                className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-lg text-center text-lg font-semibold focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                className="bg-card text-foreground flex-1 px-3 py-2 border border-border rounded-md text-center text-lg font-semibold tabular-nums focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
               />
               <button
                 onClick={() => setTotalSeats(totalSeats + 1)}
-                className="h-10 w-10 rounded-lg border border-border flex items-center justify-center text-muted-foreground hover:bg-muted"
+                className="h-10 w-10 rounded-md border border-border flex items-center justify-center text-muted-foreground hover:bg-muted"
               >
                 +
               </button>
             </div>
             <div className="flex justify-between mt-1">
-              <p className="text-xs text-muted-foreground">{t('billing.editModal.currentlyUsing', { count: subscription.used_seats })}</p>
+              <p className="text-[11px] text-muted-foreground">{t('billing.editModal.currentlyUsing', { count: subscription.used_seats })}</p>
               {seatsReduced && (
-                <p className="text-xs text-red-500 font-medium">{t('billing.editModal.cannotReduce', { count: subscription.used_seats })}</p>
+                <p className="text-[11px] text-red-500 font-medium">{t('billing.editModal.cannotReduce', { count: subscription.used_seats })}</p>
               )}
             </div>
           </div>
 
           {/* Billing Cycle */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-muted-foreground mb-2">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-muted-foreground mb-2">
               <Calendar className="h-4 w-4" /> {t('billing.editModal.billingCycle')}
             </label>
             <div className="grid grid-cols-3 gap-2">
@@ -224,7 +224,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
                 <button
                   key={cycle.value}
                   onClick={() => setBillingCycle(cycle.value)}
-                  className={`py-2 px-3 rounded-lg border-2 text-sm font-medium transition-all ${
+                  className={`py-2 px-3 rounded-md border-2 text-[13px] font-medium transition-all ${
                     billingCycle === cycle.value
                       ? "border-brand-500 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
                       : "border-border text-muted-foreground hover:border-muted-foreground"
@@ -238,7 +238,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
 
           {/* Change Summary */}
           {hasChanges && (
-            <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900/50 rounded-lg p-3 text-sm">
+            <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900/50 rounded-md p-3 text-[13px]">
               <p className="font-medium text-amber-800 dark:text-amber-200 mb-1">{t('billing.editModal.changes')}</p>
               <ul className="text-amber-700 dark:text-amber-300 space-y-0.5">
                 {planTier !== subscription.plan_tier && (
@@ -256,11 +256,11 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
         </div>
 
         <div className="flex items-center justify-between p-6 border-t border-border bg-muted rounded-b-2xl">
-          <button onClick={onClose} className="text-sm text-muted-foreground hover:text-foreground">{t('common.cancel')}</button>
+          <button onClick={onClose} className="text-[13px] text-muted-foreground hover:text-foreground">{t('common.cancel')}</button>
           <button
             onClick={() => onSave(subscription.id, { plan_tier: planTier, total_seats: totalSeats, billing_cycle: billingCycle })}
             disabled={isLoading || !hasChanges || seatsReduced}
-            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
+            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
           >
             {isLoading ? t('billing.editModal.saving') : t('billing.editModal.save')}
           </button>
@@ -345,8 +345,8 @@ export default function BillingPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{t('billing.title')}</h1>
-        <p className="text-muted-foreground mt-1">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('billing.title')}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">
           {t('billing.subtitle')}
         </p>
       </div>
@@ -361,7 +361,7 @@ export default function BillingPage() {
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className={`flex items-center gap-2 px-1 pb-3 text-sm font-medium border-b-2 transition-colors ${
+                className={`flex items-center gap-2 px-1 pb-3 text-[13px] font-medium border-b-2 transition-colors ${
                   isActive
                     ? "border-brand-600 text-brand-700 dark:text-brand-300"
                     : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
@@ -436,7 +436,7 @@ function SubscriptionsTab() {
   if (isLoading) return (
     <div className="space-y-4">
       {[1, 2].map((i) => (
-        <div key={i} className="bg-card rounded-xl border border-border p-6 animate-pulse">
+        <div key={i} className="bg-card rounded-lg border border-border p-4 animate-pulse">
           <div className="flex items-center gap-3 mb-4">
             <div className="h-10 w-10 bg-muted rounded-lg" />
             <div>
@@ -453,7 +453,7 @@ function SubscriptionsTab() {
   return (
     <div>
       {toast && (
-        <div className={`fixed bottom-6 right-6 z-50 ${isErrorToast ? "bg-red-600" : "bg-green-600"} text-white px-5 py-3 rounded-xl shadow-lg text-sm font-medium flex items-center gap-2`}>
+        <div className={`fixed bottom-6 right-6 z-50 ${isErrorToast ? "bg-red-600" : "bg-green-600"} text-white px-5 py-3 rounded-xl shadow-lg text-[13px] font-medium flex items-center gap-2`}>
           {isErrorToast ? <AlertCircle className="h-4 w-4" /> : <Check className="h-4 w-4" />}{toast}
         </div>
       )}
@@ -471,15 +471,15 @@ function SubscriptionsTab() {
       {/* Cancel confirmation */}
       {cancelConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setCancelConfirm(null)}>
-          <div className="bg-card rounded-xl shadow-xl p-6 max-w-sm mx-4" onClick={e => e.stopPropagation()}>
+          <div className="bg-card rounded-lg shadow-xl p-4 max-w-sm mx-4" onClick={e => e.stopPropagation()}>
             <h3 className="text-lg font-bold text-foreground mb-2">{t('billing.cancelModal.title')}</h3>
-            <p className="text-sm text-muted-foreground mb-4">{t('billing.cancelModal.message')}</p>
+            <p className="text-[13px] text-muted-foreground mb-4">{t('billing.cancelModal.message')}</p>
             <div className="flex gap-3 justify-end">
-              <button onClick={() => setCancelConfirm(null)} className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground">{t('billing.cancelModal.keep')}</button>
+              <button onClick={() => setCancelConfirm(null)} className="px-4 py-2 text-[13px] text-muted-foreground hover:text-foreground">{t('billing.cancelModal.keep')}</button>
               <button
                 onClick={() => handleCancel(cancelConfirm)}
                 disabled={cancelSub.isPending}
-                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+                className="px-4 py-2 text-[13px] bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
               >
                 {cancelSub.isPending ? t('billing.cancelModal.cancelling') : t('billing.cancelModal.yesCancel')}
               </button>
@@ -490,21 +490,21 @@ function SubscriptionsTab() {
 
       {/* Monthly cost summary */}
       {billing && (
-        <div className="bg-card rounded-xl border border-border p-6 mb-6">
+        <div className="bg-card rounded-lg border border-border p-4 mb-6">
           <div className="flex items-center gap-3 mb-2">
             <TrendingUp className="h-5 w-5 text-brand-600 dark:text-brand-400" />
             <h2 className="font-semibold text-foreground">{t('billing.monthlyCost')}</h2>
           </div>
-          <p className="text-3xl font-bold text-foreground">
+          <p className="text-3xl font-semibold tabular-nums text-foreground">
             {formatCurrency(billing.total_monthly_cost, billing.currency)}
-            <span className="text-sm font-normal text-muted-foreground"> {t('billing.perMonth')}</span>
+            <span className="text-[13px] font-normal text-muted-foreground"> {t('billing.perMonth')}</span>
           </p>
         </div>
       )}
 
       {/* Subscription cards */}
       {(!subscriptions || subscriptions.length === 0) ? (
-        <div className="bg-card rounded-xl border border-border p-12 text-center">
+        <div className="bg-card rounded-lg border border-border p-12 text-center">
           <CreditCard className="h-10 w-10 text-muted-foreground/50 mx-auto mb-3" />
           <p className="text-muted-foreground">{t('billing.noSubscriptions')}</p>
         </div>
@@ -513,7 +513,7 @@ function SubscriptionsTab() {
           {subscriptions.map((sub: any) => {
             const mod = moduleMap.get(sub.module_id) as any;
             return (
-              <div key={sub.id} className="bg-card rounded-xl border border-border p-6">
+              <div key={sub.id} className="bg-card rounded-lg border border-border p-4">
                 <div className="flex items-start justify-between">
                   <div className="flex items-center gap-3">
                     <div className={`h-10 w-10 rounded-lg flex items-center justify-center ${moduleColors[mod?.slug]?.bg || "bg-brand-50 dark:bg-brand-950/40"}`}>
@@ -521,11 +521,11 @@ function SubscriptionsTab() {
                     </div>
                     <div>
                       <h3 className="font-semibold text-foreground">{mod?.name || "Module"}</h3>
-                      <p className="text-xs text-muted-foreground">{mod?.slug}</p>
+                      <p className="text-[11px] text-muted-foreground">{mod?.slug}</p>
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className={`text-xs px-2 py-1 rounded-full font-medium ${
+                    <span className={`text-[11px] px-2 py-1 rounded-md font-medium ${
                       sub.status === "active" ? "bg-green-50 dark:bg-green-950/40 text-green-700 dark:text-green-300" :
                       sub.status === "trial" ? "bg-yellow-50 dark:bg-yellow-950/40 text-yellow-700 dark:text-yellow-300" :
                       sub.status === "cancelled" ? "bg-muted text-muted-foreground" :
@@ -537,14 +537,14 @@ function SubscriptionsTab() {
                       <>
                         <button
                           onClick={() => setEditingSub(sub)}
-                          className="p-1.5 text-muted-foreground hover:text-brand-600 dark:hover:text-brand-400 hover:bg-brand-50 dark:hover:bg-brand-950/40 rounded-lg transition-colors"
+                          className="p-1.5 text-muted-foreground hover:text-brand-600 dark:hover:text-brand-400 hover:bg-brand-50 dark:hover:bg-brand-950/40 rounded-md transition-colors"
                           title={t('billing.editTooltip')}
                         >
                           <Pencil className="h-4 w-4" />
                         </button>
                         <button
                           onClick={() => setCancelConfirm(sub.id)}
-                          className="p-1.5 text-muted-foreground hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 rounded-lg transition-colors"
+                          className="p-1.5 text-muted-foreground hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 rounded-md transition-colors"
                           title={t('billing.cancelTooltip')}
                         >
                           <Trash2 className="h-4 w-4" />
@@ -556,15 +556,15 @@ function SubscriptionsTab() {
 
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 pt-4 border-t border-border">
                   <div>
-                    <p className="text-xs text-muted-foreground">{t('billing.labels.plan')}</p>
-                    <p className="text-sm font-medium text-foreground capitalize">{(() => { const k = `plans.${sub.plan_tier?.toLowerCase?.() ?? ""}`; const tr = t(k); return tr !== k ? tr : sub.plan_tier; })()}</p>
+                    <p className="text-[11px] text-muted-foreground">{t('billing.labels.plan')}</p>
+                    <p className="text-[13px] font-medium text-foreground capitalize">{(() => { const k = `plans.${sub.plan_tier?.toLowerCase?.() ?? ""}`; const tr = t(k); return tr !== k ? tr : sub.plan_tier; })()}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-muted-foreground">{t('billing.labels.seats')}</p>
-                    <p className="text-sm font-medium text-foreground">
+                    <p className="text-[11px] text-muted-foreground">{t('billing.labels.seats')}</p>
+                    <p className="text-[13px] font-medium text-foreground">
                       {sub.used_seats}/{sub.total_seats}
                       {sub.used_seats >= sub.total_seats && (
-                        <span className="text-xs text-red-500 ml-1">{t('billing.full')}</span>
+                        <span className="text-[11px] text-red-500 ml-1">{t('billing.full')}</span>
                       )}
                     </p>
                     {/* Seat usage bar */}
@@ -576,14 +576,14 @@ function SubscriptionsTab() {
                     </div>
                   </div>
                   <div>
-                    <p className="text-xs text-muted-foreground">{t('billing.labels.pricePerSeat')}</p>
-                    <p className="text-sm font-medium text-foreground">
+                    <p className="text-[11px] text-muted-foreground">{t('billing.labels.pricePerSeat')}</p>
+                    <p className="text-[13px] font-medium text-foreground">
                       {formatCurrency(Number(sub.price_per_seat), sub.currency)}
                     </p>
                   </div>
                   <div>
-                    <p className="text-xs text-muted-foreground">{t('billing.labels.billingCycle')}</p>
-                    <p className="text-sm font-medium text-foreground capitalize">{(() => { const k = `billing.cycles.${sub.billing_cycle}`; const tr = t(k); return tr !== k ? tr : sub.billing_cycle; })()}</p>
+                    <p className="text-[11px] text-muted-foreground">{t('billing.labels.billingCycle')}</p>
+                    <p className="text-[13px] font-medium text-foreground capitalize">{(() => { const k = `billing.cycles.${sub.billing_cycle}`; const tr = t(k); return tr !== k ? tr : sub.billing_cycle; })()}</p>
                   </div>
                 </div>
               </div>
@@ -607,7 +607,7 @@ function OverviewTab() {
     return (
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="bg-card rounded-xl border border-border p-5 animate-pulse">
+          <div key={i} className="bg-card rounded-lg border border-border p-5 animate-pulse">
             <div className="h-3 w-20 bg-muted rounded mb-3" />
             <div className="h-7 w-24 bg-muted rounded" />
           </div>
@@ -618,7 +618,7 @@ function OverviewTab() {
 
   if (!summary) {
     return (
-      <div className="bg-card rounded-xl border border-border p-12 text-center">
+      <div className="bg-card rounded-lg border border-border p-12 text-center">
         <AlertCircle className="h-10 w-10 text-muted-foreground/50 mx-auto mb-3" />
         <p className="text-muted-foreground">{t('billing.overview.noData')}</p>
       </div>
@@ -642,53 +642,53 @@ function OverviewTab() {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
       {/* Outstanding Balance */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         <div className="flex items-center gap-3 mb-3">
           <div className="h-10 w-10 rounded-lg bg-red-50 dark:bg-red-950/40 flex items-center justify-center">
             <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
           </div>
-          <p className="text-sm text-muted-foreground">{t('billing.overview.outstandingBalance')}</p>
+          <p className="text-[13px] text-muted-foreground">{t('billing.overview.outstandingBalance')}</p>
         </div>
-        <p className="text-3xl font-bold text-foreground">
+        <p className="text-3xl font-semibold tabular-nums text-foreground">
           {formatCurrency(summary.outstandingAmount ?? 0, summary.currency)}
         </p>
       </div>
 
       {/* Next Invoice Date */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         <div className="flex items-center gap-3 mb-3">
           <div className="h-10 w-10 rounded-lg bg-blue-50 dark:bg-blue-950/40 flex items-center justify-center">
             <Calendar className="h-5 w-5 text-blue-600 dark:text-blue-400" />
           </div>
-          <p className="text-sm text-muted-foreground">{t('billing.overview.nextInvoiceDate')}</p>
+          <p className="text-[13px] text-muted-foreground">{t('billing.overview.nextInvoiceDate')}</p>
         </div>
-        <p className="text-2xl font-bold text-foreground">
+        <p className="text-2xl font-semibold tabular-nums text-foreground">
           {summary.nextInvoiceDate ? formatDate(summary.nextInvoiceDate) : "N/A"}
         </p>
       </div>
 
       {/* Monthly Recurring Cost */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         <div className="flex items-center gap-3 mb-3">
           <div className="h-10 w-10 rounded-lg bg-brand-50 dark:bg-brand-950/40 flex items-center justify-center">
             <DollarSign className="h-5 w-5 text-brand-600 dark:text-brand-400" />
           </div>
-          <p className="text-sm text-muted-foreground">{t('billing.overview.monthlyRecurring')}</p>
+          <p className="text-[13px] text-muted-foreground">{t('billing.overview.monthlyRecurring')}</p>
         </div>
-        <p className="text-3xl font-bold text-foreground">
+        <p className="text-3xl font-semibold tabular-nums text-foreground">
           {formatCurrency(summary.monthlyRecurring ?? 0, summary.currency)}
         </p>
       </div>
 
       {/* Payment Status */}
-      <div className="bg-card rounded-xl border border-border p-6">
+      <div className="bg-card rounded-lg border border-border p-4">
         <div className="flex items-center gap-3 mb-3">
           <div className="h-10 w-10 rounded-lg bg-green-50 dark:bg-green-950/40 flex items-center justify-center">
             <CreditCard className="h-5 w-5 text-green-600 dark:text-green-400" />
           </div>
-          <p className="text-sm text-muted-foreground">{t('billing.overview.paymentStatus')}</p>
+          <p className="text-[13px] text-muted-foreground">{t('billing.overview.paymentStatus')}</p>
         </div>
-        <span className={`text-sm px-3 py-1 rounded-full font-semibold capitalize ${paymentStatusColor}`}>
+        <span className={`text-[13px] px-3 py-1 rounded-md font-semibold capitalize ${paymentStatusColor}`}>
           {t(`billing.overview.${paymentStatusKey}`)}
         </span>
       </div>
@@ -714,7 +714,7 @@ function InvoicesTab() {
 
   if (invoices.length === 0) {
     return (
-      <div className="bg-card rounded-xl border border-border p-12 text-center">
+      <div className="bg-card rounded-lg border border-border p-12 text-center">
         <Receipt className="h-10 w-10 text-muted-foreground/50 mx-auto mb-3" />
         <p className="text-muted-foreground">{t('billing.invoices.none')}</p>
       </div>
@@ -723,17 +723,17 @@ function InvoicesTab() {
 
   return (
     <div>
-      <div className="bg-card rounded-xl border border-border overflow-x-auto -mx-4 lg:mx-0">
-        <table className="min-w-full text-sm">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
+        <table className="min-w-full text-[13px]">
           <thead>
             <tr className="bg-muted border-b border-border">
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground w-8" />
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.invoices.number')}</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.invoices.date')}</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.invoices.dueDate')}</th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('billing.invoices.amount')}</th>
-              <th className="text-center px-4 py-3 font-medium text-muted-foreground">{t('billing.invoices.status')}</th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground" />
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground w-8" />
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.invoices.number')}</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.invoices.date')}</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.invoices.dueDate')}</th>
+              <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.invoices.amount')}</th>
+              <th className="text-center px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.invoices.status')}</th>
+              <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground" />
             </tr>
           </thead>
           <tbody>
@@ -755,21 +755,21 @@ function InvoicesTab() {
       {/* Pagination */}
       {meta && meta.totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-sm text-muted-foreground">
+          <p className="text-[13px] text-muted-foreground tabular-nums">
             {t('billing.invoices.pagination', { page: meta.page, totalPages: meta.totalPages, total: meta.total })}
           </p>
           <div className="flex gap-2">
             <button
               disabled={page <= 1}
               onClick={() => setPage((p) => p - 1)}
-              className="px-3 py-1.5 text-sm rounded-lg border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
+              className="px-3 py-1.5 text-[13px] rounded-md border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
             >
               {t('billing.invoices.previous')}
             </button>
             <button
               disabled={page >= meta.totalPages}
               onClick={() => setPage((p) => p + 1)}
-              className="px-3 py-1.5 text-sm rounded-lg border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
+              className="px-3 py-1.5 text-[13px] rounded-md border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
             >
               {t('billing.invoices.next')}
             </button>
@@ -929,20 +929,20 @@ function PayNowButton({ invoiceId }: { invoiceId: string }) {
       <button
         onClick={(e) => { e.stopPropagation(); setShowGateways(!showGateways); }}
         disabled={loading}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50"
       >
         <CreditCard className="h-3.5 w-3.5" />
         {loading ? t('billing.invoices.processing') : t('billing.invoices.payNow')}
       </button>
       {showGateways && (
-        <div className="absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 min-w-[160px]">
-          <button onClick={(e) => { e.stopPropagation(); handlePay("stripe"); }} className="w-full text-left px-4 py-2.5 text-sm hover:bg-muted rounded-t-lg font-medium text-muted-foreground">
+        <div className="absolute left-0 top-full mt-1 bg-card border border-border rounded-md shadow-lg z-10 min-w-[160px]">
+          <button onClick={(e) => { e.stopPropagation(); handlePay("stripe"); }} className="w-full text-left px-4 py-2.5 text-[13px] hover:bg-muted rounded-t-md font-medium text-muted-foreground">
             Stripe (Card)
           </button>
-          <button onClick={(e) => { e.stopPropagation(); handlePay("razorpay"); }} className="w-full text-left px-4 py-2.5 text-sm hover:bg-muted font-medium text-muted-foreground">
+          <button onClick={(e) => { e.stopPropagation(); handlePay("razorpay"); }} className="w-full text-left px-4 py-2.5 text-[13px] hover:bg-muted font-medium text-muted-foreground">
             Razorpay (UPI/Card)
           </button>
-          <button onClick={(e) => { e.stopPropagation(); handlePay("paypal"); }} className="w-full text-left px-4 py-2.5 text-sm hover:bg-muted rounded-b-lg font-medium text-muted-foreground">
+          <button onClick={(e) => { e.stopPropagation(); handlePay("paypal"); }} className="w-full text-left px-4 py-2.5 text-[13px] hover:bg-muted rounded-b-md font-medium text-muted-foreground">
             PayPal
           </button>
         </div>
@@ -1029,10 +1029,10 @@ function InvoiceRow({
   return (
     <>
       <tr
-        className="border-b border-border hover:bg-muted transition-colors cursor-pointer"
+        className="border-b border-border hover:bg-muted/50 transition-colors cursor-pointer"
         onClick={onToggle}
       >
-        <td className="px-4 py-3">
+        <td className="px-4 py-2.5">
           <span className="text-muted-foreground">
             {isExpanded ? (
               <ChevronDown className="h-4 w-4" />
@@ -1041,19 +1041,19 @@ function InvoiceRow({
             )}
           </span>
         </td>
-        <td className="px-4 py-3 font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300">{invoice.invoiceNumber}</td>
-        <td className="px-4 py-3 text-muted-foreground">{formatDate(invoice.issueDate)}</td>
-        <td className="px-4 py-3 text-muted-foreground">{formatDate(invoice.dueDate)}</td>
-        <td className="px-4 py-3 text-right font-medium text-foreground">
+        <td className="px-4 py-2.5 font-medium text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300">{invoice.invoiceNumber}</td>
+        <td className="px-4 py-2.5 text-muted-foreground tabular-nums">{formatDate(invoice.issueDate)}</td>
+        <td className="px-4 py-2.5 text-muted-foreground tabular-nums">{formatDate(invoice.dueDate)}</td>
+        <td className="px-4 py-2.5 text-right font-medium text-foreground tabular-nums">
           {formatCurrency(invoiceTotal, invoice.currency)}
         </td>
-        <td className="px-4 py-3 text-center">
+        <td className="px-4 py-2.5 text-center">
           <StatusBadge status={invoice.status} />
         </td>
-        <td className="px-4 py-3 text-right">
+        <td className="px-4 py-2.5 text-right">
           <button
             onClick={handleDownloadPdf}
-            className="inline-flex items-center gap-1 text-xs text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300 font-medium"
+            className="inline-flex items-center gap-1 text-[11px] text-brand-600 dark:text-brand-400 hover:text-brand-700 dark:hover:text-brand-300 font-medium"
             title="Download PDF"
           >
             <Download className="h-3.5 w-3.5" />
@@ -1063,40 +1063,40 @@ function InvoiceRow({
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={7} className="bg-muted px-6 py-5 border-b border-border">
+          <td colSpan={7} className="bg-muted px-4 py-4 border-b border-border">
             {/* Invoice Detail View */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-4">
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Invoice Number</p>
-                <p className="text-sm font-semibold text-foreground">{invoice.invoiceNumber}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">Invoice Number</p>
+                <p className="text-[13px] font-semibold text-foreground tabular-nums">{invoice.invoiceNumber}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Issue Date</p>
-                <p className="text-sm text-foreground">{formatDate(invoice.issueDate)}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">Issue Date</p>
+                <p className="text-[13px] text-foreground tabular-nums">{formatDate(invoice.issueDate)}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Due Date</p>
-                <p className="text-sm text-foreground">{formatDate(invoice.dueDate)}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">Due Date</p>
+                <p className="text-[13px] text-foreground tabular-nums">{formatDate(invoice.dueDate)}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Status</p>
+                <p className="text-[11px] text-muted-foreground mb-1">Status</p>
                 <StatusBadge status={invoice.status} />
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Currency</p>
-                <p className="text-sm text-foreground">{invoice.currency || "USD"}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">Currency</p>
+                <p className="text-[13px] text-foreground">{invoice.currency || "USD"}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Reference</p>
-                <p className="text-sm text-foreground">{invoice.referenceNumber || "—"}</p>
+                <p className="text-[11px] text-muted-foreground mb-1">Reference</p>
+                <p className="text-[13px] text-foreground">{invoice.referenceNumber || "—"}</p>
               </div>
             </div>
 
             {/* Line Items */}
             {invoice.items?.length > 0 && (
               <div className="mb-4">
-                <p className="text-xs font-medium text-muted-foreground mb-2 uppercase">Line Items</p>
-                <table className="w-full text-xs">
+                <p className="text-[11px] font-semibold text-muted-foreground mb-2 uppercase tracking-wider">Line Items</p>
+                <table className="w-full text-[11px]">
                   <thead>
                     <tr className="text-muted-foreground border-b border-border">
                       <th className="text-left pb-2 font-medium">Description</th>
@@ -1109,9 +1109,9 @@ function InvoiceRow({
                     {invoice.items.map((item: any, idx: number) => (
                       <tr key={idx} className="border-t border-border">
                         <td className="py-2 text-muted-foreground">{item.name || item.description}</td>
-                        <td className="py-2 text-right text-muted-foreground">{item.quantity}</td>
-                        <td className="py-2 text-right text-muted-foreground">{formatCurrency(item.rate || item.unitPrice || 0, invoice.currency)}</td>
-                        <td className="py-2 text-right font-medium text-foreground">
+                        <td className="py-2 text-right text-muted-foreground tabular-nums">{item.quantity}</td>
+                        <td className="py-2 text-right text-muted-foreground tabular-nums">{formatCurrency(item.rate || item.unitPrice || 0, invoice.currency)}</td>
+                        <td className="py-2 text-right font-medium text-foreground tabular-nums">
                           {formatCurrency(item.amount || (item.quantity * (item.rate || item.unitPrice || 0)), invoice.currency)}
                         </td>
                       </tr>
@@ -1123,33 +1123,33 @@ function InvoiceRow({
 
             {/* Totals */}
             <div className="border-t border-border pt-3 space-y-1">
-              <div className="flex justify-between text-sm">
+              <div className="flex justify-between text-[13px]">
                 <span className="text-muted-foreground">Subtotal</span>
-                <span className="text-foreground">{formatCurrency(invoice.subtotal ?? invoiceTotal, invoice.currency)}</span>
+                <span className="text-foreground tabular-nums">{formatCurrency(invoice.subtotal ?? invoiceTotal, invoice.currency)}</span>
               </div>
               {invoice.discountAmount > 0 && (
-                <div className="flex justify-between text-sm">
+                <div className="flex justify-between text-[13px]">
                   <span className="text-muted-foreground">Discount</span>
-                  <span className="text-green-600 dark:text-green-400">-{formatCurrency(invoice.discountAmount, invoice.currency)}</span>
+                  <span className="text-green-600 dark:text-green-400 tabular-nums">-{formatCurrency(invoice.discountAmount, invoice.currency)}</span>
                 </div>
               )}
               {invoice.taxAmount > 0 && (
-                <div className="flex justify-between text-sm">
+                <div className="flex justify-between text-[13px]">
                   <span className="text-muted-foreground">Tax</span>
-                  <span className="text-foreground">{formatCurrency(invoice.taxAmount, invoice.currency)}</span>
+                  <span className="text-foreground tabular-nums">{formatCurrency(invoice.taxAmount, invoice.currency)}</span>
                 </div>
               )}
-              <div className="flex justify-between text-sm font-bold border-t border-border pt-2">
+              <div className="flex justify-between text-[13px] font-semibold border-t border-border pt-2">
                 <span className="text-foreground">Total</span>
-                <span className="text-foreground">{formatCurrency(invoiceTotal, invoice.currency)}</span>
+                <span className="text-foreground tabular-nums">{formatCurrency(invoiceTotal, invoice.currency)}</span>
               </div>
-              <div className="flex justify-between text-sm">
+              <div className="flex justify-between text-[13px]">
                 <span className="text-muted-foreground">Paid</span>
-                <span className="text-green-600 dark:text-green-400">{formatCurrency(amountPaid, invoice.currency)}</span>
+                <span className="text-green-600 dark:text-green-400 tabular-nums">{formatCurrency(amountPaid, invoice.currency)}</span>
               </div>
-              <div className="flex justify-between text-sm font-semibold">
+              <div className="flex justify-between text-[13px] font-semibold">
                 <span className="text-muted-foreground">Amount Due</span>
-                <span className={amountDue > 0 ? "text-red-600 dark:text-red-400" : "text-green-600 dark:text-green-400"}>{formatCurrency(amountDue, invoice.currency)}</span>
+                <span className={`tabular-nums ${amountDue > 0 ? "text-red-600 dark:text-red-400" : "text-green-600 dark:text-green-400"}`}>{formatCurrency(amountDue, invoice.currency)}</span>
               </div>
             </div>
 
@@ -1157,7 +1157,7 @@ function InvoiceRow({
             <div className="flex gap-3 mt-4 pt-3 border-t border-border">
               <button
                 onClick={(e) => { e.stopPropagation(); handleDownloadPdf(e); }}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-brand-600 text-white rounded-lg hover:bg-brand-700"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-[11px] font-medium bg-brand-600 text-white rounded-md hover:bg-brand-700"
               >
                 <Download className="h-3.5 w-3.5" /> {t('billing.invoices.downloadPdf')}
               </button>
@@ -1165,7 +1165,7 @@ function InvoiceRow({
                 <PayNowButton invoiceId={invoice.id} />
               )}
               {invoice.notes && (
-                <div className="text-xs text-muted-foreground italic">Note: {invoice.notes}</div>
+                <div className="text-[11px] text-muted-foreground italic">Note: {invoice.notes}</div>
               )}
             </div>
           </td>
@@ -1192,7 +1192,7 @@ function PaymentsTab() {
 
   if (payments.length === 0) {
     return (
-      <div className="bg-card rounded-xl border border-border p-12 text-center">
+      <div className="bg-card rounded-lg border border-border p-12 text-center">
         <CreditCard className="h-10 w-10 text-muted-foreground/50 mx-auto mb-3" />
         <p className="text-muted-foreground">{t('billing.payments.none')}</p>
       </div>
@@ -1201,27 +1201,27 @@ function PaymentsTab() {
 
   return (
     <div>
-      <div className="bg-card rounded-xl border border-border overflow-x-auto -mx-4 lg:mx-0">
-        <table className="min-w-full text-sm">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
+        <table className="min-w-full text-[13px]">
           <thead>
             <tr className="bg-muted border-b border-border">
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.payments.date')}</th>
-              <th className="text-right px-4 py-3 font-medium text-muted-foreground">{t('billing.payments.amount')}</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.payments.method')}</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.payments.reference')}</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">{t('billing.payments.invoice')}</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.payments.date')}</th>
+              <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.payments.amount')}</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.payments.method')}</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.payments.reference')}</th>
+              <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{t('billing.payments.invoice')}</th>
             </tr>
           </thead>
           <tbody>
             {payments.map((p: any) => (
-              <tr key={p.id} className="border-b border-border hover:bg-muted transition-colors">
-                <td className="px-4 py-3 text-muted-foreground">{formatDate(p.date)}</td>
-                <td className="px-4 py-3 text-right font-medium text-foreground">
+              <tr key={p.id} className="border-b border-border hover:bg-muted/50 transition-colors">
+                <td className="px-4 py-2.5 text-muted-foreground tabular-nums">{formatDate(p.date)}</td>
+                <td className="px-4 py-2.5 text-right font-medium text-foreground tabular-nums">
                   {formatCurrency(p.amount, p.currency)}
                 </td>
-                <td className="px-4 py-3 text-muted-foreground capitalize">{p.method}</td>
-                <td className="px-4 py-3 text-muted-foreground font-mono text-xs">{p.reference}</td>
-                <td className="px-4 py-3 text-muted-foreground text-xs">{p.invoiceId || "—"}</td>
+                <td className="px-4 py-2.5 text-muted-foreground capitalize">{p.method}</td>
+                <td className="px-4 py-2.5 text-muted-foreground font-mono text-[11px] tabular-nums">{p.reference}</td>
+                <td className="px-4 py-2.5 text-muted-foreground text-[11px]">{p.invoiceId || "—"}</td>
               </tr>
             ))}
           </tbody>
@@ -1230,21 +1230,21 @@ function PaymentsTab() {
 
       {meta && meta.totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">
-          <p className="text-sm text-muted-foreground">
+          <p className="text-[13px] text-muted-foreground tabular-nums">
             {t('billing.payments.pagination', { page: meta.page, totalPages: meta.totalPages, total: meta.total })}
           </p>
           <div className="flex gap-2">
             <button
               disabled={page <= 1}
               onClick={() => setPage((p) => p - 1)}
-              className="px-3 py-1.5 text-sm rounded-lg border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
+              className="px-3 py-1.5 text-[13px] rounded-md border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
             >
               {t('billing.invoices.previous')}
             </button>
             <button
               disabled={page >= meta.totalPages}
               onClick={() => setPage((p) => p + 1)}
-              className="px-3 py-1.5 text-sm rounded-lg border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
+              className="px-3 py-1.5 text-[13px] rounded-md border border-border text-muted-foreground hover:bg-muted disabled:opacity-40"
             >
               {t('billing.invoices.next')}
             </button>

--- a/packages/client/src/pages/subscriptions/SubscriptionsPage.tsx
+++ b/packages/client/src/pages/subscriptions/SubscriptionsPage.tsx
@@ -51,7 +51,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
         <div className="flex items-center justify-between p-6 border-b">
           <div>
             <h2 className="text-lg font-bold text-gray-900">{t("subscriptionsPage.editModal.title")}</h2>
-            <p className="text-sm text-gray-500">{moduleName}</p>
+            <p className="text-[13px] text-gray-500">{moduleName}</p>
           </div>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
             <X className="h-5 w-5" />
@@ -61,13 +61,13 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
         <div className="p-6 space-y-5">
           {/* Plan Tier */}
           <div>
-            <label className="text-sm font-medium text-gray-700 mb-2 block">{t("subscriptionsPage.editModal.planTierLabel")}</label>
+            <label className="text-[13px] font-medium text-gray-700 mb-2 block">{t("subscriptionsPage.editModal.planTierLabel")}</label>
             <div className="grid grid-cols-3 gap-2">
               {plans.map(plan => (
                 <button
                   key={plan.value}
                   onClick={() => setPlanTier(plan.value)}
-                  className={`py-2 px-3 rounded-lg border-2 text-sm font-medium transition-all ${
+                  className={`py-2 px-3 rounded-md border-2 text-[13px] font-medium transition-all ${
                     planTier === plan.value
                       ? "border-brand-500 bg-brand-50 text-brand-700"
                       : "border-gray-200 text-gray-600 hover:border-gray-300"
@@ -81,13 +81,13 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
 
           {/* Total Seats */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-gray-700 mb-2">
               <Users className="h-4 w-4" /> {t("subscriptionsPage.editModal.totalSeatsLabel")}
             </label>
             <div className="flex items-center gap-3">
               <button
                 onClick={() => setTotalSeats(Math.max(1, totalSeats - 1))}
-                className="h-10 w-10 rounded-lg border border-gray-300 flex items-center justify-center text-gray-600 hover:bg-gray-50"
+                className="h-10 w-10 rounded-md border border-gray-300 flex items-center justify-center text-gray-600 hover:bg-gray-50"
               >
                 -
               </button>
@@ -97,26 +97,26 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
                 max={10000}
                 value={totalSeats}
                 onChange={e => setTotalSeats(Math.max(1, Number(e.target.value)))}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-center text-lg font-semibold focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-center text-lg font-semibold tabular-nums focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
               />
               <button
                 onClick={() => setTotalSeats(totalSeats + 1)}
-                className="h-10 w-10 rounded-lg border border-gray-300 flex items-center justify-center text-gray-600 hover:bg-gray-50"
+                className="h-10 w-10 rounded-md border border-gray-300 flex items-center justify-center text-gray-600 hover:bg-gray-50"
               >
                 +
               </button>
             </div>
             <div className="flex justify-between mt-1">
-              <p className="text-xs text-gray-400">{t("subscriptionsPage.editModal.currentlyUsing", { seats: subscription.used_seats })}</p>
+              <p className="text-[11px] text-gray-400">{t("subscriptionsPage.editModal.currentlyUsing", { seats: subscription.used_seats })}</p>
               {seatsReduced && (
-                <p className="text-xs text-red-500 font-medium">{t("subscriptionsPage.editModal.cannotReduceBelow", { seats: subscription.used_seats })}</p>
+                <p className="text-[11px] text-red-500 font-medium">{t("subscriptionsPage.editModal.cannotReduceBelow", { seats: subscription.used_seats })}</p>
               )}
             </div>
           </div>
 
           {/* Billing Cycle */}
           <div>
-            <label className="flex items-center gap-2 text-sm font-medium text-gray-700 mb-2">
+            <label className="flex items-center gap-2 text-[13px] font-medium text-gray-700 mb-2">
               <Calendar className="h-4 w-4" /> {t("subscriptionsPage.editModal.billingCycleLabel")}
             </label>
             <div className="grid grid-cols-3 gap-2">
@@ -124,7 +124,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
                 <button
                   key={cycle.value}
                   onClick={() => setBillingCycle(cycle.value)}
-                  className={`py-2 px-3 rounded-lg border-2 text-sm font-medium transition-all ${
+                  className={`py-2 px-3 rounded-md border-2 text-[13px] font-medium transition-all ${
                     billingCycle === cycle.value
                       ? "border-brand-500 bg-brand-50 text-brand-700"
                       : "border-gray-200 text-gray-600 hover:border-gray-300"
@@ -138,7 +138,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
 
           {/* Change Summary */}
           {hasChanges && (
-            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm">
+            <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 text-[13px]">
               <p className="font-medium text-amber-800 mb-1">{t("subscriptionsPage.editModal.changesHeading")}</p>
               <ul className="text-amber-700 space-y-0.5">
                 {planTier !== subscription.plan_tier && (
@@ -162,7 +162,7 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
 
           {/* Trial-end warning */}
           {willEndTrial && (
-            <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm">
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-[13px]">
               <p className="font-medium text-red-800 mb-1">{t("subscriptionsPage.editModal.trialWarning.title")}</p>
               <p className="text-red-700">
                 {seatsIncreasing && t("subscriptionsPage.editModal.trialWarning.reason.seats")}
@@ -175,11 +175,11 @@ function EditSubscriptionModal({ subscription, moduleName, onClose, onSave, isLo
         </div>
 
         <div className="flex items-center justify-between p-6 border-t bg-gray-50 rounded-b-2xl">
-          <button onClick={onClose} className="text-sm text-gray-500 hover:text-gray-700">{t("subscriptionsPage.editModal.cancel")}</button>
+          <button onClick={onClose} className="text-[13px] text-gray-500 hover:text-gray-700">{t("subscriptionsPage.editModal.cancel")}</button>
           <button
             onClick={() => onSave(subscription.id, { plan_tier: planTier, total_seats: totalSeats, billing_cycle: billingCycle })}
             disabled={isLoading || !hasChanges || seatsReduced}
-            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
+            className="flex items-center gap-2 bg-brand-600 text-white px-5 py-2 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors"
           >
             {isLoading ? t("subscriptionsPage.editModal.saving") : t("subscriptionsPage.editModal.save")}
           </button>
@@ -227,12 +227,12 @@ export default function SubscriptionsPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">{t("subscriptionsPage.header.title")}</h1>
-        <p className="text-gray-500 mt-1">{t("subscriptionsPage.header.subtitle")}</p>
+        <h1 className="text-xl font-semibold tracking-tight text-gray-900">{t("subscriptionsPage.header.title")}</h1>
+        <p className="text-[13px] text-gray-500 mt-0.5">{t("subscriptionsPage.header.subtitle")}</p>
       </div>
 
       {toast && (
-        <div className="fixed bottom-6 right-6 z-50 bg-green-600 text-white px-5 py-3 rounded-xl shadow-lg text-sm font-medium flex items-center gap-2">
+        <div className="fixed bottom-6 right-6 z-50 bg-green-600 text-white px-5 py-3 rounded-xl shadow-lg text-[13px] font-medium flex items-center gap-2">
           <Check className="h-4 w-4" />{toast}
         </div>
       )}
@@ -252,13 +252,13 @@ export default function SubscriptionsPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setCancelConfirm(null)}>
           <div className="bg-white rounded-xl shadow-xl p-6 max-w-sm mx-4" onClick={e => e.stopPropagation()}>
             <h3 className="text-lg font-bold text-gray-900 mb-2">{t("subscriptionsPage.cancelModal.title")}</h3>
-            <p className="text-sm text-gray-500 mb-4">{t("subscriptionsPage.cancelModal.body")}</p>
+            <p className="text-[13px] text-gray-500 mb-4">{t("subscriptionsPage.cancelModal.body")}</p>
             <div className="flex gap-3 justify-end">
-              <button onClick={() => setCancelConfirm(null)} className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800">{t("subscriptionsPage.cancelModal.keep")}</button>
+              <button onClick={() => setCancelConfirm(null)} className="px-4 py-2 text-[13px] text-gray-600 hover:text-gray-800">{t("subscriptionsPage.cancelModal.keep")}</button>
               <button
                 onClick={() => handleCancel(cancelConfirm)}
                 disabled={cancelSub.isPending}
-                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+                className="px-4 py-2 text-[13px] bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
               >
                 {cancelSub.isPending ? t("subscriptionsPage.cancelModal.confirming") : t("subscriptionsPage.cancelModal.confirm")}
               </button>
@@ -269,21 +269,21 @@ export default function SubscriptionsPage() {
 
       <Link
         to="/billing"
-        className="flex items-center justify-between bg-brand-50 border border-brand-200 rounded-xl px-6 py-4 mb-6 hover:bg-brand-100 transition-colors group"
+        className="flex items-center justify-between bg-brand-50 border border-brand-200 rounded-lg px-6 py-4 mb-6 hover:bg-brand-100 transition-colors group"
       >
-        <p className="text-sm font-medium text-brand-700">{t("subscriptionsPage.billing.viewInvoicesLink")}</p>
+        <p className="text-[13px] font-medium text-brand-700">{t("subscriptionsPage.billing.viewInvoicesLink")}</p>
         <ArrowRight className="h-4 w-4 text-brand-600 group-hover:translate-x-1 transition-transform" />
       </Link>
 
       {billing && (
-        <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6">
+        <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
           <div className="flex items-center gap-3 mb-2">
             <TrendingUp className="h-5 w-5 text-brand-600" />
             <h2 className="font-semibold text-gray-900">{t("subscriptionsPage.billing.monthlyCostHeading")}</h2>
           </div>
-          <p className="text-3xl font-bold text-gray-900">
+          <p className="text-3xl font-semibold text-gray-900 tabular-nums">
             {formatCurrency(billing.total_monthly_cost, billing.currency)}
-            <span className="text-sm font-normal text-gray-500">{t("subscriptionsPage.billing.perMonthSuffix")}</span>
+            <span className="text-[13px] font-normal text-gray-500">{t("subscriptionsPage.billing.perMonthSuffix")}</span>
           </p>
         </div>
       )}
@@ -292,7 +292,7 @@ export default function SubscriptionsPage() {
         {subscriptions?.map((sub: any) => {
           const mod = moduleMap.get(sub.module_id) as any;
           return (
-            <div key={sub.id} className="bg-white rounded-xl border border-gray-200 p-6">
+            <div key={sub.id} className="bg-white rounded-lg border border-gray-200 p-4">
               <div className="flex items-start justify-between">
                 <div className="flex items-center gap-3">
                   <div className="h-10 w-10 rounded-lg bg-brand-50 flex items-center justify-center">
@@ -300,11 +300,11 @@ export default function SubscriptionsPage() {
                   </div>
                   <div>
                     <h3 className="font-semibold text-gray-900">{mod?.name || t("subscriptionsPage.moduleFallback")}</h3>
-                    <p className="text-xs text-gray-500">{mod?.slug}</p>
+                    <p className="text-[11px] text-gray-500">{mod?.slug}</p>
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={`text-xs px-2 py-1 rounded-full font-medium ${
+                  <span className={`text-[11px] px-2 py-1 rounded-md font-medium ${
                     sub.status === "active" ? "bg-green-50 text-green-700" :
                     sub.status === "trial" ? "bg-yellow-50 text-yellow-700" :
                     sub.status === "cancelled" ? "bg-gray-100 text-gray-500" :
@@ -316,14 +316,14 @@ export default function SubscriptionsPage() {
                     <>
                       <button
                         onClick={() => setEditingSub(sub)}
-                        className="p-1.5 text-gray-400 hover:text-brand-600 hover:bg-brand-50 rounded-lg transition-colors"
+                        className="p-1.5 text-gray-400 hover:text-brand-600 hover:bg-brand-50 rounded-md transition-colors"
                         title={t("subscriptionsPage.card.tooltip.edit")}
                       >
                         <Pencil className="h-4 w-4" />
                       </button>
                       <button
                         onClick={() => setCancelConfirm(sub.id)}
-                        className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                        className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
                         title={t("subscriptionsPage.card.tooltip.cancel")}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -340,14 +340,14 @@ export default function SubscriptionsPage() {
                 const daysLeft = Math.ceil(msLeft / 86400000);
                 if (daysLeft <= 0) {
                   return (
-                    <div className="mt-3 bg-red-50 border border-red-200 rounded-lg px-3 py-2 text-xs text-red-700">
+                    <div className="mt-3 bg-red-50 border border-red-200 rounded-lg px-3 py-2 text-[11px] text-red-700">
                       {t("subscriptionsPage.trial.expired")}
                     </div>
                   );
                 }
                 const tone = daysLeft <= 3 ? "amber" : "blue";
                 return (
-                  <div className={`mt-3 ${tone === "amber" ? "bg-amber-50 border-amber-200 text-amber-700" : "bg-blue-50 border-blue-200 text-blue-700"} border rounded-lg px-3 py-2 text-xs flex items-center gap-1.5`}>
+                  <div className={`mt-3 ${tone === "amber" ? "bg-amber-50 border-amber-200 text-amber-700" : "bg-blue-50 border-blue-200 text-blue-700"} border rounded-lg px-3 py-2 text-[11px] flex items-center gap-1.5`}>
                     <Calendar className="h-3.5 w-3.5" />
                     {t("subscriptionsPage.trial.endsIn", { count: daysLeft, date: trialEnd.toLocaleDateString() })}
                   </div>
@@ -356,8 +356,8 @@ export default function SubscriptionsPage() {
 
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4 pt-4 border-t border-gray-100">
                 <div>
-                  <p className="text-xs text-gray-500">{t("subscriptionsPage.card.field.plan")}</p>
-                  <p className="text-sm font-medium text-gray-900 capitalize">{t(`subscriptionsPage.planTier.${sub.plan_tier}`, { defaultValue: sub.plan_tier })}</p>
+                  <p className="text-[11px] text-gray-500">{t("subscriptionsPage.card.field.plan")}</p>
+                  <p className="text-[13px] font-medium text-gray-900 capitalize">{t(`subscriptionsPage.planTier.${sub.plan_tier}`, { defaultValue: sub.plan_tier })}</p>
                 </div>
                 {/* #1448 — Seat tile is now a link to /users?module=<slug> so
                     admins can quickly see which employees have this seat. */}
@@ -365,11 +365,11 @@ export default function SubscriptionsPage() {
                   to={`/users?module=${mod?.slug || ""}`}
                   className="group"
                 >
-                  <p className="text-xs text-gray-500 group-hover:text-brand-600">{t("subscriptionsPage.card.field.seats")}</p>
-                  <p className="text-sm font-medium text-gray-900 group-hover:text-brand-700 group-hover:underline">
+                  <p className="text-[11px] text-gray-500 group-hover:text-brand-600">{t("subscriptionsPage.card.field.seats")}</p>
+                  <p className="text-[13px] font-medium text-gray-900 group-hover:text-brand-700 group-hover:underline tabular-nums">
                     {sub.used_seats}/{sub.total_seats}
                     {sub.used_seats >= sub.total_seats && (
-                      <span className="text-xs text-red-500 ml-1">{t("subscriptionsPage.card.seatsFull")}</span>
+                      <span className="text-[11px] text-red-500 ml-1">{t("subscriptionsPage.card.seatsFull")}</span>
                     )}
                   </p>
                   {/* Seat usage bar */}
@@ -381,14 +381,14 @@ export default function SubscriptionsPage() {
                   </div>
                 </Link>
                 <div>
-                  <p className="text-xs text-gray-500">{t("subscriptionsPage.card.field.pricePerSeat")}</p>
-                  <p className="text-sm font-medium text-gray-900">
+                  <p className="text-[11px] text-gray-500">{t("subscriptionsPage.card.field.pricePerSeat")}</p>
+                  <p className="text-[13px] font-medium text-gray-900 tabular-nums">
                     {formatCurrency(Number(sub.price_per_seat), sub.currency)}
                   </p>
                 </div>
                 <div>
-                  <p className="text-xs text-gray-500">{t("subscriptionsPage.card.field.billingCycle")}</p>
-                  <p className="text-sm font-medium text-gray-900 capitalize">{t(`subscriptionsPage.billingCycle.${sub.billing_cycle}`, { defaultValue: sub.billing_cycle })}</p>
+                  <p className="text-[11px] text-gray-500">{t("subscriptionsPage.card.field.billingCycle")}</p>
+                  <p className="text-[13px] font-medium text-gray-900 capitalize">{t(`subscriptionsPage.billingCycle.${sub.billing_cycle}`, { defaultValue: sub.billing_cycle })}</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Applies the enterprise density guide (`docs/UI-UPLIFT-GUIDE.md`) to the **Billing** module. Surface-only — no logic changes.

**Pages**
- `BillingPage.tsx` (invoices, payments, KPI cards, subscription cards, expandable invoice detail)
- `SubscriptionsPage.tsx` (subscription cards + edit / cancel modals)

**Changes**
- `rounded-xl` cards → `rounded-lg`, `p-6` → `p-4`; `rounded-lg` controls → `rounded-md`
- invoice / subscription / payment status pills `rounded-full` → `rounded-md` (progress tracks/fills kept round; **semantic status hues preserved** — green=paid, red=overdue, amber=pending)
- page titles `text-2xl font-bold` → `text-xl font-semibold tracking-tight`
- KPI stat numbers: `font-bold` → `font-semibold` + `tabular-nums` (size kept)
- table headers → `[11px]` uppercase tracking-wider; cells `px-4 py-3` → `px-4 py-2.5`
- body `text-sm` → `[13px]`, `text-xs` → `[11px]`; `tabular-nums` on money / dates / counts
- row hovers → `hover:bg-muted/50 transition-colors`

**Safety**
- print-invoice HTML template string (inline CSS) left untouched
- `formatCurrency` / `formatDate` calls and all status-computing ternary conditions unchanged

**Note — SubscriptionsPage dark-mode gap (deferred):** SubscriptionsPage is a light-only page still using raw `gray-*` / `bg-white`. This pass is **density-only** by design; the raw-gray → semantic-token (dark-mode) migration is deferred to a follow-up so this PR stays a clean density diff.

**Verification**
- className-only diff (173 insertions = 173 deletions)
- `tsc --noEmit`: 0 errors
- client `npm run build`: passes