### PR TITLE
feat(attendance): late-count date range on the Attendance Details modal

### DIFF
--- a/packages/client/src/locales/ar.json
+++ b/packages/client/src/locales/ar.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "فشل تطبيق الإجازة"
     },
-    "location": "الموقع"
+    "location": "الموقع",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} يوم تأخير",
+      "lateDaysOther": "{{count}} أيام تأخير",
+      "lateDaysCol": "أيام التأخير",
+      "totalLateCol": "إجمالي التأخير",
+      "presetToday": "اليوم",
+      "presetMonth": "هذا الشهر",
+      "preset15": "آخر 15 يومًا",
+      "preset30": "آخر 30 يومًا",
+      "presetCustom": "مخصص",
+      "rangeFrom": "من تاريخ",
+      "rangeTo": "إلى تاريخ"
+    }
   },
   "manager": {
     "title": "فريقي",

--- a/packages/client/src/locales/de.json
+++ b/packages/client/src/locales/de.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "Urlaub konnte nicht beantragt werden"
     },
-    "location": "Standort"
+    "location": "Standort",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} Tag zu spät",
+      "lateDaysOther": "{{count}} Tage zu spät",
+      "lateDaysCol": "Verspätete Tage",
+      "totalLateCol": "Gesamtverspätung",
+      "presetToday": "Heute",
+      "presetMonth": "Dieser Monat",
+      "preset15": "Letzte 15 Tage",
+      "preset30": "Letzte 30 Tage",
+      "presetCustom": "Benutzerdefiniert",
+      "rangeFrom": "Von Datum",
+      "rangeTo": "Bis Datum"
+    }
   },
   "manager": {
     "title": "Mein Team",

--- a/packages/client/src/locales/en.json
+++ b/packages/client/src/locales/en.json
@@ -1326,7 +1326,20 @@
     "checkedOutAt": "Checked out {{time}}",
     "updateCheckOutHint": "Check out again to correct the time",
     "checkInSuccess": "Successfully checked in at {{time}}",
-    "checkOutSuccess": "Successfully checked out at {{time}}"
+    "checkOutSuccess": "Successfully checked out at {{time}}",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} late day",
+      "lateDaysOther": "{{count}} late days",
+      "lateDaysCol": "Late Days",
+      "totalLateCol": "Total Late",
+      "presetToday": "Today",
+      "presetMonth": "This month",
+      "preset15": "Last 15 days",
+      "preset30": "Last 30 days",
+      "presetCustom": "Custom",
+      "rangeFrom": "From date",
+      "rangeTo": "To date"
+    }
   },
   "manager": {
     "title": "My Team",

--- a/packages/client/src/locales/es.json
+++ b/packages/client/src/locales/es.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "No se pudo aplicar el permiso"
     },
-    "location": "Ubicación"
+    "location": "Ubicación",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} día de retraso",
+      "lateDaysOther": "{{count}} días de retraso",
+      "lateDaysCol": "Días de retraso",
+      "totalLateCol": "Retraso total",
+      "presetToday": "Hoy",
+      "presetMonth": "Este mes",
+      "preset15": "Últimos 15 días",
+      "preset30": "Últimos 30 días",
+      "presetCustom": "Personalizado",
+      "rangeFrom": "Fecha desde",
+      "rangeTo": "Fecha hasta"
+    }
   },
   "manager": {
     "title": "Mi Equipo",

--- a/packages/client/src/locales/fr.json
+++ b/packages/client/src/locales/fr.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "Échec de l'application du congé"
     },
-    "location": "Emplacement"
+    "location": "Emplacement",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} jour de retard",
+      "lateDaysOther": "{{count}} jours de retard",
+      "lateDaysCol": "Jours de retard",
+      "totalLateCol": "Retard total",
+      "presetToday": "Aujourd’hui",
+      "presetMonth": "Ce mois",
+      "preset15": "15 derniers jours",
+      "preset30": "30 derniers jours",
+      "presetCustom": "Personnalisé",
+      "rangeFrom": "Date de début",
+      "rangeTo": "Date de fin"
+    }
   },
   "manager": {
     "title": "Mon équipe",

--- a/packages/client/src/locales/hi.json
+++ b/packages/client/src/locales/hi.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "अवकाश लागू करने में विफल"
     },
-    "location": "स्थान"
+    "location": "स्थान",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} दिन देरी",
+      "lateDaysOther": "{{count}} दिन देरी",
+      "lateDaysCol": "देरी के दिन",
+      "totalLateCol": "कुल देरी",
+      "presetToday": "आज",
+      "presetMonth": "इस माह",
+      "preset15": "पिछले 15 दिन",
+      "preset30": "पिछले 30 दिन",
+      "presetCustom": "कस्टम",
+      "rangeFrom": "आरंभ तिथि",
+      "rangeTo": "अंत तिथि"
+    }
   },
   "manager": {
     "title": "मेरी टीम",

--- a/packages/client/src/locales/ja.json
+++ b/packages/client/src/locales/ja.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "休暇の適用に失敗しました"
     },
-    "location": "勤務地"
+    "location": "勤務地",
+    "monthlyLate": {
+      "lateDaysOne": "遅刻{{count}}日",
+      "lateDaysOther": "遅刻{{count}}日",
+      "lateDaysCol": "遅刻日数",
+      "totalLateCol": "遅刻合計",
+      "presetToday": "今日",
+      "presetMonth": "今月",
+      "preset15": "過去15日間",
+      "preset30": "過去30日間",
+      "presetCustom": "カスタム",
+      "rangeFrom": "開始日",
+      "rangeTo": "終了日"
+    }
   },
   "manager": {
     "title": "マイチーム",

--- a/packages/client/src/locales/pt.json
+++ b/packages/client/src/locales/pt.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "Falha ao aplicar a licença"
     },
-    "location": "Local"
+    "location": "Local",
+    "monthlyLate": {
+      "lateDaysOne": "{{count}} dia de atraso",
+      "lateDaysOther": "{{count}} dias de atraso",
+      "lateDaysCol": "Dias de atraso",
+      "totalLateCol": "Atraso total",
+      "presetToday": "Hoje",
+      "presetMonth": "Este mês",
+      "preset15": "Últimos 15 dias",
+      "preset30": "Últimos 30 dias",
+      "presetCustom": "Personalizado",
+      "rangeFrom": "Data inicial",
+      "rangeTo": "Data final"
+    }
   },
   "manager": {
     "title": "Minha Equipe",

--- a/packages/client/src/locales/zh.json
+++ b/packages/client/src/locales/zh.json
@@ -1321,7 +1321,20 @@
       },
       "applyLeaveFailed": "申请请假失败"
     },
-    "location": "地点"
+    "location": "地点",
+    "monthlyLate": {
+      "lateDaysOne": "迟到 {{count}} 天",
+      "lateDaysOther": "迟到 {{count}} 天",
+      "lateDaysCol": "迟到天数",
+      "totalLateCol": "迟到总计",
+      "presetToday": "今天",
+      "presetMonth": "本月",
+      "preset15": "最近15天",
+      "preset30": "最近30天",
+      "presetCustom": "自定义",
+      "rangeFrom": "起始日期",
+      "rangeTo": "结束日期"
+    }
   },
   "manager": {
     "title": "我的团队",

--- a/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceDashboardPage.tsx
@@ -252,6 +252,49 @@ export default function AttendanceDashboardPage() {
   const [breakdownLoc, setBreakdownLoc] = useState("");
   const BREAKDOWN_PAGE_SIZE = 10;
 
+  // "Late" tab range control inside the Attendance Details modal. Presets:
+  // today (default — today's late list), month (current calendar month), d15/d30
+  // (rolling windows), custom (from–to). "today" shows the day list (check-in
+  // time + minutes late); the ranges show each employee's TOTAL late days over
+  // the window. Same "late" definition as the daily cards (late_minutes>0 on a
+  // present/half_day/checked_in row).
+  type LatePreset = "today" | "month" | "d15" | "d30" | "custom";
+  const [latePreset, setLatePreset] = useState<LatePreset>("today");
+  const [lateCustomFrom, setLateCustomFrom] = useState(todayStr);
+  const [lateCustomTo, setLateCustomTo] = useState(todayStr);
+  const shiftDays = (n: number) => { const d = new Date(now); d.setDate(d.getDate() + n); return toDateStr(d); };
+  // Resolve the active preset to a concrete [from,to] window (YYYY-MM-DD).
+  const lateRange: { from: string; to: string } =
+    latePreset === "month"
+      ? { from: toDateStr(new Date(now.getFullYear(), now.getMonth(), 1)), to: toDateStr(new Date(now.getFullYear(), now.getMonth() + 1, 0)) }
+      : latePreset === "d15"
+      ? { from: shiftDays(-14), to: todayStr }
+      : latePreset === "d30"
+      ? { from: shiftDays(-29), to: todayStr }
+      : latePreset === "custom"
+      ? { from: lateCustomFrom || todayStr, to: lateCustomTo || todayStr }
+      : { from: todayStr, to: todayStr };
+  const lateIsRange = breakdownOpen === "late" && latePreset !== "today";
+  // Range mode → per-employee late-day counts over the window.
+  const { data: lateCounts, isLoading: lateCountsLoading } = useQuery({
+    queryKey: ["attendance-late-counts", lateRange.from, lateRange.to],
+    queryFn: () =>
+      api
+        .get("/attendance/late-counts", { params: { date_from: lateRange.from, date_to: lateRange.to } })
+        .then((r) => r.data.data),
+    enabled: lateIsRange,
+  });
+  // "Today" preset → today's late list (check-in time + minutes late), fixed to
+  // today regardless of the shared breakdown date the other tabs use.
+  const { data: lateTodayData, isLoading: lateTodayLoading } = useQuery({
+    queryKey: ["attendance-dashboard-breakdown", todayStr],
+    queryFn: () =>
+      api
+        .get("/attendance/dashboard/breakdown", { params: { date: todayStr } })
+        .then((r) => r.data.data),
+    enabled: breakdownOpen === "late" && latePreset === "today",
+  });
+
   const { data: breakdown, isLoading: breakdownLoading } = useQuery({
     queryKey: ["attendance-dashboard-breakdown", breakdownDate],
     queryFn: () =>
@@ -269,6 +312,10 @@ export default function AttendanceDashboardPage() {
     setBreakdownSearch("");
     setBreakdownDept("");
     setBreakdownLoc("");
+    // Late tab always opens on the "today" preset.
+    setLatePreset("today");
+    setLateCustomFrom(todayStr);
+    setLateCustomTo(todayStr);
     setBreakdownOpen(category);
   };
 
@@ -326,9 +373,20 @@ export default function AttendanceDashboardPage() {
 
       {/* Breakdown Modal ("Attendance Details") */}
       {breakdownOpen !== null && (() => {
+        // Late tab in a range preset shows per-employee late-day COUNTS over the
+        // window; the "today" preset (and all other tabs) show the day-scoped list.
+        const isLateRange = lateIsRange; // breakdownOpen === "late" && preset !== "today"
+        const isLateToday = breakdownOpen === "late" && latePreset === "today";
+        const rangeLabel = lateRange.from === lateRange.to ? lateRange.from : `${lateRange.from} – ${lateRange.to}`;
+        const listLoading = isLateRange ? lateCountsLoading : isLateToday ? lateTodayLoading : breakdownLoading;
+        const fmtDuration = (min: number) => (min >= 60 ? `${Math.floor(min / 60)}h ${min % 60}m` : `${min}m`);
         // Active tab's employees. "total" stitches present + absent + on_leave
         // together (late is a subset of present, so it isn't appended again).
-        const tabList: any[] = breakdownOpen === "total"
+        const tabList: any[] = isLateRange
+          ? (lateCounts?.employees ?? [])
+          : isLateToday
+          ? (lateTodayData?.late ?? [])
+          : breakdownOpen === "total"
           ? [
               ...(breakdown?.present ?? []),
               ...(breakdown?.absent ?? []),
@@ -374,6 +432,24 @@ export default function AttendanceDashboardPage() {
         // Export exactly what's on screen — the current tab + department /
         // location / search filters — as an .xlsx via the shared helper.
         const exportBreakdown = () => {
+          if (isLateRange) {
+            const headers = [
+              t('common.name'),
+              t('attendance.department'),
+              t('attendance.location'),
+              t('attendance.monthlyLate.lateDaysCol'),
+              t('attendance.monthlyLate.totalLateCol'),
+            ];
+            const rows = filteredList.map((emp: any) => [
+              `${emp.first_name ?? ""} ${emp.last_name ?? ""}`.trim(),
+              emp.department ?? "",
+              emp.location ?? "",
+              Number(emp.late_count) || 0,
+              Number(emp.total_late_minutes) > 0 ? fmtDuration(Number(emp.total_late_minutes)) : "",
+            ]);
+            downloadExcel(headers, rows, `late-${lateRange.from}_${lateRange.to}.xlsx`, "Late");
+            return;
+          }
           const headers = [
             t('common.name'),
             t('attendance.department'),
@@ -403,23 +479,25 @@ export default function AttendanceDashboardPage() {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between gap-3 px-6 py-4 border-b border-border">
-              <h3 className="text-base font-semibold text-foreground">{t('attendance.breakdown.title', { date: breakdown?.date ?? breakdownDate })}</h3>
+              <h3 className="text-base font-semibold text-foreground">{t('attendance.breakdown.title', { date: breakdownOpen === "late" ? rangeLabel : (breakdown?.date ?? breakdownDate) })}</h3>
               <div className="flex items-center gap-3">
-                <div className="flex items-center gap-2">
-                  <label htmlFor="breakdown-date" className="text-xs font-medium text-muted-foreground whitespace-nowrap">{t('attendance.breakdown.dateLabel')}</label>
-                  <input
-                    id="breakdown-date"
-                    type="date"
-                    value={breakdownDate}
-                    max={todayStr}
-                    onChange={(e) => { setBreakdownDate(e.target.value); setBreakdownPage(1); }}
-                    className="bg-card text-foreground px-2.5 py-1.5 border border-border rounded-md text-[13px]"
-                  />
-                </div>
+                {breakdownOpen !== "late" && (
+                  <div className="flex items-center gap-2">
+                    <label htmlFor="breakdown-date" className="text-xs font-medium text-muted-foreground whitespace-nowrap">{t('attendance.breakdown.dateLabel')}</label>
+                    <input
+                      id="breakdown-date"
+                      type="date"
+                      value={breakdownDate}
+                      max={todayStr}
+                      onChange={(e) => { setBreakdownDate(e.target.value); setBreakdownPage(1); }}
+                      className="bg-card text-foreground px-2.5 py-1.5 border border-border rounded-md text-[13px]"
+                    />
+                  </div>
+                )}
                 <button
                   type="button"
                   onClick={exportBreakdown}
-                  disabled={breakdownLoading || filteredList.length === 0}
+                  disabled={listLoading || filteredList.length === 0}
                   className="inline-flex items-center gap-1.5 rounded-md bg-green-600 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
                   title={t('attendance.breakdown.export')}
                 >
@@ -449,7 +527,14 @@ export default function AttendanceDashboardPage() {
                 ).map((tab) => {
                   const count = tab.key === "total"
                     ? (breakdown?.present?.length ?? 0) + (breakdown?.absent?.length ?? 0) + (breakdown?.on_leave?.length ?? 0)
+                    : tab.key === "late" && isLateRange
+                    ? (lateCounts?.total_late_employees ?? 0)
+                    : tab.key === "late" && isLateToday
+                    ? (lateTodayData?.late?.length ?? 0)
                     : breakdown?.[tab.key]?.length ?? 0;
+                  const tabLoading = tab.key === "late"
+                    ? (isLateRange ? lateCountsLoading : isLateToday ? lateTodayLoading : breakdownLoading)
+                    : breakdownLoading;
                   const active = breakdownOpen === tab.key;
                   return (
                     <button
@@ -460,12 +545,61 @@ export default function AttendanceDashboardPage() {
                         active ? tab.color : "text-muted-foreground border-transparent hover:text-foreground"
                       }`}
                     >
-                      {tab.label} ({breakdownLoading ? "…" : count})
+                      {tab.label} ({tabLoading ? "…" : count})
                     </button>
                   );
                 })}
               </div>
             </div>
+            {breakdownOpen === "late" && (
+              <div className="px-6 pt-3 flex flex-wrap items-center gap-2">
+                {([
+                  { k: "today", label: t('attendance.monthlyLate.presetToday') },
+                  { k: "month", label: t('attendance.monthlyLate.presetMonth') },
+                  { k: "d15", label: t('attendance.monthlyLate.preset15') },
+                  { k: "d30", label: t('attendance.monthlyLate.preset30') },
+                  { k: "custom", label: t('attendance.monthlyLate.presetCustom') },
+                ] as const).map((p) => (
+                  <button
+                    key={p.k}
+                    type="button"
+                    onClick={() => { setLatePreset(p.k); setBreakdownPage(1); }}
+                    className={`px-3 py-1 text-[12px] font-medium rounded-md border transition-colors ${
+                      latePreset === p.k
+                        ? "border-brand-400 bg-brand-50 dark:bg-brand-950/40 text-brand-700 dark:text-brand-300"
+                        : "border-border text-muted-foreground hover:text-foreground"
+                    }`}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+                {latePreset === "custom" && (
+                  <div className="flex items-center gap-1.5">
+                    <input
+                      type="date"
+                      aria-label={t('attendance.monthlyLate.rangeFrom')}
+                      value={lateCustomFrom}
+                      max={lateCustomTo || todayStr}
+                      onChange={(e) => { setLateCustomFrom(e.target.value); setBreakdownPage(1); }}
+                      className="bg-card text-foreground px-2 py-1 border border-border rounded-md text-[12px]"
+                    />
+                    <span className="text-muted-foreground text-[12px]">–</span>
+                    <input
+                      type="date"
+                      aria-label={t('attendance.monthlyLate.rangeTo')}
+                      value={lateCustomTo}
+                      min={lateCustomFrom || undefined}
+                      max={todayStr}
+                      onChange={(e) => { setLateCustomTo(e.target.value); setBreakdownPage(1); }}
+                      className="bg-card text-foreground px-2 py-1 border border-border rounded-md text-[12px]"
+                    />
+                  </div>
+                )}
+                {latePreset !== "today" && latePreset !== "custom" && (
+                  <span className="text-[11px] text-muted-foreground">{rangeLabel}</span>
+                )}
+              </div>
+            )}
             <div className="px-6 py-3 border-b border-border space-y-2">
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -503,7 +637,7 @@ export default function AttendanceDashboardPage() {
               </div>
             </div>
             <div className="overflow-y-auto flex-1 px-6 py-4">
-              {breakdownLoading ? (
+              {listLoading ? (
                 <div className="flex justify-center py-12">
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
@@ -513,6 +647,43 @@ export default function AttendanceDashboardPage() {
                     ? t('attendance.breakdown.noEmployeesInCategory')
                     : t('attendance.breakdown.noSearchResults')}
                 </p>
+              ) : isLateRange ? (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-[11px] text-muted-foreground uppercase tracking-wider border-b border-border">
+                      <th className="py-2 font-semibold">{t('common.name')}</th>
+                      <th className="py-2 font-semibold">{t('attendance.department')}</th>
+                      <th className="py-2 font-semibold whitespace-nowrap">{t('attendance.monthlyLate.lateDaysCol')}</th>
+                      <th className="py-2 font-semibold whitespace-nowrap">{t('attendance.monthlyLate.totalLateCol')}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pageList.map((emp: any) => (
+                      <tr key={emp.user_id} className="border-b border-border last:border-0">
+                        <td className="py-3">
+                          <div className="font-medium text-foreground">
+                            {emp.first_name} {emp.last_name}
+                            {emp.emp_code ? <span className="ml-2 text-xs text-muted-foreground">{emp.emp_code}</span> : null}
+                          </div>
+                          <div className="text-xs text-muted-foreground">{emp.email}</div>
+                        </td>
+                        <td className="py-3 text-muted-foreground">{emp.department || "—"}</td>
+                        <td className="py-3">
+                          <span
+                            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[12px] font-semibold whitespace-nowrap ${
+                              Number(emp.late_count) > 0
+                                ? "bg-yellow-50 dark:bg-yellow-950/40 text-yellow-700 dark:text-yellow-300"
+                                : "bg-muted text-muted-foreground"
+                            }`}
+                          >
+                            {t(Number(emp.late_count) === 1 ? 'attendance.monthlyLate.lateDaysOne' : 'attendance.monthlyLate.lateDaysOther', { count: Number(emp.late_count) || 0 })}
+                          </span>
+                        </td>
+                        <td className="py-3 text-muted-foreground whitespace-nowrap">{Number(emp.total_late_minutes) > 0 ? fmtDuration(Number(emp.total_late_minutes)) : "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               ) : (
                 <table className="w-full text-sm">
                   <thead>
@@ -552,7 +723,7 @@ export default function AttendanceDashboardPage() {
             </div>
             {/* Pagination footer — always shown when there are results so the
                 control is visibly part of the modal even for a single page. */}
-            {!breakdownLoading && filteredList.length > 0 && (
+            {!listLoading && filteredList.length > 0 && (
               <div className="flex items-center justify-between px-6 py-3 border-t border-border">
                 <p className="text-[13px] tabular-nums text-muted-foreground">{t('attendance.pagination', { page: safePage, totalPages, total: filteredList.length })}</p>
                 <div className="flex gap-2">
@@ -577,6 +748,7 @@ export default function AttendanceDashboardPage() {
         </div>
         );
       })()}
+
 
       {/* Quick Links */}
       <div className="flex gap-2.5 mb-4">

--- a/packages/server/src/api/routes/attendance.routes.ts
+++ b/packages/server/src/api/routes/attendance.routes.ts
@@ -699,6 +699,43 @@ router.get("/monthly-report", authenticate, requirePermission("attendance:view_a
   } catch (err) { next(err); }
 });
 
+// GET /api/v1/attendance/late-counts?date_from=&date_to=&department_id=&location_id=
+// Per-employee count of LATE days in the given date range — drives the "Late"
+// tab range view (Last 15 days / This month / custom). Same "late" definition
+// and scope resolution as /dashboard so it stays consistent with the card.
+// Defaults to the current calendar month when the range is not supplied.
+router.get(
+  "/late-counts",
+  authenticate,
+  requirePermission(
+    "attendance:view_all",
+    "attendance:view_team",
+    "attendance:approve_regularization_team", "attendance:approve_regularization_all",
+    "attendance:manage",
+  ),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const now = new Date();
+      const iso = (d: Date) => d.toISOString().slice(0, 10);
+      const monthStart = iso(new Date(now.getFullYear(), now.getMonth(), 1));
+      const monthEnd = iso(new Date(now.getFullYear(), now.getMonth() + 1, 0));
+      // Basic YYYY-MM-DD guard; fall back to the current month on missing/garbage.
+      const isDate = (v: unknown): v is string => typeof v === "string" && /^\d{4}-\d{2}-\d{2}$/.test(v);
+      const dateFrom = isDate(req.query.date_from) ? req.query.date_from : monthStart;
+      const dateTo = isDate(req.query.date_to) ? req.query.date_to : monthEnd;
+      const departmentId = req.query.department_id ? Number(req.query.department_id) : undefined;
+      const locationId = req.query.location_id ? Number(req.query.location_id) : undefined;
+      const userIds = await resolveAttendanceScope(req);
+      const result = await attendanceService.getLateCounts(
+        req.user!.org_id,
+        { date_from: dateFrom, date_to: dateTo, department_id: departmentId, location_id: locationId },
+        userIds ?? undefined,
+      );
+      sendSuccess(res, result);
+    } catch (err) { next(err); }
+  },
+);
+
 // GET /api/v1/attendance/grid?month=&year= — per-employee per-day matrix.
 // Powers the new Attendance Grid page (date columns 1..31 with single-letter
 // status codes P / A / H / L / WO / HO).

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -1022,6 +1022,83 @@ export async function getMonthlyReport(
   return { month: params.month, year: params.year, report: records };
 }
 
+// ---------------------------------------------------------------------------
+// Late counts over a date range — per-employee number of LATE days between
+// date_from and date_to (inclusive). Drives the "Late" tab range view ("how
+// many times was each employee late over the last 15 days / this month / a
+// custom range"). Uses the SAME definition of late as the daily dashboard
+// (#1928): a day counts as late only when the row is present/half_day/
+// checked_in AND has positive late_minutes, so a stale late_minutes on a row
+// later flipped to on_leave/absent never inflates the count. Every in-scope
+// employee is returned (0-late included) so any employee is findable/searchable
+// in the modal; ordered most-late first.
+// ---------------------------------------------------------------------------
+export async function getLateCounts(
+  orgId: number,
+  params: { date_from: string; date_to: string; department_id?: number; location_id?: number },
+  userIds?: number[],
+) {
+  const db = getDB();
+  const startDate = params.date_from;
+  const endDate = params.date_to;
+
+  const teamScoped = Array.isArray(userIds);
+  const emptyTeam = teamScoped && userIds!.length === 0;
+
+  // The gated "late day" predicate, reused for both the count and the minutes sum.
+  const latePredicate =
+    "ar.status IN ('present','half_day','checked_in') AND ar.late_minutes > 0";
+
+  // The date window lives in the JOIN (not WHERE) so a LEFT JOIN still yields a
+  // row for employees with zero attendance records in the range (late_count = 0),
+  // instead of dropping them.
+  const query = db("users as u")
+    .leftJoin("organization_departments as d", "u.department_id", "d.id")
+    .leftJoin("organization_locations as loc", "u.location_id", "loc.id")
+    .leftJoin("attendance_records as ar", function () {
+      this.on("ar.user_id", "=", "u.id").andOnBetween("ar.date", [startDate, endDate]);
+    })
+    .where("u.organization_id", orgId)
+    .where("u.status", 1)
+    .whereNot("u.role", "super_admin");
+
+  if (params.department_id) query.where("u.department_id", params.department_id);
+  if (params.location_id) query.where("u.location_id", params.location_id);
+  if (teamScoped) {
+    if (emptyTeam) query.where(db.raw("1 = 0"));
+    else query.whereIn("u.id", userIds!);
+  }
+
+  const rows = await query
+    .select(
+      "u.id as user_id",
+      "u.first_name",
+      "u.last_name",
+      "u.email",
+      "u.emp_code",
+      "d.name as department",
+      "loc.name as location",
+      db.raw(`COUNT(CASE WHEN ${latePredicate} THEN 1 END) as late_count`),
+      db.raw(`SUM(CASE WHEN ${latePredicate} THEN ar.late_minutes ELSE 0 END) as total_late_minutes`),
+    )
+    .groupBy("u.id", "u.first_name", "u.last_name", "u.email", "u.emp_code", "d.name", "loc.name")
+    .orderByRaw("late_count DESC")
+    .orderBy(["u.first_name", "u.last_name"]);
+
+  const employees = rows.map((r: any) => ({
+    ...r,
+    late_count: Number(r.late_count) || 0,
+    total_late_minutes: Number(r.total_late_minutes) || 0,
+  }));
+
+  return {
+    date_from: startDate,
+    date_to: endDate,
+    total_late_employees: employees.filter((e) => e.late_count > 0).length,
+    employees,
+  };
+}
+
 // =============================================================================
 // MONTHLY GRID — per-employee per-day attendance matrix
 // =============================================================================


### PR DESCRIPTION
## What & why

On the Attendance dashboard, the **Late Today** stat card / **Attendance Details** modal was day-scoped only — you could see who was late *today*, but not *how many times* each employee was late over a period. This adds a date-range view to the **Late** tab so HR can answer "how many times was each employee late this month / in the last 15 days / in a custom range".

## Changes

### Late tab range control (client)
The **Late** tab of the Attendance Details modal gains a range selector:
- **Today** *(default)* — today's late list (check-in time + minutes late). Unchanged behaviour.
- **This month** — current calendar month.
- **Last 15 days** / **Last 30 days** — rolling windows ending today.
- **Custom** — from/to date pickers for any range.

For the range presets, the list becomes a per-employee table — **Name · Department · Late Days · Total Late** — sorted most-late first, with every in-scope employee shown (0-late included) so anyone is searchable. The **Late (N)** tab count, the modal title range, and **Export** all follow the selected range. The other tabs (All / Present / Absent / On Leave) are unchanged and keep their single-date picker. Search + Department + Location filters work in every range.

### Backend
- New service `getLateCounts(orgId, { date_from, date_to, department_id?, location_id? }, userIds?)` in `attendance.service.ts`.
- New route `GET /api/v1/attendance/late-counts?date_from=&date_to=&department_id=&location_id=` (defaults to the current calendar month when the range is omitted/invalid).
- A "late day" is a `present`/`half_day`/`checked_in` row with `late_minutes > 0` — the **same definition** as the "Late Today" card (#1928), so counts stay consistent. LEFT JOIN from `users` keeps 0-late employees in the result. Same permission set + `resolveAttendanceScope` as `/dashboard` (a team-scoped manager sees only their team). Every query is org-scoped.

### i18n
Preset, range and column labels added to all 9 locales (en, hi, es, fr, de, ar, pt, ja, zh).

## Verification
- `tsc --noEmit` clean for both `packages/server` and `packages/client`.
- Live Playwright (org TechNova; late records: Rahul & Arjun on 2026-07-13, Meera on 2026-07-23):
  - **Today** → `Late (0)` (nobody late today).
  - **This month** (2026-07-01 – 07-31) → `Late (3)` — Arjun, Meera, Rahul, 1 late day each with durations.
  - **Last 15 days** (2026-07-17 – 07-31) → `Late (1)` — only Meera (the others fall outside the window; correct date filtering).
  - **Custom** → from/to date pickers appear.
  - No console/page errors.

## Notes
- No DB migration — uses existing `attendance_records.late_minutes`.
- No changes to the day-scoped Late column in the records table or to the other stat cards.