### PR TITLE
UI density uplift: Misc pages (Chatbot, Kiosk, Audit, Onboarding, Whistleblowing)

### DIFF
--- a/packages/client/src/pages/audit/AuditPage.tsx
+++ b/packages/client/src/pages/audit/AuditPage.tsx
@@ -88,7 +88,7 @@ function ActionTypeSelect({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center justify-between gap-2 rounded-lg border border-border bg-card px-3 py-2 text-left text-sm text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-brand-500"
+        className="flex w-full items-center justify-between gap-2 rounded-md border border-border bg-card px-3 py-2 text-left text-[13px] text-muted-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-brand-500"
         aria-haspopup="listbox"
         aria-expanded={open}
       >
@@ -97,7 +97,7 @@ function ActionTypeSelect({
       </button>
 
       {open && (
-        <div className="absolute z-30 mt-1 w-full rounded-lg border border-border bg-card shadow-lg">
+        <div className="absolute z-30 mt-1 w-full rounded-md border border-border bg-card shadow-lg">
           <div className="border-b border-border p-2">
             <div className="relative">
               <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -108,13 +108,13 @@ function ActionTypeSelect({
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={onInputKeyDown}
                 placeholder={searchPlaceholder}
-                className="w-full rounded-md border border-border py-1.5 pl-8 pr-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
+                className="w-full rounded-md border border-border py-1.5 pl-8 pr-2 text-[13px] focus:outline-none focus:ring-2 focus:ring-brand-500 bg-card text-foreground"
               />
             </div>
           </div>
           <ul role="listbox" className="max-h-60 overflow-y-auto py-1">
             {filtered.length === 0 ? (
-              <li className="px-3 py-2 text-sm text-muted-foreground">{noMatchLabel}</li>
+              <li className="px-3 py-2 text-[13px] text-muted-foreground">{noMatchLabel}</li>
             ) : (
               filtered.map((o, i) => {
                 const isSelected = o.value === value;
@@ -128,7 +128,7 @@ function ActionTypeSelect({
                       aria-selected={isSelected}
                       onClick={() => choose(o.value)}
                       onMouseEnter={() => setActiveIndex(i)}
-                      className={`flex w-full items-center px-3 py-1.5 text-left text-sm ${
+                      className={`flex w-full items-center px-3 py-1.5 text-left text-[13px] ${
                         isSelected ? "font-medium text-brand-700 dark:text-brand-300" : "text-muted-foreground"
                       } ${isActive ? "bg-muted" : ""}`}
                     >
@@ -214,19 +214,19 @@ export default function AuditPage() {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">{tx("title")}</h1>
-        <p className="text-muted-foreground mt-1">{tx("subtitle")}</p>
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{tx("title")}</h1>
+        <p className="text-[13px] text-muted-foreground mt-0.5">{tx("subtitle")}</p>
       </div>
 
       {/* Filter Controls */}
-      <div className="bg-card rounded-xl border border-border p-4 mb-4">
+      <div className="bg-card rounded-lg border border-border p-4 mb-4">
         <div className="flex items-center gap-2 mb-3">
           <Filter className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium text-muted-foreground">{tx("filters")}</span>
+          <span className="text-[13px] font-medium text-muted-foreground">{tx("filters")}</span>
           {hasFilters && (
             <button
               onClick={clearFilters}
-              className="ml-auto flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              className="ml-auto flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
             >
               <RotateCcw className="h-3 w-3" /> {tx("clearAll")}
             </button>
@@ -235,7 +235,7 @@ export default function AuditPage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {/* Action Type Filter — searchable single-select */}
           <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1">{tx("actionType")}</label>
+            <label className="block text-[11px] font-medium text-muted-foreground mb-1">{tx("actionType")}</label>
             <ActionTypeSelect
               value={action}
               options={AUDIT_ACTION_VALUES.map((value) => ({ value, label: actionLabel(value) }))}
@@ -249,7 +249,7 @@ export default function AuditPage() {
               Replaces the old separate From/To native date inputs; Apply drives
               start_date / end_date so the query contract is unchanged. */}
           <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1">
+            <label className="block text-[11px] font-medium text-muted-foreground mb-1">
               <span className="flex items-center gap-1"><Calendar className="h-3 w-3" /> {t("attendance.dateFrom")} &mdash; {t("attendance.dateTo")}</span>
             </label>
             <DateRangePicker
@@ -268,7 +268,7 @@ export default function AuditPage() {
 
       {/* Results Summary */}
       {hasFilters && meta && (
-        <div className="text-sm text-muted-foreground mb-3">
+        <div className="text-[13px] text-muted-foreground mb-3">
           {tx("showingResults", { count: logs.length, total: meta.total })}
           {action && <span className="ml-1">{tx("showingFor")} <span className="font-medium text-muted-foreground">{actionLabel(action)}</span></span>}
           {startDate && <span className="ml-1">{tx("showingFrom")} <span className="font-medium text-muted-foreground">{startDate}</span></span>}
@@ -276,15 +276,15 @@ export default function AuditPage() {
         </div>
       )}
 
-      <div className="bg-card rounded-xl border border-border overflow-x-auto -mx-4 lg:mx-0">
+      <div className="bg-card rounded-lg border border-border overflow-x-auto -mx-4 lg:mx-0">
         <table className="min-w-full">
           <thead className="bg-muted border-b border-border">
             <tr>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{tx("colTime")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{tx("colAction")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{tx("colUser")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{tx("colResource")}</th>
-              <th className="text-left text-xs font-medium text-muted-foreground uppercase px-6 py-3">{tx("colIp")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{tx("colTime")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{tx("colAction")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{tx("colUser")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{tx("colResource")}</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase tracking-wider px-4 py-2.5">{tx("colIp")}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -292,11 +292,11 @@ export default function AuditPage() {
               <>
                 {[1, 2, 3, 4, 5].map((i) => (
                   <tr key={i} className="animate-pulse">
-                    <td className="px-6 py-4"><div className="h-4 w-32 bg-muted rounded" /></td>
-                    <td className="px-6 py-4"><div className="h-4 w-24 bg-muted rounded-full" /></td>
-                    <td className="px-6 py-4"><div className="h-4 w-16 bg-muted rounded" /></td>
-                    <td className="px-6 py-4"><div className="h-4 w-20 bg-muted rounded" /></td>
-                    <td className="px-6 py-4"><div className="h-4 w-24 bg-muted rounded" /></td>
+                    <td className="px-4 py-2.5"><div className="h-4 w-32 bg-muted rounded" /></td>
+                    <td className="px-4 py-2.5"><div className="h-4 w-24 bg-muted rounded-full" /></td>
+                    <td className="px-4 py-2.5"><div className="h-4 w-16 bg-muted rounded" /></td>
+                    <td className="px-4 py-2.5"><div className="h-4 w-20 bg-muted rounded" /></td>
+                    <td className="px-4 py-2.5"><div className="h-4 w-24 bg-muted rounded" /></td>
                   </tr>
                 ))}
               </>
@@ -304,11 +304,11 @@ export default function AuditPage() {
               <tr>
                 <td colSpan={5} className="px-6 py-12 text-center">
                   <Search className="h-8 w-8 text-muted-foreground/50 mx-auto mb-2" />
-                  <p className="text-muted-foreground text-sm">
+                  <p className="text-muted-foreground text-[13px]">
                     {hasFilters ? tx("noMatchingFilters") : tx("noLogs")}
                   </p>
                   {hasFilters && (
-                    <button onClick={clearFilters} className="text-brand-600 dark:text-brand-400 text-sm mt-1 hover:underline">
+                    <button onClick={clearFilters} className="text-brand-600 dark:text-brand-400 text-[13px] mt-1 hover:underline">
                       {tx("clearFilters")}
                     </button>
                   )}
@@ -316,26 +316,26 @@ export default function AuditPage() {
               </tr>
             ) : (
               logs.map((log: any) => (
-                <tr key={log.id} className="hover:bg-muted">
-                  <td className="px-6 py-3 text-sm text-muted-foreground whitespace-nowrap">{formatDate(log.created_at)}</td>
-                  <td className="px-6 py-3">
-                    <span className={`text-xs px-2 py-1 rounded-full font-mono font-medium ${getActionStyle(log.action)}`}>
+                <tr key={log.id} className="hover:bg-muted/50 transition-colors">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground whitespace-nowrap tabular-nums">{formatDate(log.created_at)}</td>
+                  <td className="px-4 py-2.5">
+                    <span className={`text-[11px] px-2 py-1 rounded-md font-mono font-medium ${getActionStyle(log.action)}`}>
                       {log.action}
                     </span>
                   </td>
-                  <td className="px-6 py-3 text-sm text-muted-foreground">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                     {log.user_first_name
                       ? `${log.user_first_name} ${log.user_last_name || ""}`.trim()
                       : log.user_id
                         ? (tx("userHash", { id: log.user_id }) as string)
                         : (tx("system") as string)}
                     {log.user_email && (
-                      <span className="block text-xs text-muted-foreground">{log.user_email}</span>
+                      <span className="block text-[11px] text-muted-foreground">{log.user_email}</span>
                     )}
                   </td>
-                  <td className="px-6 py-3 text-sm text-muted-foreground">
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                     {log.resource_type ? (
-                      <span className="text-xs">
+                      <span className="text-[11px]">
                         {log.resource_type}
                         {log.resource_id && <span className="text-muted-foreground ml-1">#{log.resource_id}</span>}
                       </span>
@@ -343,7 +343,7 @@ export default function AuditPage() {
                       <span className="text-muted-foreground/50">--</span>
                     )}
                   </td>
-                  <td className="px-6 py-3 text-sm text-muted-foreground font-mono">{log.ip_address || "--"}</td>
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground font-mono tabular-nums">{log.ip_address || "--"}</td>
                 </tr>
               ))
             )}
@@ -351,13 +351,13 @@ export default function AuditPage() {
         </table>
 
         {meta && meta.total_pages > 1 && (
-          <div className="flex items-center justify-between px-6 py-3 border-t border-border">
-            <p className="text-sm text-muted-foreground">
+          <div className="flex items-center justify-between px-4 py-2.5 border-t border-border">
+            <p className="text-[13px] text-muted-foreground tabular-nums">
               {tx("pageOf", { page: meta.page, total_pages: meta.total_pages, total: meta.total })}
             </p>
             <div className="flex gap-2">
-              <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1} className="px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50 hover:bg-muted">{t("common.previous")}</button>
-              <button onClick={() => setPage((p) => p + 1)} disabled={page >= meta.total_pages} className="px-3 py-1 text-sm border border-border rounded-lg disabled:opacity-50 hover:bg-muted">{t("common.next")}</button>
+              <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1} className="px-3 py-1 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted">{t("common.previous")}</button>
+              <button onClick={() => setPage((p) => p + 1)} disabled={page >= meta.total_pages} className="px-3 py-1 text-[13px] border border-border rounded-md disabled:opacity-50 hover:bg-muted">{t("common.next")}</button>
             </div>
           </div>
         )}

--- a/packages/client/src/pages/biometrics/KioskBiometricPage.tsx
+++ b/packages/client/src/pages/biometrics/KioskBiometricPage.tsx
@@ -109,20 +109,20 @@ export default function KioskBiometricPage() {
       <button
         type="button"
         onClick={() => navigate("/biometrics")}
-        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        className="mb-4 inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
       >
         <ArrowLeft className="h-4 w-4" /> {t("kioskPin.backToBiometrics")}
       </button>
 
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-foreground">{t("kioskPin.title")}</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("kioskPin.title")}</h1>
+        <p className="mt-0.5 text-[13px] text-muted-foreground">
           {t("kioskPin.subtitle")}
         </p>
       </div>
 
       {/* Status card */}
-      <div className="rounded-xl border border-border bg-card p-6 shadow-sm">
+      <div className="rounded-lg border border-border bg-card p-4 shadow-sm">
         <div className="flex items-start gap-4">
           <div
             className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-lg ${
@@ -132,11 +132,11 @@ export default function KioskBiometricPage() {
             <Fingerprint className="h-6 w-6" />
           </div>
           <div className="flex-1">
-            <p className="text-sm font-medium text-muted-foreground">{t("kioskPin.status")}</p>
+            <p className="text-[13px] font-medium text-muted-foreground">{t("kioskPin.status")}</p>
             <p className="text-lg font-semibold text-foreground">
               {isLoading ? t("kioskPin.loading") : status ? t("kioskPin.enabled") : t("kioskPin.disabled")}
             </p>
-            <p className="mt-1 text-xs text-muted-foreground">
+            <p className="mt-1 text-[11px] text-muted-foreground">
               {status
                 ? t("kioskPin.statusOnHint")
                 : t("kioskPin.statusOffHint")}
@@ -153,7 +153,7 @@ export default function KioskBiometricPage() {
                 setMode("enable");
               }}
               disabled={isLoading}
-              className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-700 disabled:opacity-50"
+              className="inline-flex items-center gap-2 rounded-md bg-brand-600 px-4 py-2 text-[13px] font-medium text-white shadow-sm hover:bg-brand-700 disabled:opacity-50"
             >
               <ShieldCheck className="h-4 w-4" /> {t("kioskPin.enableBiometric")}
             </button>
@@ -166,7 +166,7 @@ export default function KioskBiometricPage() {
                   reset();
                   setMode("change");
                 }}
-                className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted"
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-card px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-muted/50 transition-colors"
               >
                 <KeyRound className="h-4 w-4" /> {t("kioskPin.changePin")}
               </button>
@@ -176,7 +176,7 @@ export default function KioskBiometricPage() {
                   reset();
                   setMode("disable");
                 }}
-                className="inline-flex items-center gap-2 rounded-lg border border-red-300 bg-card px-4 py-2 text-sm font-medium text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/40"
+                className="inline-flex items-center gap-2 rounded-md border border-red-300 dark:border-red-900 bg-card px-4 py-2 text-[13px] font-medium text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/40"
               >
                 <ShieldOff className="h-4 w-4" /> {t("kioskPin.disableBiometric")}
               </button>
@@ -202,13 +202,13 @@ export default function KioskBiometricPage() {
           stays close to the status card and the page remains keyboard-only
           friendly. */}
       {mode && (
-        <div className="mt-6 rounded-xl border border-border bg-card p-6 shadow-sm">
+        <div className="mt-6 rounded-lg border border-border bg-card p-4 shadow-sm">
           <h2 className="text-base font-semibold text-foreground">
             {mode === "enable" && t("kioskPin.panelEnableTitle")}
             {mode === "change" && t("kioskPin.panelChangeTitle")}
             {mode === "disable" && t("kioskPin.panelDisableTitle")}
           </h2>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-[11px] text-muted-foreground">
             {mode === "disable"
               ? t("kioskPin.panelDisableHint")
               : t("kioskPin.panelSetHint")}
@@ -231,20 +231,20 @@ export default function KioskBiometricPage() {
               />
             )}
             {error && (
-              <div className="rounded-md bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300">{error}</div>
+              <div className="rounded-md bg-red-50 dark:bg-red-950/40 px-3 py-2 text-[13px] text-red-700 dark:text-red-300">{error}</div>
             )}
             <div className="flex items-center justify-end gap-2 pt-2">
               <button
                 type="button"
                 onClick={reset}
-                className="rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-muted"
+                className="rounded-md border border-border bg-card px-4 py-2 text-[13px] font-medium text-muted-foreground hover:bg-muted/50 transition-colors"
               >
                 {t("kioskPin.cancel")}
               </button>
               <button
                 type="submit"
                 disabled={submitMutation.isPending}
-                className={`inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white shadow-sm disabled:opacity-50 ${
+                className={`inline-flex items-center gap-2 rounded-md px-4 py-2 text-[13px] font-medium text-white shadow-sm disabled:opacity-50 ${
                   mode === "disable" ? "bg-red-600 hover:bg-red-700" : "bg-brand-600 hover:bg-brand-700"
                 }`}
               >
@@ -334,24 +334,24 @@ function LivenessSettingsCard() {
     !!baseline && (baseline.enabled !== enabled || baseline.level !== level);
 
   return (
-    <div className="mt-6 rounded-xl border border-border bg-card p-6 shadow-sm">
+    <div className="mt-6 rounded-lg border border-border bg-card p-4 shadow-sm">
       <div className="flex items-start gap-4">
         <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300">
           <Eye className="h-6 w-6" />
         </div>
         <div className="flex-1">
           <h2 className="text-base font-semibold text-foreground">{t("kioskPin.livenessTitle")}</h2>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-[11px] text-muted-foreground">
             {t("kioskPin.livenessDesc")}
           </p>
         </div>
       </div>
 
       {/* Enable toggle */}
-      <div className="mt-5 flex items-center justify-between rounded-lg border border-border bg-muted px-4 py-3">
+      <div className="mt-5 flex items-center justify-between rounded-md border border-border bg-muted px-4 py-3">
         <div>
-          <p className="text-sm font-medium text-foreground">{t("kioskPin.enableLiveness")}</p>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-[13px] font-medium text-foreground">{t("kioskPin.enableLiveness")}</p>
+          <p className="text-[11px] text-muted-foreground">
             {isLoading ? t("kioskPin.loading") : enabled ? t("kioskPin.livenessOnHint") : t("kioskPin.livenessOffHint")}
           </p>
         </div>
@@ -386,10 +386,10 @@ function LivenessSettingsCard() {
       {enabled && <LivenessLevelSlider level={level} onChange={setLevel} disabled={isLoading || saveMutation.isPending} />}
 
       {error && (
-        <div className="mt-3 rounded-md bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300">{error}</div>
+        <div className="mt-3 rounded-md bg-red-50 dark:bg-red-950/40 px-3 py-2 text-[13px] text-red-700 dark:text-red-300">{error}</div>
       )}
       {saved && (
-        <div className="mt-3 rounded-md bg-green-50 dark:bg-green-950/40 px-3 py-2 text-sm text-green-700 dark:text-green-300">
+        <div className="mt-3 rounded-md bg-green-50 dark:bg-green-950/40 px-3 py-2 text-[13px] text-green-700 dark:text-green-300">
           {t("kioskPin.livenessSaved")}
         </div>
       )}
@@ -399,7 +399,7 @@ function LivenessSettingsCard() {
           type="button"
           onClick={() => saveMutation.mutate()}
           disabled={!dirty || isLoading || saveMutation.isPending}
-          className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-700 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-md bg-brand-600 px-4 py-2 text-[13px] font-medium text-white shadow-sm hover:bg-brand-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {saveMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
           {t("kioskPin.save")}
@@ -432,14 +432,14 @@ function LivenessLevelSlider({
   const idx = Math.max(0, LIVENESS_LEVELS.findIndex((l) => l.value === level));
   const current = LIVENESS_LEVELS[idx] || LIVENESS_LEVELS[1];
   return (
-    <div className="mt-3 rounded-lg border border-border bg-card px-4 py-4">
+    <div className="mt-3 rounded-md border border-border bg-card px-4 py-4">
       <div className="flex items-baseline justify-between">
-        <label className="block text-sm font-medium text-foreground" htmlFor="liveness-level-slider">
+        <label className="block text-[13px] font-medium text-foreground" htmlFor="liveness-level-slider">
           {t("kioskPin.sensitivityLevel")}
         </label>
-        <span className={`text-sm font-semibold ${current.cls}`}>{t(current.labelKey)}</span>
+        <span className={`text-[13px] font-semibold ${current.cls}`}>{t(current.labelKey)}</span>
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">{t(current.descKey)}</p>
+      <p className="mt-1 text-[11px] text-muted-foreground">{t(current.descKey)}</p>
 
       <div className="mt-4">
         <input
@@ -529,14 +529,14 @@ function LinkedOrganizationsCard() {
   });
 
   return (
-    <div className="mt-6 rounded-xl border border-border bg-card p-6 shadow-sm">
+    <div className="mt-6 rounded-lg border border-border bg-card p-4 shadow-sm">
       <div className="flex items-start gap-4">
         <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-300">
           <Link2 className="h-6 w-6" />
         </div>
         <div className="flex-1">
           <h2 className="text-base font-semibold text-foreground">{t("kioskPin.linkedOrgsTitle")}</h2>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className="mt-1 text-[11px] text-muted-foreground">
             {t("kioskPin.linkedOrgsDesc")}
           </p>
         </div>
@@ -545,22 +545,22 @@ function LinkedOrganizationsCard() {
       {/* Existing links */}
       <div className="mt-5 space-y-2">
         {isLoading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2 text-[13px] text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" /> {t("kioskPin.loading")}
           </div>
         ) : linked.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t("kioskPin.noOrgsLinked")}</p>
+          <p className="text-[13px] text-muted-foreground">{t("kioskPin.noOrgsLinked")}</p>
         ) : (
           linked.map((row) => (
             <div
               key={row.email}
-              className="flex items-center justify-between rounded-lg border border-border bg-muted px-3 py-2"
+              className="flex items-center justify-between rounded-md border border-border bg-muted px-3 py-2"
             >
               <div className="flex items-center gap-2 min-w-0">
                 <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-foreground truncate">{row.email}</p>
-                  <p className="text-xs text-muted-foreground truncate">
+                  <p className="text-[13px] font-medium text-foreground truncate">{row.email}</p>
+                  <p className="text-[11px] text-muted-foreground truncate">
                     {row.organization_name
                       ? row.organization_name
                       : row.organization_id == null
@@ -602,19 +602,19 @@ function LinkedOrganizationsCard() {
           value={newEmail}
           onChange={(e) => setNewEmail(e.target.value)}
           placeholder="admin@othercompany.com"
-          className="flex-1 rounded-lg border border-border bg-card text-foreground px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-100"
+          className="flex-1 rounded-md border border-border bg-card text-foreground px-3 py-2 text-[13px] focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-100"
         />
         <button
           type="submit"
           disabled={addMutation.isPending}
-          className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50"
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-4 py-2 text-[13px] font-medium text-white hover:bg-brand-700 disabled:opacity-50"
         >
           {addMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
           {t("kioskPin.linkOrganization")}
         </button>
       </form>
       {error && (
-        <div className="mt-2 rounded-md bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300">{error}</div>
+        <div className="mt-2 rounded-md bg-red-50 dark:bg-red-950/40 px-3 py-2 text-[13px] text-red-700 dark:text-red-300">{error}</div>
       )}
     </div>
   );
@@ -634,7 +634,7 @@ function PinField({
 }) {
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
+      <label className="mb-1 block text-[11px] font-medium text-muted-foreground">{label}</label>
       <input
         type="password"
         inputMode="numeric"
@@ -645,7 +645,7 @@ function PinField({
         value={value}
         onChange={(e) => onChange(e.target.value.replace(/\D/g, "").slice(0, 6))}
         placeholder="••••••"
-        className="w-40 rounded-lg border border-border px-3 py-2 text-center text-xl tracking-[0.5em] text-foreground focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-100"
+        className="w-40 rounded-md border border-border px-3 py-2 text-center text-xl tracking-[0.5em] text-foreground focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-100"
       />
     </div>
   );

--- a/packages/client/src/pages/chatbot/ChatbotPage.tsx
+++ b/packages/client/src/pages/chatbot/ChatbotPage.tsx
@@ -69,7 +69,7 @@ function renderMarkdown(text: string, onClickSuggestion?: (text: string) => void
       const body = tableRows.slice(1).filter((r) => !r.every((c) => /^[-|:\s]+$/.test(c)));
       elements.push(
         <div key={`table-${elements.length}`} className="overflow-x-auto my-3">
-          <table className="min-w-full text-sm border border-border rounded-lg">
+          <table className="min-w-full text-[13px] border border-border rounded-lg">
             <thead>
               <tr className="bg-muted">
                 {header.map((cell, i) => (
@@ -208,7 +208,7 @@ function renderInline(text: string, onClickSuggestion?: (text: string) => void):
       parts.push(
         <code
           key={`c-${match.index}`}
-          className="bg-muted text-pink-600 dark:text-pink-400 px-1.5 py-0.5 rounded text-xs font-mono"
+          className="bg-muted text-pink-600 dark:text-pink-400 px-1.5 py-0.5 rounded text-[11px] font-mono"
         >
           {match[9]}
         </code>
@@ -269,11 +269,11 @@ function MessageBubble({ message, onSend }: { message: Message; onSend?: (text: 
               : "bg-card border border-border text-foreground rounded-bl-md shadow-sm"
           }`}
         >
-          <div className={`text-sm ${isUser ? "text-white" : "text-foreground"}`}>
+          <div className={`text-[13px] ${isUser ? "text-white" : "text-foreground"}`}>
             {isUser ? message.content : renderMarkdown(message.content, onSend)}
           </div>
         </div>
-        <p className={`text-[10px] text-muted-foreground mt-1 ${isUser ? "text-right" : "text-left"}`}>
+        <p className={`text-[10px] tabular-nums text-muted-foreground mt-1 ${isUser ? "text-right" : "text-left"}`}>
           {time}
         </p>
       </div>
@@ -441,7 +441,7 @@ export default function ChatbotPage() {
   const visibleConversations = conversations.filter((c) => c.message_count > 0);
 
   return (
-    <div className="h-[calc(100vh-7rem)] flex rounded-xl border border-border bg-card overflow-hidden shadow-sm">
+    <div className="h-[calc(100vh-7rem)] flex rounded-lg border border-border bg-card overflow-hidden shadow-sm">
       {/* Sidebar — conversation list */}
       <div
         className={`${
@@ -456,7 +456,7 @@ export default function ChatbotPage() {
                 <Sparkles className="h-4 w-4 text-white" />
               </div>
               <div>
-                <h2 className="text-sm font-semibold text-foreground">AI Assistant</h2>
+                <h2 className="text-[13px] font-semibold text-foreground">AI Assistant</h2>
                 <p className="text-[10px] text-muted-foreground">
                   {aiStatus?.engine === "ai" ? "AI-powered" : "Basic mode"}
                 </p>
@@ -466,7 +466,7 @@ export default function ChatbotPage() {
           <button
             onClick={handleNewChat}
             disabled={createConvo.isPending}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-brand-600 text-white text-sm font-medium rounded-lg hover:bg-brand-700 transition-colors disabled:opacity-50"
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-brand-600 text-white text-[13px] font-medium rounded-md hover:bg-brand-700 transition-colors disabled:opacity-50"
           >
             {createConvo.isPending ? (
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -482,27 +482,27 @@ export default function ChatbotPage() {
           {visibleConversations.length === 0 ? (
             <div className="text-center py-12 px-4">
               <MessageCircle className="h-10 w-10 text-muted-foreground/50 mx-auto mb-3" />
-              <p className="text-sm text-muted-foreground">No conversations yet</p>
-              <p className="text-xs text-muted-foreground mt-1">Start a new conversation above</p>
+              <p className="text-[13px] text-muted-foreground">No conversations yet</p>
+              <p className="text-[11px] text-muted-foreground mt-1">Start a new conversation above</p>
             </div>
           ) : (
             visibleConversations.map((c) => (
               <div
                 key={c.id}
-                className={`group flex items-center gap-2 rounded-lg cursor-pointer transition-colors ${
+                className={`group flex items-center gap-2 rounded-md cursor-pointer transition-colors ${
                   activeConvoId === c.id
-                    ? "bg-brand-50 dark:bg-brand-950/40 border border-brand-200"
-                    : "hover:bg-muted border border-transparent"
+                    ? "bg-brand-50 dark:bg-brand-950/40 border border-brand-200 dark:border-brand-800"
+                    : "hover:bg-muted/50 transition-colors border border-transparent"
                 }`}
               >
                 <button
                   onClick={() => handleSelectConvo(c.id)}
                   className="flex-1 text-left px-3 py-2.5 min-w-0"
                 >
-                  <p className="text-sm font-medium text-foreground truncate">
+                  <p className="text-[13px] font-medium text-foreground truncate">
                     {c.title || "New conversation"}
                   </p>
-                  <p className="text-[10px] text-muted-foreground mt-0.5">
+                  <p className="text-[10px] tabular-nums text-muted-foreground mt-0.5">
                     {new Date(c.updated_at).toLocaleDateString("en-US", {
                       month: "short",
                       day: "numeric",
@@ -534,7 +534,7 @@ export default function ChatbotPage() {
               <button
                 onClick={handleBack}
                 title="Back to conversations"
-                className="p-1.5 text-muted-foreground hover:text-muted-foreground rounded-lg hover:bg-muted"
+                className="p-1.5 text-muted-foreground hover:text-muted-foreground rounded-md hover:bg-muted"
               >
                 <ArrowLeft className="h-5 w-5" />
               </button>
@@ -542,17 +542,17 @@ export default function ChatbotPage() {
                 <Bot className="h-4 w-4 text-white" />
               </div>
               <div>
-                <h3 className="text-sm font-medium text-foreground">
+                <h3 className="text-[13px] font-medium text-foreground">
                   {conversations.find((c) => c.id === activeConvoId)?.title || "New Conversation"}
                 </h3>
                 <div className="flex items-center gap-1.5">
                   <p className="text-[10px] text-green-600 dark:text-green-400 font-medium">Online</p>
                   {aiStatus?.engine === "ai" ? (
-                    <span className="inline-flex items-center gap-0.5 bg-violet-100 text-violet-700 px-1.5 py-0.5 rounded-full text-[9px] font-medium">
+                    <span className="inline-flex items-center gap-0.5 bg-violet-100 text-violet-700 px-1.5 py-0.5 rounded-md text-[9px] font-medium">
                       <Sparkles className="h-2.5 w-2.5" /> AI-powered
                     </span>
                   ) : (
-                    <span className="inline-flex items-center gap-0.5 bg-muted text-muted-foreground px-1.5 py-0.5 rounded-full text-[9px]">
+                    <span className="inline-flex items-center gap-0.5 bg-muted text-muted-foreground px-1.5 py-0.5 rounded-md text-[9px]">
                       Basic mode
                     </span>
                   )}
@@ -561,7 +561,7 @@ export default function ChatbotPage() {
               <button
                 onClick={handleMinimize}
                 title="Minimize assistant"
-                className="ml-auto p-1.5 text-muted-foreground hover:text-violet-700 hover:bg-violet-50 rounded-lg transition-colors"
+                className="ml-auto p-1.5 text-muted-foreground hover:text-violet-700 hover:bg-violet-50 rounded-md transition-colors"
               >
                 <Minimize2 className="h-4 w-4" />
               </button>
@@ -577,7 +577,7 @@ export default function ChatbotPage() {
                   <h3 className="text-lg font-semibold text-foreground mb-1">
                     How can I help you today?
                   </h3>
-                  <p className="text-sm text-muted-foreground mb-6 max-w-md">
+                  <p className="text-[13px] text-muted-foreground mb-6 max-w-md">
                     I can answer questions about leave, attendance, policies, holidays, and more.
                   </p>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 max-w-lg w-full">
@@ -585,7 +585,7 @@ export default function ChatbotPage() {
                       <button
                         key={i}
                         onClick={() => handleSend(s)}
-                        className="text-left px-3 py-2.5 text-sm text-muted-foreground bg-card border border-border rounded-xl hover:border-brand-300 hover:bg-brand-50 dark:hover:bg-brand-950/40 transition-colors shadow-sm"
+                        className="text-left px-3 py-2.5 text-[13px] text-muted-foreground bg-card border border-border rounded-lg hover:border-brand-300 hover:bg-brand-50 dark:hover:bg-brand-950/40 transition-colors shadow-sm"
                       >
                         {s}
                       </button>
@@ -610,7 +610,7 @@ export default function ChatbotPage() {
                   <button
                     key={i}
                     onClick={() => handleSend(s)}
-                    className="shrink-0 text-xs px-3 py-1.5 text-brand-700 dark:text-brand-300 bg-brand-50 dark:bg-brand-950/40 border border-brand-200 rounded-full hover:bg-brand-100 dark:hover:bg-brand-950/40 transition-colors"
+                    className="shrink-0 text-[11px] px-3 py-1.5 text-brand-700 dark:text-brand-300 bg-brand-50 dark:bg-brand-950/40 border border-brand-200 dark:border-brand-800 dark:border-brand-800 rounded-md hover:bg-brand-100 dark:hover:bg-brand-950/40 transition-colors"
                   >
                     {s}
                   </button>
@@ -634,12 +634,12 @@ export default function ChatbotPage() {
                   }}
                   placeholder="Type your message..."
                   disabled={sendMsg.isPending}
-                  className="flex-1 px-4 py-2.5 bg-muted border border-border rounded-xl text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent disabled:opacity-50"
+                  className="flex-1 px-4 py-2.5 bg-muted border border-border rounded-md text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent disabled:opacity-50"
                 />
                 <button
                   onClick={() => handleSend()}
                   disabled={!inputValue.trim() || sendMsg.isPending}
-                  className="h-10 w-10 flex items-center justify-center bg-brand-600 text-white rounded-xl hover:bg-brand-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
+                  className="h-10 w-10 flex items-center justify-center bg-brand-600 text-white rounded-md hover:bg-brand-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed shrink-0"
                 >
                   {sendMsg.isPending ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -661,21 +661,21 @@ export default function ChatbotPage() {
             <button
               onClick={handleMinimize}
               title="Minimize assistant"
-              className="absolute top-3 right-3 p-1.5 text-muted-foreground hover:text-violet-700 hover:bg-violet-50 rounded-lg transition-colors"
+              className="absolute top-3 right-3 p-1.5 text-muted-foreground hover:text-violet-700 hover:bg-violet-50 rounded-md transition-colors"
             >
               <Minimize2 className="h-4 w-4" />
             </button>
             <div className="h-20 w-20 rounded-2xl bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center mb-6 shadow-xl shadow-violet-200">
               <Sparkles className="h-10 w-10 text-white" />
             </div>
-            <h2 className="text-xl font-bold text-foreground mb-2">AI HR Assistant</h2>
-            <p className="text-sm text-muted-foreground mb-6 max-w-sm text-center">
+            <h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">AI HR Assistant</h2>
+            <p className="text-[13px] text-muted-foreground mb-6 max-w-sm text-center">
               Get instant answers to your HR questions. Ask about leave, attendance, policies, holidays, and more.
             </p>
             <button
               onClick={handleNewChat}
               disabled={createConvo.isPending}
-              className="flex items-center gap-2 px-6 py-3 bg-brand-600 text-white text-sm font-medium rounded-xl hover:bg-brand-700 transition-colors shadow-lg shadow-brand-200 disabled:opacity-50"
+              className="flex items-center gap-2 px-6 py-3 bg-brand-600 text-white text-[13px] font-medium rounded-md hover:bg-brand-700 transition-colors shadow-lg shadow-brand-200 disabled:opacity-50"
             >
               {createConvo.isPending ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -688,7 +688,7 @@ export default function ChatbotPage() {
               {suggestions.slice(0, 4).map((s, i) => (
                 <div
                   key={i}
-                  className="text-left px-3 py-2.5 text-sm text-muted-foreground bg-card border border-border rounded-xl"
+                  className="text-left px-3 py-2.5 text-[13px] text-muted-foreground bg-card border border-border rounded-lg"
                 >
                   <span className="text-muted-foreground mr-1">&quot;</span>
                   {s}

--- a/packages/client/src/pages/onboarding/OnboardingWizard.tsx
+++ b/packages/client/src/pages/onboarding/OnboardingWizard.tsx
@@ -387,7 +387,7 @@ export default function OnboardingWizard() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen bg-gray-50">
+      <div className="flex items-center justify-center h-screen bg-muted/50">
         <Loader2 className="h-8 w-8 animate-spin text-brand-600" />
       </div>
     );
@@ -400,31 +400,31 @@ export default function OnboardingWizard() {
     : "translate-x-0 opacity-100";
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
+    <div className="min-h-screen bg-muted/50 flex flex-col">
       {/* Header */}
-      <div className="bg-white border-b border-gray-200 px-6 py-4">
+      <div className="bg-card border-b border-border px-6 py-4">
         <div className="max-w-3xl mx-auto flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Building2 className="h-7 w-7 text-brand-600" />
-            <span className="text-lg font-bold text-gray-900">EMP Cloud Setup</span>
+            <span className="text-base font-semibold tracking-tight text-foreground">EMP Cloud Setup</span>
           </div>
         </div>
       </div>
 
       {/* Progress */}
-      <div className="bg-white border-b border-gray-100 px-6 py-6">
+      <div className="bg-card border-b border-border px-6 py-6">
         <div className="max-w-3xl mx-auto">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-gray-700">
+            <span className="text-[13px] font-medium text-foreground tabular-nums">
               Step {activeStep} of 5
             </span>
-            <span className="text-sm text-gray-500">
+            <span className="text-[13px] text-muted-foreground tabular-nums">
               {Math.round((activeStep / 5) * 100)}% complete
             </span>
           </div>
 
           {/* Progress bar */}
-          <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden mb-6">
+          <div className="w-full h-2 bg-muted rounded-full overflow-hidden mb-6">
             <div
               className="h-full bg-brand-600 rounded-full transition-all duration-500 ease-out"
               style={{ width: `${(activeStep / 5) * 100}%` }}
@@ -443,7 +443,7 @@ export default function OnboardingWizard() {
                   {idx > 0 && (
                     <div
                       className={`hidden sm:block w-12 md:w-20 h-0.5 mx-1 transition-colors duration-300 ${
-                        stepNum <= activeStep ? "bg-brand-600" : "bg-gray-200"
+                        stepNum <= activeStep ? "bg-brand-600" : "bg-muted"
                       }`}
                     />
                   )}
@@ -454,7 +454,7 @@ export default function OnboardingWizard() {
                           ? "bg-brand-600 text-white"
                           : isActive
                             ? "bg-brand-600 text-white ring-4 ring-brand-100"
-                            : "bg-gray-100 text-gray-400"
+                            : "bg-muted text-muted-foreground"
                       }`}
                     >
                       {isCompleted ? (
@@ -464,8 +464,8 @@ export default function OnboardingWizard() {
                       )}
                     </div>
                     <span
-                      className={`text-xs font-medium hidden sm:block ${
-                        isActive ? "text-brand-600" : isCompleted ? "text-gray-700" : "text-gray-400"
+                      className={`text-[11px] font-medium hidden sm:block ${
+                        isActive ? "text-brand-600" : isCompleted ? "text-foreground" : "text-muted-foreground"
                       }`}
                     >
                       {status?.steps[idx]?.name || `Step ${stepNum}`}
@@ -481,13 +481,13 @@ export default function OnboardingWizard() {
       {/* Step Content */}
       <div className="flex-1 px-4 py-8">
         <div className={`max-w-2xl mx-auto transition-all duration-200 ease-out ${slideClass}`}>
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+          <div className="bg-card rounded-lg shadow-sm border border-border overflow-hidden">
             {/* Step header */}
             <div className="px-8 pt-8 pb-4">
-              <h2 className="text-xl font-bold text-gray-900">
+              <h2 className="text-xl font-semibold tracking-tight text-foreground">
                 {status?.steps[activeStep - 1]?.name || `Step ${activeStep}`}
               </h2>
-              <p className="text-sm text-gray-500 mt-1">
+              <p className="text-[13px] text-muted-foreground mt-0.5">
                 {STEP_DESCRIPTIONS[activeStep - 1]}
               </p>
             </div>
@@ -580,13 +580,13 @@ export default function OnboardingWizard() {
             </div>
 
             {/* Step footer */}
-            <div className="px-8 py-5 bg-gray-50 border-t border-gray-100 flex items-center justify-between">
+            <div className="px-8 py-5 bg-muted/50 border-t border-border flex items-center justify-between">
               <div>
                 {activeStep > 1 ? (
                   <button
                     onClick={handleBack}
                     disabled={submitting}
-                    className="inline-flex items-center gap-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50"
+                    className="inline-flex items-center gap-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
                   >
                     <ChevronLeft className="h-4 w-4" />
                     Back
@@ -601,7 +601,7 @@ export default function OnboardingWizard() {
                   onClick={handleNext}
                   disabled={submitting || (activeStep === 4 && modules.length > 0 && selectedModuleCount === 0)}
                   title={activeStep === 4 && modules.length > 0 && selectedModuleCount === 0 ? "Select at least one module to continue" : undefined}
-                  className="inline-flex items-center gap-2 bg-brand-600 text-white px-5 py-2.5 rounded-lg text-sm font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="inline-flex items-center gap-2 bg-brand-600 text-white px-5 py-2.5 rounded-md text-[13px] font-medium hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                 >
                   {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
                   {activeStep === 5 ? (
@@ -688,44 +688,44 @@ function Step1CompanyInfo({
   return (
     <div className="space-y-5 pt-2">
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">Company Name</label>
+        <label className="block text-[13px] font-medium text-foreground mb-1">Company Name</label>
         <input
           type="text"
           value={companyName}
           onChange={(e) => setCompanyName(e.target.value)}
-          className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+          className="w-full px-3 py-2.5 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
           placeholder="Acme Corp"
         />
       </div>
 
       <div className="grid grid-cols-3 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Country</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1">Country</label>
           <input
             type="text"
             value={country}
             onChange={(e) => setCountry(e.target.value)}
-            className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+            className="w-full px-3 py-2.5 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
             placeholder="IN"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">State</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1">State</label>
           <input
             type="text"
             value={state}
             onChange={(e) => setState(e.target.value)}
-            className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+            className="w-full px-3 py-2.5 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
             placeholder="Karnataka"
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">City</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1">City</label>
           <input
             type="text"
             value={city}
             onChange={(e) => setCity(e.target.value)}
-            className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+            className="w-full px-3 py-2.5 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
             placeholder="Bengaluru"
           />
         </div>
@@ -733,11 +733,11 @@ function Step1CompanyInfo({
 
       <div className="grid grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Timezone</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1">Timezone</label>
           <select
             value={timezone}
             onChange={(e) => setTimezone(e.target.value)}
-            className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none bg-white"
+            className="w-full px-3 py-2.5 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none bg-card text-foreground"
           >
             {TIMEZONES.map((tz) => (
               <option key={tz} value={tz}>
@@ -747,11 +747,11 @@ function Step1CompanyInfo({
           </select>
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Language</label>
+          <label className="block text-[13px] font-medium text-foreground mb-1">Language</label>
           <select
             value={language}
             onChange={(e) => setLanguage(e.target.value)}
-            className="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none bg-white"
+            className="w-full px-3 py-2.5 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none bg-card text-foreground"
           >
             {LANGUAGES.map((lang) => (
               <option key={lang.value} value={lang.value}>
@@ -763,16 +763,16 @@ function Step1CompanyInfo({
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Company Logo <span className="text-gray-400 font-normal">(optional)</span>
+        <label className="block text-[13px] font-medium text-foreground mb-1">
+          Company Logo <span className="text-muted-foreground font-normal">(optional)</span>
         </label>
         <div
-          className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors cursor-pointer ${
+          className={`border-2 border-dashed rounded-md p-4 text-center transition-colors cursor-pointer ${
             dragOver
               ? "border-brand-500 bg-brand-50"
               : logoPreview
-                ? "border-gray-200 bg-gray-50"
-                : "border-gray-200 hover:border-gray-300"
+                ? "border-border bg-muted/50"
+                : "border-border hover:border-brand-400"
           }`}
           onClick={() => fileInputRef.current?.click()}
           onDragOver={(e) => {
@@ -794,7 +794,7 @@ function Step1CompanyInfo({
                 alt="Company logo preview"
                 className="h-20 w-20 object-contain rounded"
               />
-              <p className="text-xs text-gray-500">
+              <p className="text-[11px] text-muted-foreground">
                 {logoFile?.name}{" "}
                 <button
                   type="button"
@@ -811,11 +811,11 @@ function Step1CompanyInfo({
             </div>
           ) : (
             <>
-              <Building2 className="h-8 w-8 text-gray-300 mx-auto mb-2" />
-              <p className="text-sm text-gray-500">
+              <Building2 className="h-8 w-8 text-muted-foreground/50 mx-auto mb-2" />
+              <p className="text-[13px] text-muted-foreground">
                 Drag &amp; drop your logo here, or click to browse
               </p>
-              <p className="text-xs text-gray-400 mt-1">PNG, JPG, WebP, SVG up to 2MB</p>
+              <p className="text-[11px] text-muted-foreground mt-1">PNG, JPG, WebP, SVG up to 2MB</p>
             </>
           )}
           <input
@@ -830,7 +830,7 @@ function Step1CompanyInfo({
           />
         </div>
         {logoError && (
-          <p className="mt-2 text-xs text-red-600">{logoError}</p>
+          <p className="mt-2 text-[11px] text-red-600">{logoError}</p>
         )}
       </div>
     </div>
@@ -858,7 +858,7 @@ function Step2Departments({
 }) {
   return (
     <div className="space-y-5 pt-2">
-      <p className="text-sm text-gray-500">
+      <p className="text-[13px] text-muted-foreground">
         Select the departments you want to create. You can always add more later.
       </p>
 
@@ -869,15 +869,15 @@ function Step2Departments({
             <button
               key={dept}
               onClick={() => toggleDept(dept)}
-              className={`flex items-center gap-3 px-4 py-3 rounded-lg border text-sm font-medium transition-all text-left ${
+              className={`flex items-center gap-3 px-4 py-3 rounded-lg border text-[13px] font-medium transition-all text-left ${
                 isSelected
                   ? "border-brand-500 bg-brand-50 text-brand-700"
-                  : "border-gray-200 bg-white text-gray-600 hover:border-gray-300"
+                  : "border-border bg-card text-muted-foreground hover:border-brand-400"
               }`}
             >
               <div
                 className={`w-5 h-5 rounded flex items-center justify-center flex-shrink-0 transition-colors ${
-                  isSelected ? "bg-brand-600 text-white" : "bg-gray-100"
+                  isSelected ? "bg-brand-600 text-white" : "bg-muted"
                 }`}
               >
                 {isSelected && <Check className="h-3.5 w-3.5" />}
@@ -894,13 +894,13 @@ function Step2Departments({
           value={customDept}
           onChange={(e) => setCustomDept(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && addCustomDept()}
-          className="flex-1 px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+          className="flex-1 px-3 py-2.5 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
           placeholder="Add custom department..."
         />
         <button
           onClick={addCustomDept}
           disabled={!customDept.trim()}
-          className="inline-flex items-center gap-1.5 px-4 py-2.5 bg-gray-100 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-200 disabled:opacity-50 transition-colors"
+          className="inline-flex items-center gap-1.5 px-4 py-2.5 bg-muted text-foreground rounded-md text-[13px] font-medium hover:bg-muted-foreground/10 disabled:opacity-50 transition-colors"
         >
           <Plus className="h-4 w-4" />
           Add
@@ -927,7 +927,7 @@ function Step3InviteTeam({
 }) {
   return (
     <div className="space-y-5 pt-2">
-      <p className="text-sm text-gray-500">
+      <p className="text-[13px] text-muted-foreground">
         Invite your team members by email. They will receive an invitation to join your organization.
       </p>
 
@@ -938,13 +938,13 @@ function Step3InviteTeam({
               type="email"
               value={inv.email}
               onChange={(e) => updateInvitation(idx, "email", e.target.value)}
-              className="flex-1 px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+              className="flex-1 px-3 py-2.5 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
               placeholder="colleague@company.com"
             />
             <select
               value={inv.role}
               onChange={(e) => updateInvitation(idx, "role", e.target.value)}
-              className="w-36 px-3 py-2.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none bg-white"
+              className="w-36 px-3 py-2.5 border border-border rounded-md text-[13px] focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none bg-card text-foreground"
             >
               <option value="employee">Employee</option>
               <option value="manager">Manager</option>
@@ -954,7 +954,7 @@ function Step3InviteTeam({
             {invitations.length > 1 && (
               <button
                 onClick={() => removeInvitation(idx)}
-                className="p-2 text-gray-400 hover:text-red-500 transition-colors"
+                className="p-2 text-muted-foreground hover:text-red-500 transition-colors"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -965,7 +965,7 @@ function Step3InviteTeam({
 
       <button
         onClick={addInvitation}
-        className="inline-flex items-center gap-1.5 text-sm font-medium text-brand-600 hover:text-brand-700 transition-colors"
+        className="inline-flex items-center gap-1.5 text-[13px] font-medium text-brand-600 hover:text-brand-700 transition-colors"
       >
         <Plus className="h-4 w-4" />
         Add another person
@@ -996,9 +996,9 @@ function Step4Modules({
   if (modules.length === 0) {
     return (
       <div className="pt-2 text-center py-12">
-        <Package className="h-10 w-10 text-gray-300 mx-auto mb-3" />
-        <p className="text-sm text-gray-500">No modules available at the moment.</p>
-        <p className="text-xs text-gray-400 mt-1">
+        <Package className="h-10 w-10 text-muted-foreground/50 mx-auto mb-3" />
+        <p className="text-[13px] text-muted-foreground">No modules available at the moment.</p>
+        <p className="text-[11px] text-muted-foreground mt-1">
           You can subscribe to modules later from the Modules page.
         </p>
       </div>
@@ -1015,27 +1015,27 @@ function Step4Modules({
 
   return (
     <div className="space-y-5 pt-2">
-      <p className="text-sm text-gray-500">
+      <p className="text-[13px] text-muted-foreground">
         Choose the modules your organization needs, then set the plan tier and number of licenses for each.
       </p>
 
       {selectedCount === 0 && (
-        <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg border border-amber-200 bg-amber-50 text-sm text-amber-800">
+        <div className="flex items-center gap-2 px-3 py-2.5 rounded-md border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/40 text-[13px] text-amber-800 dark:text-amber-200">
           <Package className="h-4 w-4 shrink-0" />
           Select at least one module to continue — this step can't be skipped.
         </div>
       )}
 
-      <label className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 bg-gray-50 cursor-pointer hover:bg-gray-100 transition-colors">
+      <label className="flex items-start gap-3 p-3 rounded-lg border border-border bg-muted/50 cursor-pointer hover:bg-muted transition-colors">
         <input
           type="checkbox"
           checked={skipTrial}
           onChange={(e) => setSkipTrial(e.target.checked)}
-          className="mt-0.5 rounded border-gray-300"
+          className="mt-0.5 rounded border-border"
         />
         <div>
-          <div className="text-sm font-medium text-gray-900">Skip trial — start paid subscription immediately</div>
-          <div className="text-xs text-gray-500 mt-0.5">
+          <div className="text-[13px] font-medium text-foreground">Skip trial — start paid subscription immediately</div>
+          <div className="text-[11px] text-muted-foreground mt-0.5">
             When checked, subscriptions are activated right away and an invoice is generated for each module. Leave unchecked to get a 14-day free trial.
           </div>
         </div>
@@ -1046,7 +1046,7 @@ function Step4Modules({
           <div
             key={mod.id}
             className={`rounded-lg border transition-all ${
-              mod.selected ? "border-brand-500 bg-brand-50" : "border-gray-200 bg-white"
+              mod.selected ? "border-brand-500 dark:bg-brand-950/40 bg-brand-50" : "border-border bg-card"
             }`}
           >
             <button
@@ -1055,26 +1055,26 @@ function Step4Modules({
             >
               <div
                 className={`w-5 h-5 rounded mt-0.5 flex items-center justify-center flex-shrink-0 transition-colors ${
-                  mod.selected ? "bg-brand-600 text-white" : "bg-gray-100"
+                  mod.selected ? "bg-brand-600 text-white" : "bg-muted"
                 }`}
               >
                 {mod.selected && <Check className="h-3.5 w-3.5" />}
               </div>
               <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium text-gray-900">{mod.name}</div>
+                <div className="text-[13px] font-medium text-foreground">{mod.name}</div>
                 {mod.description && (
-                  <div className="text-xs text-gray-500 mt-0.5 line-clamp-2">{mod.description}</div>
+                  <div className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">{mod.description}</div>
                 )}
               </div>
             </button>
             {mod.selected && (
               <div className="px-4 pb-4 pt-1 grid grid-cols-1 sm:grid-cols-2 gap-3 border-t border-brand-100">
                 <div>
-                  <label className="block text-xs font-medium text-gray-700 mb-1">Plan tier</label>
+                  <label className="block text-[11px] font-medium text-foreground mb-1">Plan tier</label>
                   <select
                     value={mod.plan_tier}
                     onChange={(e) => updateModulePlan(mod.id, e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                    className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
                   >
                     {PLAN_TIERS.map((p) => (
                       <option key={p.value} value={p.value}>{p.label}</option>
@@ -1082,14 +1082,14 @@ function Step4Modules({
                   </select>
                 </div>
                 <div>
-                  <label className="block text-xs font-medium text-gray-700 mb-1">Licenses (seats)</label>
+                  <label className="block text-[11px] font-medium text-foreground mb-1">Licenses (seats)</label>
                   <input
                     type="number"
                     min={1}
                     max={10000}
                     value={mod.total_seats}
                     onChange={(e) => updateModuleSeats(mod.id, Math.max(1, Number(e.target.value) || 1))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-white focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                    className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
                   />
                 </div>
               </div>
@@ -1133,8 +1133,8 @@ function Step5QuickSetup({
     <div className="space-y-6 pt-2">
       {/* Leave Types */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 mb-1">Default Leave Types</h3>
-        <p className="text-xs text-gray-500 mb-3">
+        <h3 className="text-[13px] font-semibold text-foreground mb-1">Default Leave Types</h3>
+        <p className="text-[11px] text-muted-foreground mb-3">
           Set up the standard leave types for your organization. You can customize these later.
         </p>
 
@@ -1143,20 +1143,20 @@ function Step5QuickSetup({
             <div
               key={lt.code}
               className={`flex items-center gap-4 p-3 rounded-lg border transition-colors ${
-                lt.enabled ? "border-gray-200 bg-white" : "border-gray-100 bg-gray-50 opacity-60"
+                lt.enabled ? "border-border bg-card" : "border-border bg-muted/50 opacity-60"
               }`}
             >
               <button
                 onClick={() => toggleLeaveType(idx)}
                 className={`w-5 h-5 rounded flex items-center justify-center flex-shrink-0 transition-colors ${
-                  lt.enabled ? "bg-brand-600 text-white" : "bg-gray-200"
+                  lt.enabled ? "bg-brand-600 text-white" : "bg-muted"
                 }`}
               >
                 {lt.enabled && <Check className="h-3.5 w-3.5" />}
               </button>
               <div className="flex-1 min-w-0">
-                <div className="text-sm font-medium text-gray-900">{leaveTypeLabel(t, lt)}</div>
-                <div className="text-xs text-gray-500">{lt.code}</div>
+                <div className="text-[13px] font-medium text-foreground">{leaveTypeLabel(t, lt)}</div>
+                <div className="text-[11px] text-muted-foreground">{lt.code}</div>
               </div>
               <div className="flex items-center gap-2">
                 <input
@@ -1166,9 +1166,9 @@ function Step5QuickSetup({
                   value={lt.annual_quota}
                   onChange={(e) => updateLeaveQuota(idx, parseInt(e.target.value) || 0)}
                   disabled={!lt.enabled}
-                  className="w-16 px-2 py-1.5 border border-gray-300 rounded text-sm text-center focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none disabled:opacity-50"
+                  className="w-16 px-2 py-1.5 border border-border rounded text-[13px] text-center focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none disabled:opacity-50"
                 />
-                <span className="text-xs text-gray-500">days/yr</span>
+                <span className="text-[11px] text-muted-foreground">days/yr</span>
               </div>
             </div>
           ))}
@@ -1177,48 +1177,48 @@ function Step5QuickSetup({
 
       {/* Default Shift */}
       <div>
-        <h3 className="text-sm font-semibold text-gray-900 mb-1">Default Work Shift</h3>
-        <p className="text-xs text-gray-500 mb-3">
+        <h3 className="text-[13px] font-semibold text-foreground mb-1">Default Work Shift</h3>
+        <p className="text-[11px] text-muted-foreground mb-3">
           Set up the default working hours for your team.
         </p>
 
-        <div className="p-4 rounded-lg border border-gray-200 bg-white space-y-4">
+        <div className="p-4 rounded-lg border border-border bg-card space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Shift Name</label>
+            <label className="block text-[13px] font-medium text-foreground mb-1">Shift Name</label>
             <input
               type="text"
               value={shiftName}
               onChange={(e) => setShiftName(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+              className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
             />
           </div>
 
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Start Time</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Start Time</label>
               <input
                 type="time"
                 value={shiftStart}
                 onChange={(e) => setShiftStart(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">End Time</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">End Time</label>
               <input
                 type="time"
                 value={shiftEnd}
                 onChange={(e) => setShiftEnd(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-card text-foreground focus:ring-2 focus:ring-brand-500 focus:border-brand-500 outline-none"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Work Days</label>
+              <label className="block text-[13px] font-medium text-foreground mb-1">Work Days</label>
               <input
                 type="text"
                 value={workDays}
                 readOnly
-                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm bg-gray-50 text-gray-600"
+                className="w-full px-3 py-2 border border-border rounded-md text-[13px] bg-muted/50 text-muted-foreground"
               />
             </div>
           </div>

--- a/packages/client/src/pages/whistleblowing/ReportDetailPage.tsx
+++ b/packages/client/src/pages/whistleblowing/ReportDetailPage.tsx
@@ -123,17 +123,17 @@ export default function ReportDetailPage() {
     <div className="max-w-4xl mx-auto">
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
-        <Link to="/whistleblowing/reports" className="p-1 hover:bg-muted rounded-lg transition">
+        <Link to="/whistleblowing/reports" className="p-1 hover:bg-muted/50 rounded-md transition-colors">
           <ArrowLeft className="h-5 w-5 text-muted-foreground" />
         </Link>
         <ShieldAlert className="h-6 w-6 text-brand-600 dark:text-brand-400" />
         <div className="flex-1">
           <div className="flex items-center gap-3">
-            <h1 className="text-xl font-bold text-foreground font-mono">{data.case_number}</h1>
-            <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${statusCfg.color}`}>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground font-mono tabular-nums">{data.case_number}</h1>
+            <span className={`px-2.5 py-0.5 rounded-md text-[11px] font-medium ${statusCfg.color}`}>
               {statusLabel}
             </span>
-            <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${SEVERITY_BADGE[data.severity] || ""}`}>
+            <span className={`px-2.5 py-0.5 rounded-md text-[11px] font-medium ${SEVERITY_BADGE[data.severity] || ""}`}>
               {t(`reportDetail.severity.${data.severity}`, { defaultValue: data.severity })}
             </span>
           </div>
@@ -144,9 +144,9 @@ export default function ReportDetailPage() {
         {/* Main Content */}
         <div className="lg:col-span-2 space-y-6">
           {/* Report Info */}
-          <div className="bg-card rounded-xl shadow-sm border p-6">
+          <div className="bg-card rounded-lg shadow-sm border p-4">
             <h2 className="text-lg font-semibold text-foreground mb-4">{data.subject}</h2>
-            <div className="flex gap-4 mb-4 text-sm">
+            <div className="flex gap-4 mb-4 text-[13px]">
               <div>
                 <span className="text-muted-foreground">{t("reportDetail.reportInfo.categoryLabel")}</span>{" "}
                 <span className="font-medium capitalize">{data.category?.replace(/_/g, " ")}</span>
@@ -164,15 +164,15 @@ export default function ReportDetailPage() {
                 </div>
               )}
             </div>
-            <div className="bg-muted rounded-lg p-4 text-sm text-muted-foreground whitespace-pre-wrap">
+            <div className="bg-muted rounded-md p-4 text-[13px] text-muted-foreground whitespace-pre-wrap">
               {data.description}
             </div>
             {data.evidence_paths && data.evidence_paths.length > 0 && (
               <div className="mt-4">
-                <p className="text-sm font-medium text-muted-foreground mb-2">{t("reportDetail.reportInfo.evidenceFilesLabel")}</p>
+                <p className="text-[13px] font-medium text-muted-foreground mb-2">{t("reportDetail.reportInfo.evidenceFilesLabel")}</p>
                 <div className="flex flex-wrap gap-2">
                   {data.evidence_paths.map((path: string, idx: number) => (
-                    <span key={idx} className="px-3 py-1 bg-muted rounded-lg text-sm text-muted-foreground">
+                    <span key={idx} className="px-3 py-1 bg-muted rounded-md text-[13px] text-muted-foreground">
                       {path.split("/").pop()}
                     </span>
                   ))}
@@ -182,25 +182,25 @@ export default function ReportDetailPage() {
           </div>
 
           {/* Investigation Timeline */}
-          <div className="bg-card rounded-xl shadow-sm border p-6">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase mb-4">{t("reportDetail.timeline.heading")}</h3>
+          <div className="bg-card rounded-lg shadow-sm border p-4">
+            <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">{t("reportDetail.timeline.heading")}</h3>
             {data.updates && data.updates.length > 0 ? (
               <div className="space-y-4">
                 {data.updates.map((u: any) => (
                   <div key={u.id} className="flex gap-3 border-l-2 border-border pl-4 pb-2">
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs font-medium px-2 py-0.5 rounded bg-muted text-muted-foreground capitalize">
+                        <span className="text-[11px] font-medium px-2 py-0.5 rounded bg-muted text-muted-foreground capitalize">
                           {u.update_type.replace(/_/g, " ")}
                         </span>
                         {u.is_visible_to_reporter && (
-                          <span className="text-xs px-2 py-0.5 rounded bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300">
+                          <span className="text-[11px] px-2 py-0.5 rounded bg-green-100 dark:bg-green-950/40 text-green-700 dark:text-green-300">
                             {t("reportDetail.timeline.visibleToReporterBadge")}
                           </span>
                         )}
                       </div>
-                      <p className="text-sm text-foreground">{u.content}</p>
-                      <p className="text-xs text-muted-foreground mt-1">
+                      <p className="text-[13px] text-foreground">{u.content}</p>
+                      <p className="text-[11px] tabular-nums text-muted-foreground mt-1">
                         {u.created_by_name || t("reportDetail.timeline.systemAuthor")} &middot; {new Date(u.created_at).toLocaleString()}
                       </p>
                     </div>
@@ -208,25 +208,25 @@ export default function ReportDetailPage() {
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-muted-foreground">{t("reportDetail.timeline.empty")}</p>
+              <p className="text-[13px] text-muted-foreground">{t("reportDetail.timeline.empty")}</p>
             )}
           </div>
 
           {/* Add Update */}
-          <div className="bg-card rounded-xl shadow-sm border p-6">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase mb-4">{t("reportDetail.addUpdate.heading")}</h3>
+          <div className="bg-card rounded-lg shadow-sm border p-4">
+            <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">{t("reportDetail.addUpdate.heading")}</h3>
             <div className="space-y-3">
               <div className="flex gap-3">
                 <select
                   value={updateType}
                   onChange={(e) => setUpdateType(e.target.value)}
-                  className="border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground"
+                  className="border border-border rounded-md px-3 py-2 text-[13px] bg-card text-foreground"
                 >
                   <option value="note">{t("reportDetail.addUpdate.typeNote")}</option>
                   <option value="response_to_reporter">{t("reportDetail.addUpdate.typeResponseToReporter")}</option>
                   <option value="status_change">{t("reportDetail.addUpdate.typeStatusChange")}</option>
                 </select>
-                <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                <label className="flex items-center gap-2 text-[13px] text-muted-foreground">
                   <input
                     type="checkbox"
                     checked={visibleToReporter}
@@ -241,12 +241,12 @@ export default function ReportDetailPage() {
                 onChange={(e) => setUpdateContent(e.target.value)}
                 rows={3}
                 placeholder={t("reportDetail.addUpdate.contentPlaceholder")}
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground"
+                className="w-full border border-border rounded-md px-3 py-2 text-[13px] bg-card text-foreground"
               />
               <button
                 onClick={() => updateMutation.mutate()}
                 disabled={!updateContent.trim() || updateMutation.isPending}
-                className="px-4 py-2 bg-brand-600 text-white rounded-lg text-sm hover:bg-brand-700 disabled:opacity-50 transition flex items-center gap-2"
+                className="px-4 py-2 bg-brand-600 text-white rounded-md text-[13px] hover:bg-brand-700 disabled:opacity-50 transition flex items-center gap-2"
               >
                 <MessageSquare className="h-4 w-4" />
                 {updateMutation.isPending ? t("reportDetail.addUpdate.submitSending") : t("reportDetail.addUpdate.submit")}
@@ -258,35 +258,35 @@ export default function ReportDetailPage() {
         {/* Sidebar Actions */}
         <div className="space-y-4">
           {/* Info Card */}
-          <div className="bg-card rounded-xl shadow-sm border p-5 space-y-3">
-            <div className="flex items-center gap-2 text-sm">
+          <div className="bg-card rounded-lg shadow-sm border p-5 space-y-3">
+            <div className="flex items-center gap-2 text-[13px]">
               <Clock className="h-4 w-4 text-muted-foreground" />
               <span className="text-muted-foreground">{t("reportDetail.info.submittedLabel")}</span>
               <span className="text-foreground">{new Date(data.created_at).toLocaleDateString()}</span>
             </div>
             {data.investigator_name && (
-              <div className="flex items-center gap-2 text-sm">
+              <div className="flex items-center gap-2 text-[13px]">
                 <User className="h-4 w-4 text-muted-foreground" />
                 <span className="text-muted-foreground">{t("reportDetail.info.investigatorLabel")}</span>
                 <span className="text-foreground">{data.investigator_name}</span>
               </div>
             )}
             {data.escalated_to && (
-              <div className="flex items-center gap-2 text-sm">
+              <div className="flex items-center gap-2 text-[13px]">
                 <ArrowUpRight className="h-4 w-4 text-orange-500" />
                 <span className="text-muted-foreground">{t("reportDetail.info.escalatedToLabel")}</span>
                 <span className="text-foreground">{data.escalated_to}</span>
               </div>
             )}
             {data.resolved_at && (
-              <div className="flex items-center gap-2 text-sm">
+              <div className="flex items-center gap-2 text-[13px]">
                 <CheckCircle className="h-4 w-4 text-green-500" />
                 <span className="text-muted-foreground">{t("reportDetail.info.resolvedLabel")}</span>
                 <span className="text-foreground">{new Date(data.resolved_at).toLocaleDateString()}</span>
               </div>
             )}
             {data.resolution && (
-              <div className="mt-2 p-3 bg-green-50 dark:bg-green-950/40 rounded-lg text-sm text-green-800 dark:text-green-200">
+              <div className="mt-2 p-3 bg-green-50 dark:bg-green-950/40 rounded-md text-[13px] text-green-800 dark:text-green-200">
                 <p className="font-medium mb-1">{t("reportDetail.info.resolutionLabel")}</p>
                 <p>{data.resolution}</p>
               </div>
@@ -294,17 +294,17 @@ export default function ReportDetailPage() {
           </div>
 
           {/* Assign Investigator */}
-          <div className="bg-card rounded-xl shadow-sm border p-5">
-            <h4 className="text-sm font-semibold text-muted-foreground mb-3">{t("reportDetail.assign.heading")}</h4>
+          <div className="bg-card rounded-lg shadow-sm border p-5">
+            <h4 className="text-[13px] font-semibold text-muted-foreground mb-3">{t("reportDetail.assign.heading")}</h4>
             {usersError && (
-              <p className="text-xs text-red-600 dark:text-red-400 mb-2">{t("reportDetail.assign.loadUsersError")}</p>
+              <p className="text-[11px] text-red-600 dark:text-red-400 mb-2">{t("reportDetail.assign.loadUsersError")}</p>
             )}
             <div className="flex items-center gap-2">
               <select
                 value={investigatorId}
                 onChange={(e) => setInvestigatorId(e.target.value)}
                 disabled={usersLoading || !!usersError}
-                className="flex-1 min-w-0 border border-border rounded-lg px-3 py-2 text-sm disabled:opacity-50 bg-card text-foreground"
+                className="flex-1 min-w-0 border border-border rounded-lg px-3 py-2 text-[13px] disabled:opacity-50 bg-card text-foreground"
               >
                 <option value="">
                   {usersLoading
@@ -326,29 +326,29 @@ export default function ReportDetailPage() {
               <button
                 onClick={() => assignMutation.mutate()}
                 disabled={!investigatorId || assignMutation.isPending}
-                className="shrink-0 px-3 py-2 bg-brand-600 text-white rounded-lg text-sm hover:bg-brand-700 disabled:opacity-50 transition"
+                className="shrink-0 px-3 py-2 bg-brand-600 text-white rounded-md text-[13px] hover:bg-brand-700 disabled:opacity-50 transition"
               >
                 <User className="h-4 w-4" />
               </button>
             </div>
             {assignMutation.isError && (
-              <p className="text-xs text-red-600 dark:text-red-400 mt-2">
+              <p className="text-[11px] text-red-600 dark:text-red-400 mt-2">
                 {(assignMutation.error as any)?.response?.data?.error?.message || t("reportDetail.assign.error")}
               </p>
             )}
             {assignMutation.isSuccess && (
-              <p className="text-xs text-green-600 dark:text-green-400 mt-2">{t("reportDetail.assign.success")}</p>
+              <p className="text-[11px] text-green-600 dark:text-green-400 mt-2">{t("reportDetail.assign.success")}</p>
             )}
           </div>
 
           {/* Change Status */}
-          <div className="bg-card rounded-xl shadow-sm border p-5">
-            <h4 className="text-sm font-semibold text-muted-foreground mb-3">{t("reportDetail.changeStatus.heading")}</h4>
+          <div className="bg-card rounded-lg shadow-sm border p-5">
+            <h4 className="text-[13px] font-semibold text-muted-foreground mb-3">{t("reportDetail.changeStatus.heading")}</h4>
             <div className="space-y-2">
               <select
                 value={newStatus}
                 onChange={(e) => setNewStatus(e.target.value)}
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground"
+                className="w-full border border-border rounded-md px-3 py-2 text-[13px] bg-card text-foreground"
               >
                 <option value="">{t("reportDetail.changeStatus.optionSelect")}</option>
                 {STATUSES.filter((s) => s !== data.status).map((s) => (
@@ -361,13 +361,13 @@ export default function ReportDetailPage() {
                   onChange={(e) => setResolution(e.target.value)}
                   rows={2}
                   placeholder={t("reportDetail.changeStatus.resolutionPlaceholder")}
-                  className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground"
+                  className="w-full border border-border rounded-md px-3 py-2 text-[13px] bg-card text-foreground"
                 />
               )}
               <button
                 onClick={() => statusMutation.mutate()}
                 disabled={!newStatus || statusMutation.isPending}
-                className="w-full px-3 py-2 bg-brand-600 text-white rounded-lg text-sm hover:bg-brand-700 disabled:opacity-50 transition"
+                className="w-full px-3 py-2 bg-brand-600 text-white rounded-md text-[13px] hover:bg-brand-700 disabled:opacity-50 transition"
               >
                 {statusMutation.isPending ? t("reportDetail.changeStatus.submitUpdating") : t("reportDetail.changeStatus.submit")}
               </button>
@@ -375,8 +375,8 @@ export default function ReportDetailPage() {
           </div>
 
           {/* Escalate */}
-          <div className="bg-card rounded-xl shadow-sm border p-5">
-            <h4 className="text-sm font-semibold text-muted-foreground mb-3 flex items-center gap-2">
+          <div className="bg-card rounded-lg shadow-sm border p-5">
+            <h4 className="text-[13px] font-semibold text-muted-foreground mb-3 flex items-center gap-2">
               <AlertTriangle className="h-4 w-4 text-orange-500" />
               {t("reportDetail.escalate.heading")}
             </h4>
@@ -386,12 +386,12 @@ export default function ReportDetailPage() {
                 value={escalateTo}
                 onChange={(e) => setEscalateTo(e.target.value)}
                 placeholder={t("reportDetail.escalate.placeholder")}
-                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground"
+                className="w-full border border-border rounded-md px-3 py-2 text-[13px] bg-card text-foreground"
               />
               <button
                 onClick={() => escalateMutation.mutate()}
                 disabled={!escalateTo.trim() || escalateMutation.isPending}
-                className="w-full px-3 py-2 bg-orange-500 text-white rounded-lg text-sm hover:bg-orange-600 disabled:opacity-50 transition flex items-center justify-center gap-2"
+                className="w-full px-3 py-2 bg-orange-500 text-white rounded-md text-[13px] hover:bg-orange-600 disabled:opacity-50 transition flex items-center justify-center gap-2"
               >
                 <ArrowUpRight className="h-4 w-4" />
                 {escalateMutation.isPending ? t("reportDetail.escalate.submitEscalating") : t("reportDetail.escalate.submit")}

--- a/packages/client/src/pages/whistleblowing/ReportListPage.tsx
+++ b/packages/client/src/pages/whistleblowing/ReportListPage.tsx
@@ -62,21 +62,21 @@ export default function ReportListPage() {
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <ShieldAlert className="h-7 w-7 text-brand-600 dark:text-brand-400" />
-          <h1 className="text-2xl font-bold text-foreground">{t("whistleblowing.reports.title")}</h1>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("whistleblowing.reports.title")}</h1>
         </div>
       </div>
 
       {/* Filters */}
-      <div className="bg-card rounded-xl shadow-sm border p-4 mb-4">
+      <div className="bg-card rounded-lg shadow-sm border p-4 mb-4">
         <div className="flex flex-wrap gap-3 items-center">
           <div className="flex items-center gap-2">
             <Filter className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm text-muted-foreground">{t("whistleblowing.reports.filters")}</span>
+            <span className="text-[13px] text-muted-foreground">{t("whistleblowing.reports.filters")}</span>
           </div>
           <select
             value={statusFilter}
             onChange={(e) => { setStatusFilter(e.target.value); setPage(1); }}
-            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-card text-foreground"
+            className="border border-border rounded-md px-3 py-1.5 text-[13px] bg-card text-foreground"
           >
             <option value="">{t("whistleblowing.reports.allStatuses")}</option>
             {STATUSES.map((s) => (
@@ -86,7 +86,7 @@ export default function ReportListPage() {
           <select
             value={categoryFilter}
             onChange={(e) => { setCategoryFilter(e.target.value); setPage(1); }}
-            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-card text-foreground"
+            className="border border-border rounded-md px-3 py-1.5 text-[13px] bg-card text-foreground"
           >
             <option value="">{t("whistleblowing.reports.allCategories")}</option>
             {CATEGORIES.map((c) => (
@@ -96,7 +96,7 @@ export default function ReportListPage() {
           <select
             value={severityFilter}
             onChange={(e) => { setSeverityFilter(e.target.value); setPage(1); }}
-            className="border border-border rounded-lg px-3 py-1.5 text-sm bg-card text-foreground"
+            className="border border-border rounded-md px-3 py-1.5 text-[13px] bg-card text-foreground"
           >
             <option value="">{t("whistleblowing.reports.allSeverities")}</option>
             {SEVERITIES.map((s) => (
@@ -110,11 +110,11 @@ export default function ReportListPage() {
               onChange={(e) => setSearchInput(e.target.value)}
               onKeyDown={(e) => { if (e.key === "Enter") { setSearch(searchInput); setPage(1); } }}
               placeholder={t("whistleblowing.reports.search")}
-              className="border border-border rounded-lg px-3 py-1.5 text-sm w-48 bg-card text-foreground"
+              className="border border-border rounded-lg px-3 py-1.5 text-[13px] w-48 bg-card text-foreground"
             />
             <button
               onClick={() => { setSearch(searchInput); setPage(1); }}
-              className="p-1.5 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition"
+              className="p-1.5 bg-brand-600 text-white rounded-md hover:bg-brand-700 transition"
             >
               <Search className="h-4 w-4" />
             </button>
@@ -123,7 +123,7 @@ export default function ReportListPage() {
       </div>
 
       {/* Table */}
-      <div className="bg-card rounded-xl shadow-sm border overflow-hidden">
+      <div className="bg-card rounded-lg shadow-sm border overflow-hidden">
         {isLoading ? (
           <div className="flex items-center justify-center h-64">
             <div className="animate-spin h-8 w-8 border-4 border-brand-600 border-t-transparent rounded-full" />
@@ -131,54 +131,54 @@ export default function ReportListPage() {
         ) : reports.length > 0 ? (
           <>
             <table className="w-full">
-              <thead className="bg-muted text-xs text-muted-foreground uppercase">
+              <thead className="bg-muted text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
                 <tr>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colCase")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colCategory")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colSeverity")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colSubject")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colAnonymous")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colInvestigator")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colStatus")}</th>
-                  <th className="px-5 py-3 text-left">{t("whistleblowing.reports.colDate")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colCase")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colCategory")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colSeverity")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colSubject")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colAnonymous")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colInvestigator")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colStatus")}</th>
+                  <th className="px-4 py-2.5 text-left">{t("whistleblowing.reports.colDate")}</th>
                 </tr>
               </thead>
               <tbody className="divide-y">
                 {reports.map((r: any) => (
-                  <tr key={r.id} className="hover:bg-muted">
-                    <td className="px-5 py-3">
+                  <tr key={r.id} className="hover:bg-muted/50 transition-colors">
+                    <td className="px-4 py-2.5">
                       <Link
                         to={`/whistleblowing/reports/${r.id}`}
-                        className="font-mono text-sm text-brand-600 dark:text-brand-400 hover:underline"
+                        className="font-mono text-[13px] tabular-nums text-brand-600 dark:text-brand-400 hover:underline"
                       >
                         {r.case_number}
                       </Link>
                     </td>
-                    <td className="px-5 py-3 text-sm text-muted-foreground">
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                       {t(`whistleblowing.reports.category.${r.category}`, { defaultValue: r.category.replace(/_/g, " ") })}
                     </td>
-                    <td className="px-5 py-3">
-                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${SEVERITY_BADGE[r.severity] || ""}`}>
+                    <td className="px-4 py-2.5">
+                      <span className={`px-2 py-0.5 rounded-md text-[11px] font-medium ${SEVERITY_BADGE[r.severity] || ""}`}>
                         {t(`whistleblowing.reports.severity.${r.severity}`, { defaultValue: r.severity })}
                       </span>
                     </td>
-                    <td className="px-5 py-3 text-sm text-foreground max-w-xs truncate">{r.subject}</td>
-                    <td className="px-5 py-3 text-sm">
+                    <td className="px-4 py-2.5 text-[13px] text-foreground max-w-xs truncate">{r.subject}</td>
+                    <td className="px-4 py-2.5 text-[13px]">
                       {r.is_anonymous ? (
                         <span className="text-green-600 dark:text-green-400 font-medium">{t("whistleblowing.reports.yes")}</span>
                       ) : (
                         <span className="text-muted-foreground">{t("whistleblowing.reports.no")}</span>
                       )}
                     </td>
-                    <td className="px-5 py-3 text-sm text-muted-foreground">
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                       {r.investigator_name || <span className="text-muted-foreground">{t("whistleblowing.reports.unassigned")}</span>}
                     </td>
-                    <td className="px-5 py-3">
-                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE[r.status] || ""}`}>
+                    <td className="px-4 py-2.5">
+                      <span className={`px-2 py-0.5 rounded-md text-[11px] font-medium ${STATUS_BADGE[r.status] || ""}`}>
                         {t(`whistleblowing.reports.status.${r.status}`, { defaultValue: r.status.replace(/_/g, " ") })}
                       </span>
                     </td>
-                    <td className="px-5 py-3 text-sm text-muted-foreground">
+                    <td className="px-4 py-2.5 text-[13px] text-muted-foreground">
                       {new Date(r.created_at).toLocaleDateString()}
                     </td>
                   </tr>
@@ -188,22 +188,22 @@ export default function ReportListPage() {
 
             {/* Pagination */}
             {meta && meta.total_pages > 1 && (
-              <div className="flex items-center justify-between px-5 py-3 border-t bg-muted">
-                <p className="text-sm text-muted-foreground">
+              <div className="flex items-center justify-between px-4 py-2.5 border-t bg-muted">
+                <p className="text-[13px] text-muted-foreground">
                   {t("whistleblowing.reports.pageOf", { page: meta.page, total_pages: meta.total_pages, total: meta.total })}
                 </p>
                 <div className="flex gap-2">
                   <button
                     onClick={() => setPage(page - 1)}
                     disabled={page === 1}
-                    className="px-3 py-1 text-sm bg-card border rounded-lg disabled:opacity-50"
+                    className="px-3 py-1 text-[13px] bg-card border rounded-md disabled:opacity-50"
                   >
                     {t("whistleblowing.reports.previous")}
                   </button>
                   <button
                     onClick={() => setPage(page + 1)}
                     disabled={page >= meta.total_pages}
-                    className="px-3 py-1 text-sm bg-card border rounded-lg disabled:opacity-50"
+                    className="px-3 py-1 text-[13px] bg-card border rounded-md disabled:opacity-50"
                   >
                     {t("whistleblowing.reports.next")}
                   </button>

--- a/packages/client/src/pages/whistleblowing/SubmitReportPage.tsx
+++ b/packages/client/src/pages/whistleblowing/SubmitReportPage.tsx
@@ -49,19 +49,19 @@ export default function SubmitReportPage() {
   if (submittedCase) {
     return (
       <div className="max-w-2xl mx-auto py-12">
-        <div className="bg-card rounded-xl shadow-sm border p-8 text-center">
+        <div className="bg-card rounded-lg shadow-sm border p-8 text-center">
           <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-foreground mb-2">{t("submitReport.success.title")}</h2>
+          <h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">{t("submitReport.success.title")}</h2>
           <p className="text-muted-foreground mb-6">
             {t("submitReport.success.description")}
           </p>
           <div className="bg-muted border-2 border-dashed border-border rounded-lg p-6 mb-6">
-            <p className="text-sm text-muted-foreground mb-1">{t("submitReport.success.caseNumberLabel")}</p>
-            <p className="text-3xl font-mono font-bold text-brand-700 dark:text-brand-300">{submittedCase}</p>
+            <p className="text-[13px] text-muted-foreground mb-1">{t("submitReport.success.caseNumberLabel")}</p>
+            <p className="text-3xl font-mono font-semibold tabular-nums text-brand-700 dark:text-brand-300">{submittedCase}</p>
           </div>
           <div className="bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900 rounded-lg p-4 text-left">
-            <p className="text-sm text-amber-800 dark:text-amber-200 font-medium">{t("submitReport.success.importantLabel")}</p>
-            <ul className="text-sm text-amber-700 dark:text-amber-300 mt-1 list-disc list-inside space-y-1">
+            <p className="text-[13px] text-amber-800 dark:text-amber-200 font-medium">{t("submitReport.success.importantLabel")}</p>
+            <ul className="text-[13px] text-amber-700 dark:text-amber-300 mt-1 list-disc list-inside space-y-1">
               <li>{t("submitReport.success.saveCaseNumber")}</li>
               <li>{isAnonymous ? t("submitReport.success.identityAnonymous") : t("submitReport.success.identityAttached")}</li>
               <li>{t("submitReport.success.trackReportHint")}</li>
@@ -75,7 +75,7 @@ export default function SubmitReportPage() {
               setSubject("");
               setDescription("");
             }}
-            className="mt-6 px-6 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition"
+            className="mt-6 px-6 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 transition"
           >
             {t("submitReport.success.submitAnother")}
           </button>
@@ -89,14 +89,14 @@ export default function SubmitReportPage() {
       <div className="flex items-center gap-3 mb-6">
         <ShieldAlert className="h-7 w-7 text-brand-600 dark:text-brand-400" />
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("submitReport.header.title")}</h1>
-          <p className="text-sm text-muted-foreground">
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("submitReport.header.title")}</h1>
+          <p className="text-[13px] text-muted-foreground">
             {t("submitReport.header.subtitle")}
           </p>
         </div>
       </div>
 
-      <div className="bg-card rounded-xl shadow-sm border p-6 space-y-6">
+      <div className="bg-card rounded-lg shadow-sm border p-4 space-y-6">
         {/* Anonymous Toggle */}
         <div className="flex items-center justify-between p-4 bg-muted rounded-lg border">
           <div className="flex items-center gap-3">
@@ -109,7 +109,7 @@ export default function SubmitReportPage() {
               <p className="font-medium text-foreground">
                 {isAnonymous ? t("submitReport.anonymous.anonymousTitle") : t("submitReport.anonymous.identifiedTitle")}
               </p>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-[13px] text-muted-foreground">
                 {isAnonymous
                   ? t("submitReport.anonymous.anonymousDescription")
                   : t("submitReport.anonymous.identifiedDescription")}
@@ -133,13 +133,13 @@ export default function SubmitReportPage() {
 
         {/* Category */}
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">
             {t("submitReport.form.categoryLabel")} <span className="text-red-500">{t("submitReport.form.required")}</span>
           </label>
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value)}
-            className="w-full border border-border rounded-lg px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
+            className="w-full border border-border rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
           >
             <option value="">{t("submitReport.form.categoryPlaceholder")}</option>
             {CATEGORIES.map((c) => (
@@ -152,7 +152,7 @@ export default function SubmitReportPage() {
 
         {/* Severity */}
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-2">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-2">
             {t("submitReport.form.severityLabel")} <span className="text-red-500">{t("submitReport.form.required")}</span>
           </label>
           <div className="flex gap-3">
@@ -161,7 +161,7 @@ export default function SubmitReportPage() {
                 key={s.value}
                 type="button"
                 onClick={() => setSeverity(s.value)}
-                className={`px-4 py-2 rounded-lg text-sm font-medium border transition ${
+                className={`px-4 py-2 rounded-md text-[13px] font-medium border transition ${
                   severity === s.value
                     ? `${s.color} border-current ring-2 ring-offset-1 ring-offset-card`
                     : "bg-muted text-muted-foreground border-border hover:bg-muted"
@@ -175,7 +175,7 @@ export default function SubmitReportPage() {
 
         {/* Subject */}
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">
             {t("submitReport.form.subjectLabel")} <span className="text-red-500">{t("submitReport.form.required")}</span>
           </label>
           <input
@@ -184,13 +184,13 @@ export default function SubmitReportPage() {
             onChange={(e) => setSubject(e.target.value)}
             placeholder={t("submitReport.form.subjectPlaceholder")}
             maxLength={255}
-            className="w-full border border-border rounded-lg px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
+            className="w-full border border-border rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
           />
         </div>
 
         {/* Description */}
         <div>
-          <label className="block text-sm font-medium text-muted-foreground mb-1">
+          <label className="block text-[13px] font-medium text-muted-foreground mb-1">
             {t("submitReport.form.descriptionLabel")} <span className="text-red-500">{t("submitReport.form.required")}</span>
           </label>
           <textarea
@@ -198,7 +198,7 @@ export default function SubmitReportPage() {
             onChange={(e) => setDescription(e.target.value)}
             rows={6}
             placeholder={t("submitReport.form.descriptionPlaceholder")}
-            className="w-full border border-border rounded-lg px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
+            className="w-full border border-border rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
           />
         </div>
 
@@ -215,14 +215,14 @@ export default function SubmitReportPage() {
               })
             }
             disabled={!category || !subject || !description || submitMutation.isPending}
-            className="px-6 py-2.5 bg-brand-600 text-white rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
+            className="px-6 py-2.5 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium"
           >
             {submitMutation.isPending ? t("submitReport.actions.submitting") : t("submitReport.actions.submit")}
           </button>
         </div>
 
         {submitMutation.isError && (
-          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg p-3 text-sm text-red-700 dark:text-red-300">
+          <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg p-3 text-[13px] text-red-700 dark:text-red-300">
             {t("submitReport.error.submitFailed")}
           </div>
         )}

--- a/packages/client/src/pages/whistleblowing/TrackReportPage.tsx
+++ b/packages/client/src/pages/whistleblowing/TrackReportPage.tsx
@@ -45,14 +45,14 @@ export default function TrackReportPage() {
       <div className="flex items-center gap-3 mb-6">
         <FileText className="h-7 w-7 text-brand-600 dark:text-brand-400" />
         <div>
-          <h1 className="text-2xl font-bold text-foreground">{t("whistleblowing.track.title")}</h1>
-          <p className="text-sm text-muted-foreground">{t("whistleblowing.track.subtitle")}</p>
+          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("whistleblowing.track.title")}</h1>
+          <p className="text-[13px] text-muted-foreground mt-0.5">{t("whistleblowing.track.subtitle")}</p>
         </div>
       </div>
 
       {/* Search Box */}
-      <div className="bg-card rounded-xl shadow-sm border p-6 mb-6">
-        <label className="block text-sm font-medium text-muted-foreground mb-2">{t("whistleblowing.track.caseNumber")}</label>
+      <div className="bg-card rounded-lg shadow-sm border p-4 mb-6">
+        <label className="block text-[13px] font-medium text-muted-foreground mb-2">{t("whistleblowing.track.caseNumber")}</label>
         <div className="flex gap-3">
           <input
             type="text"
@@ -60,12 +60,12 @@ export default function TrackReportPage() {
             onChange={(e) => setCaseNumber(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleSearch()}
             placeholder={t("whistleblowing.track.placeholder")}
-            className="flex-1 border border-border rounded-lg px-4 py-2.5 font-mono text-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
+            className="flex-1 border border-border rounded-md px-4 py-2.5 font-mono text-lg tabular-nums focus:ring-2 focus:ring-brand-500 focus:border-brand-500 bg-card text-foreground"
           />
           <button
             onClick={handleSearch}
             disabled={!caseNumber.trim()}
-            className="px-6 py-2.5 bg-brand-600 text-white rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium flex items-center gap-2"
+            className="px-6 py-2.5 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition font-medium flex items-center gap-2"
           >
             <Search className="h-4 w-4" />
             {t("whistleblowing.track.lookup")}
@@ -75,7 +75,7 @@ export default function TrackReportPage() {
 
       {/* Loading */}
       {isLoading && (
-        <div className="bg-card rounded-xl shadow-sm border p-12 text-center">
+        <div className="bg-card rounded-lg shadow-sm border p-12 text-center">
           <div className="animate-spin h-8 w-8 border-4 border-brand-600 border-t-transparent rounded-full mx-auto mb-3" />
           <p className="text-muted-foreground">{t("whistleblowing.track.lookingUp")}</p>
         </div>
@@ -83,10 +83,10 @@ export default function TrackReportPage() {
 
       {/* Error */}
       {isError && (
-        <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-xl p-6 text-center">
+        <div className="bg-red-50 dark:bg-red-950/40 border border-red-200 dark:border-red-900 rounded-lg p-4 text-center">
           <AlertTriangle className="h-8 w-8 text-red-400 mx-auto mb-2" />
           <p className="text-red-700 dark:text-red-300 font-medium">{t("whistleblowing.track.notFound")}</p>
-          <p className="text-sm text-red-600 dark:text-red-400 mt-1">
+          <p className="text-[13px] text-red-600 dark:text-red-400 mt-1">
             {t("whistleblowing.track.notFoundDetail", { caseNumber: searchCase })}
           </p>
         </div>
@@ -94,15 +94,15 @@ export default function TrackReportPage() {
 
       {/* Report Details */}
       {data && (
-        <div className="bg-card rounded-xl shadow-sm border overflow-hidden">
-          <div className="p-6 border-b bg-muted">
+        <div className="bg-card rounded-lg shadow-sm border overflow-hidden">
+          <div className="p-4 border-b bg-muted">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm text-muted-foreground">{t("whistleblowing.track.caseNumber")}</p>
-                <p className="text-xl font-mono font-bold text-foreground">{data.case_number}</p>
+                <p className="text-[13px] text-muted-foreground">{t("whistleblowing.track.caseNumber")}</p>
+                <p className="text-xl font-mono font-bold tabular-nums text-foreground">{data.case_number}</p>
               </div>
               <div className="flex items-center gap-3">
-                <span className={`px-3 py-1 rounded-full text-xs font-medium ${SEVERITY_BADGE[data.severity] || ""}`}>
+                <span className={`px-3 py-1 rounded-md text-[11px] font-medium ${SEVERITY_BADGE[data.severity] || ""}`}>
                   {t(`whistleblowing.reports.severity.${data.severity}`, { defaultValue: data.severity })}
                 </span>
                 {(() => {
@@ -110,7 +110,7 @@ export default function TrackReportPage() {
                   if (!cfg) return null;
                   const Icon = cfg.icon;
                   return (
-                    <span className={`px-3 py-1.5 rounded-full text-sm font-medium flex items-center gap-1.5 ${cfg.color}`}>
+                    <span className={`px-3 py-1.5 rounded-md text-[13px] font-medium flex items-center gap-1.5 ${cfg.color}`}>
                       <Icon className="h-4 w-4" />
                       {t(`whistleblowing.reports.status.${data.status}`, { defaultValue: data.status })}
                     </span>
@@ -120,25 +120,25 @@ export default function TrackReportPage() {
             </div>
           </div>
 
-          <div className="p-6 space-y-4">
+          <div className="p-4 space-y-4">
             <div>
-              <p className="text-sm text-muted-foreground">{t("whistleblowing.track.category")}</p>
+              <p className="text-[13px] text-muted-foreground">{t("whistleblowing.track.category")}</p>
               <p className="font-medium text-foreground capitalize">
                 {t(`whistleblowing.reports.category.${data.category}`, { defaultValue: data.category?.replace(/_/g, " ") })}
               </p>
             </div>
             <div>
-              <p className="text-sm text-muted-foreground">{t("whistleblowing.track.subject")}</p>
+              <p className="text-[13px] text-muted-foreground">{t("whistleblowing.track.subject")}</p>
               <p className="font-medium text-foreground">{data.subject}</p>
             </div>
             <div className="flex gap-6">
               <div>
-                <p className="text-sm text-muted-foreground">{t("whistleblowing.track.submitted")}</p>
+                <p className="text-[13px] text-muted-foreground">{t("whistleblowing.track.submitted")}</p>
                 <p className="text-foreground">{new Date(data.created_at).toLocaleDateString()}</p>
               </div>
               {data.resolved_at && (
                 <div>
-                  <p className="text-sm text-muted-foreground">{t("whistleblowing.track.resolved")}</p>
+                  <p className="text-[13px] text-muted-foreground">{t("whistleblowing.track.resolved")}</p>
                   <p className="text-foreground">{new Date(data.resolved_at).toLocaleDateString()}</p>
                 </div>
               )}
@@ -147,8 +147,8 @@ export default function TrackReportPage() {
 
           {/* Updates Timeline */}
           {data.updates && data.updates.length > 0 && (
-            <div className="p-6 border-t">
-              <h3 className="text-sm font-semibold text-muted-foreground uppercase mb-4">{t("whistleblowing.track.updates")}</h3>
+            <div className="p-4 border-t">
+              <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">{t("whistleblowing.track.updates")}</h3>
               <div className="space-y-4">
                 {data.updates.map((update: { id: number; update_type: string; content: string; created_at: string }) => (
                   <div key={update.id} className="flex gap-3">
@@ -156,8 +156,8 @@ export default function TrackReportPage() {
                       <div className="h-2.5 w-2.5 rounded-full bg-brand-400" />
                     </div>
                     <div className="flex-1">
-                      <p className="text-sm text-foreground">{update.content}</p>
-                      <p className="text-xs text-muted-foreground mt-1">
+                      <p className="text-[13px] text-foreground">{update.content}</p>
+                      <p className="text-[11px] tabular-nums text-muted-foreground mt-1">
                         {new Date(update.created_at).toLocaleString()} &middot;{" "}
                         <span className="capitalize">{update.update_type.replace(/_/g, " ")}</span>
                       </p>

--- a/packages/client/src/pages/whistleblowing/WhistleblowingDashboardPage.tsx
+++ b/packages/client/src/pages/whistleblowing/WhistleblowingDashboardPage.tsx
@@ -43,13 +43,13 @@ export default function WhistleblowingDashboardPage() {
         <div className="flex items-center gap-3">
           <ShieldAlert className="h-7 w-7 text-brand-600 dark:text-brand-400" />
           <div>
-            <h1 className="text-2xl font-bold text-foreground">{t("whistleblowingDashboard.header.title")}</h1>
-            <p className="text-sm text-muted-foreground">{t("whistleblowingDashboard.header.subtitle")}</p>
+            <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("whistleblowingDashboard.header.title")}</h1>
+            <p className="text-[13px] text-muted-foreground mt-0.5">{t("whistleblowingDashboard.header.subtitle")}</p>
           </div>
         </div>
         <Link
           to="/whistleblowing/reports"
-          className="px-4 py-2 bg-brand-600 text-white rounded-lg hover:bg-brand-700 transition text-sm font-medium"
+          className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 transition text-[13px] font-medium"
         >
           {t("whistleblowingDashboard.header.viewAllReports")}
         </Link>
@@ -57,33 +57,33 @@ export default function WhistleblowingDashboardPage() {
 
       {/* Stat Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
-        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-xl shadow-sm border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-lg shadow-sm border p-5 hover:border-brand-400 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
             <FileText className="h-5 w-5 text-muted-foreground" />
-            <span className="text-sm text-muted-foreground">{t("whistleblowingDashboard.stats.totalReports")}</span>
+            <span className="text-[13px] text-muted-foreground">{t("whistleblowingDashboard.stats.totalReports")}</span>
           </div>
-          <p className="text-3xl font-bold text-foreground">{data.total}</p>
+          <p className="text-3xl font-semibold tabular-nums text-foreground">{data.total}</p>
         </Link>
-        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-xl shadow-sm border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-lg shadow-sm border p-5 hover:border-brand-400 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
             <Clock className="h-5 w-5 text-yellow-500" />
-            <span className="text-sm text-muted-foreground">{t("whistleblowingDashboard.stats.open")}</span>
+            <span className="text-[13px] text-muted-foreground">{t("whistleblowingDashboard.stats.open")}</span>
           </div>
-          <p className="text-3xl font-bold text-yellow-600 dark:text-yellow-400">{data.open}</p>
+          <p className="text-3xl font-semibold tabular-nums text-yellow-600 dark:text-yellow-400">{data.open}</p>
         </Link>
-        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-xl shadow-sm border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-lg shadow-sm border p-5 hover:border-brand-400 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
             <CheckCircle className="h-5 w-5 text-green-500" />
-            <span className="text-sm text-muted-foreground">{t("whistleblowingDashboard.stats.resolved")}</span>
+            <span className="text-[13px] text-muted-foreground">{t("whistleblowingDashboard.stats.resolved")}</span>
           </div>
-          <p className="text-3xl font-bold text-green-600 dark:text-green-400">{data.resolved}</p>
+          <p className="text-3xl font-semibold tabular-nums text-green-600 dark:text-green-400">{data.resolved}</p>
         </Link>
-        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-xl shadow-sm border p-5 transition-all hover:border-brand-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-500">
+        <Link to="/whistleblowing/reports" className="block text-left w-full bg-card rounded-lg shadow-sm border p-5 hover:border-brand-400 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500">
           <div className="flex items-center gap-3 mb-2">
             <TrendingUp className="h-5 w-5 text-brand-500" />
-            <span className="text-sm text-muted-foreground">{t("whistleblowingDashboard.stats.avgResolution")}</span>
+            <span className="text-[13px] text-muted-foreground">{t("whistleblowingDashboard.stats.avgResolution")}</span>
           </div>
-          <p className="text-3xl font-bold text-foreground">
+          <p className="text-3xl font-semibold tabular-nums text-foreground">
             {data.avg_resolution_days !== null
               ? t("whistleblowingDashboard.stats.avgResolutionDays", { count: data.avg_resolution_days })
               : t("whistleblowingDashboard.stats.noValue")}
@@ -93,69 +93,69 @@ export default function WhistleblowingDashboardPage() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {/* By Severity */}
-        <div className="bg-card rounded-xl shadow-sm border p-5">
-          <h3 className="text-sm font-semibold text-muted-foreground uppercase mb-4">{t("whistleblowingDashboard.section.bySeverity")}</h3>
+        <div className="bg-card rounded-lg shadow-sm border p-5">
+          <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">{t("whistleblowingDashboard.section.bySeverity")}</h3>
           <div className="space-y-3">
             {data.by_severity?.map((item: { severity: string; count: number }) => (
               <div key={item.severity} className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <div className={`h-3 w-3 rounded-full ${SEVERITY_COLOR[item.severity] || "bg-gray-400"}`} />
-                  <span className="text-sm text-muted-foreground capitalize">{t(`whistleblowingDashboard.severity.${item.severity}`, { defaultValue: item.severity })}</span>
+                  <div className={`h-3 w-3 rounded-full ${SEVERITY_COLOR[item.severity] || "bg-muted-foreground/40"}`} />
+                  <span className="text-[13px] text-muted-foreground capitalize">{t(`whistleblowingDashboard.severity.${item.severity}`, { defaultValue: item.severity })}</span>
                 </div>
-                <span className="text-sm font-semibold text-foreground">{Number(item.count)}</span>
+                <span className="text-[13px] font-semibold tabular-nums text-foreground">{Number(item.count)}</span>
               </div>
             ))}
             {(!data.by_severity || data.by_severity.length === 0) && (
-              <p className="text-sm text-muted-foreground">{t("whistleblowingDashboard.empty.noData")}</p>
+              <p className="text-[13px] text-muted-foreground">{t("whistleblowingDashboard.empty.noData")}</p>
             )}
           </div>
         </div>
 
         {/* By Category */}
-        <div className="bg-card rounded-xl shadow-sm border p-5">
-          <h3 className="text-sm font-semibold text-muted-foreground uppercase mb-4">{t("whistleblowingDashboard.section.byCategory")}</h3>
+        <div className="bg-card rounded-lg shadow-sm border p-5">
+          <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">{t("whistleblowingDashboard.section.byCategory")}</h3>
           <div className="space-y-3">
             {data.by_category?.map((item: { category: string; count: number }) => (
               <div key={item.category} className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground capitalize">{t(`whistleblowingDashboard.category.${item.category}`, { defaultValue: item.category.replace(/_/g, " ") })}</span>
-                <span className="text-sm font-semibold text-foreground">{Number(item.count)}</span>
+                <span className="text-[13px] text-muted-foreground capitalize">{t(`whistleblowingDashboard.category.${item.category}`, { defaultValue: item.category.replace(/_/g, " ") })}</span>
+                <span className="text-[13px] font-semibold tabular-nums text-foreground">{Number(item.count)}</span>
               </div>
             ))}
             {(!data.by_category || data.by_category.length === 0) && (
-              <p className="text-sm text-muted-foreground">{t("whistleblowingDashboard.empty.noData")}</p>
+              <p className="text-[13px] text-muted-foreground">{t("whistleblowingDashboard.empty.noData")}</p>
             )}
           </div>
         </div>
       </div>
 
       {/* Recent Reports */}
-      <div className="bg-card rounded-xl shadow-sm border overflow-hidden">
+      <div className="bg-card rounded-lg shadow-sm border overflow-hidden">
         <div className="p-5 border-b">
-          <h3 className="text-sm font-semibold text-muted-foreground uppercase">{t("whistleblowingDashboard.section.recentReports")}</h3>
+          <h3 className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">{t("whistleblowingDashboard.section.recentReports")}</h3>
         </div>
         {data.recent && data.recent.length > 0 ? (
           <table className="w-full">
-            <thead className="bg-muted text-xs text-muted-foreground uppercase">
+            <thead className="bg-muted text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
               <tr>
-                <th className="px-5 py-3 text-left">{t("whistleblowingDashboard.table.caseNumber")}</th>
-                <th className="px-5 py-3 text-left">{t("whistleblowingDashboard.table.category")}</th>
-                <th className="px-5 py-3 text-left">{t("whistleblowingDashboard.table.severity")}</th>
-                <th className="px-5 py-3 text-left">{t("whistleblowingDashboard.table.subject")}</th>
-                <th className="px-5 py-3 text-left">{t("whistleblowingDashboard.table.status")}</th>
-                <th className="px-5 py-3 text-left">{t("whistleblowingDashboard.table.date")}</th>
+                <th className="px-4 py-2.5 text-left">{t("whistleblowingDashboard.table.caseNumber")}</th>
+                <th className="px-4 py-2.5 text-left">{t("whistleblowingDashboard.table.category")}</th>
+                <th className="px-4 py-2.5 text-left">{t("whistleblowingDashboard.table.severity")}</th>
+                <th className="px-4 py-2.5 text-left">{t("whistleblowingDashboard.table.subject")}</th>
+                <th className="px-4 py-2.5 text-left">{t("whistleblowingDashboard.table.status")}</th>
+                <th className="px-4 py-2.5 text-left">{t("whistleblowingDashboard.table.date")}</th>
               </tr>
             </thead>
             <tbody className="divide-y">
               {data.recent.map((r: { id: number; case_number: string; category: string; severity: string; subject: string; status: string; created_at: string }) => (
                 <tr key={r.id} className="hover:bg-muted">
-                  <td className="px-5 py-3">
-                    <Link to={`/whistleblowing/reports/${r.id}`} className="font-mono text-sm text-brand-600 dark:text-brand-400 hover:underline">
+                  <td className="px-4 py-2.5">
+                    <Link to={`/whistleblowing/reports/${r.id}`} className="font-mono text-[13px] tabular-nums text-brand-600 dark:text-brand-400 hover:underline">
                       {r.case_number}
                     </Link>
                   </td>
-                  <td className="px-5 py-3 text-sm text-muted-foreground capitalize">{t(`whistleblowingDashboard.category.${r.category}`, { defaultValue: r.category.replace(/_/g, " ") })}</td>
-                  <td className="px-5 py-3">
-                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground capitalize">{t(`whistleblowingDashboard.category.${r.category}`, { defaultValue: r.category.replace(/_/g, " ") })}</td>
+                  <td className="px-4 py-2.5">
+                    <span className={`px-2 py-0.5 rounded-md text-[11px] font-medium ${
                       r.severity === "critical" ? "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300" :
                       r.severity === "high" ? "bg-orange-100 dark:bg-orange-950/40 text-orange-700 dark:text-orange-300" :
                       r.severity === "medium" ? "bg-yellow-100 dark:bg-yellow-950/40 text-yellow-700 dark:text-yellow-300" :
@@ -164,13 +164,13 @@ export default function WhistleblowingDashboardPage() {
                       {t(`whistleblowingDashboard.severity.${r.severity}`, { defaultValue: r.severity })}
                     </span>
                   </td>
-                  <td className="px-5 py-3 text-sm text-foreground max-w-xs truncate">{r.subject}</td>
-                  <td className="px-5 py-3">
-                    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_BADGE[r.status] || ""}`}>
+                  <td className="px-4 py-2.5 text-[13px] text-foreground max-w-xs truncate">{r.subject}</td>
+                  <td className="px-4 py-2.5">
+                    <span className={`px-2 py-0.5 rounded-md text-[11px] font-medium ${STATUS_BADGE[r.status] || ""}`}>
                       {t(`whistleblowingDashboard.status.${r.status}`, { defaultValue: r.status.replace(/_/g, " ") })}
                     </span>
                   </td>
-                  <td className="px-5 py-3 text-sm text-muted-foreground">{new Date(r.created_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-2.5 text-[13px] text-muted-foreground">{new Date(r.created_at).toLocaleDateString()}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
Applies the enterprise density guide (`docs/UI-UPLIFT-GUIDE.md`) to the remaining **misc** pages — the last group of the module-by-module uplift. Surface-only, no logic changes.

**Pages (9)**
- `ChatbotPage.tsx` (AI HR assistant)
- `KioskBiometricPage.tsx` (biometric kiosk PIN/settings)
- `AuditPage.tsx` (audit log table)
- `OnboardingWizard.tsx` (5-step org setup wizard)
- Whistleblowing ×5: `WhistleblowingDashboardPage`, `ReportListPage`, `ReportDetailPage`, `SubmitReportPage`, `TrackReportPage`

**Changes**
- `rounded-xl` cards → `rounded-lg` (+ `p-6` → `p-4`); `rounded-lg` controls → `rounded-md`
- status / severity / action pills `rounded-full` → `rounded-md` (avatars, chat bubbles, typing dots, timeline nodes, progress tracks, and the **anonymity toggle** kept round)
- page titles `text-2xl font-bold` → `text-xl font-semibold tracking-tight`
- KPI / stat numbers: `font-bold` → `font-semibold` + `tabular-nums` (size kept)
- table headers → `[11px]` uppercase tracking-wider; cells `px-6`/`px-5 py-3`/`py-4` → `px-4 py-2.5`
- body `text-sm` → `[13px]`, `text-xs` → `[11px]`; `tabular-nums` on dates / case-numbers / counts
- row & card hovers softened to `/50 transition-colors` / `hover:border-brand-400`

**Dark-mode fixes**
- **OnboardingWizard** was light-only: full raw-`gray-*`/`bg-white` → semantic-token migration (`bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`) + amber-alert `dark:` siblings. Step-indicator shape/logic kept; idle states tokenized.
- **KioskBiometricPage**: disable-button `border-red-300` was missing `dark:border-red-900`
- **ChatbotPage**: active-conversation row + suggestion chip `border-brand-200` missing `dark:border-brand-800`
- **Whistleblowing Dashboard**: `bg-gray-400` severity-dot fallback → `bg-muted-foreground/40`

**Preserved (not touched beyond radius/size)**
- chat-bubble colors & bot/user logic, anonymity toggle + submission logic, biometric scan/success-fail states, audit action-color coding, all severity/status semantic hues, print/gateway-adjacent code
- Chatbot hero prompt ("How can I help you today?") kept as a readable title, not shrunk to a micro-label

**Verification**
- className-only diff (360 insertions = 360 deletions)
- `tsc --noEmit`: 0 errors
- client `npm run build`: passes