### PR TITLE
fix(attendance): persist Present override for approved leave

### DIFF
--- a/packages/client/src/pages/attendance/AttendanceGridPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceGridPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import api from "@/api/client";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { ChevronLeft, ChevronRight, Loader2, Search, X, CalendarPlus, AlertTriangle, Download } from "lucide-react";
 import * as XLSX from "xlsx";
 
@@ -116,6 +117,13 @@ export default function AttendanceGridPage() {
   // without waiting for the refetch (the refetch still fires).
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [editing, setEditing] = useState<{ uid: number; date: string } | null>(null);
+  const [pendingLeaveOverride, setPendingLeaveOverride] = useState<{
+    uid: number;
+    date: string;
+    code: string;
+    leaveCode: string;
+  } | null>(null);
+  const [savingLeaveOverride, setSavingLeaveOverride] = useState(false);
   // Client-side filters — the row set is small (one row per active employee
   // in the org) so filtering with useMemo is plenty fast and avoids round-
   // tripping the whole grid on every keystroke.
@@ -222,6 +230,17 @@ export default function AttendanceGridPage() {
   };
 
   async function commitCell(uid: number, date: string, newCode: string) {
+    const employee = data.employees.find((item) => item.user_id === uid);
+    const approvedLeave = employee?.leaves?.[date];
+    if (newCode === "P" && approvedLeave) {
+      setEditing(null);
+      setPendingLeaveOverride({ uid, date, code: newCode, leaveCode: approvedLeave.code });
+      return;
+    }
+    await saveCell(uid, date, newCode);
+  }
+
+  async function saveCell(uid: number, date: string, newCode: string) {
     setOverrides((prev) => ({ ...prev, [cellKey(uid, date)]: newCode }));
     setEditing(null);
     try {
@@ -804,6 +823,35 @@ export default function AttendanceGridPage() {
       <p className="text-xs text-gray-500 dark:text-gray-400">
         {t("attendance.grid.tip")}
       </p>
+
+      <ConfirmDialog
+        open={pendingLeaveOverride !== null}
+        title="Replace approved leave with Present?"
+        description={
+          pendingLeaveOverride
+            ? `This employee has approved ${pendingLeaveOverride.leaveCode} leave on ${pendingLeaveOverride.date}. ` +
+              "The leave for this date will be cancelled and the deducted balance will be restored."
+            : undefined
+        }
+        confirmText="Mark Present"
+        cancelText="Keep Leave"
+        variant="info"
+        loading={savingLeaveOverride}
+        onCancel={() => {
+          if (!savingLeaveOverride) setPendingLeaveOverride(null);
+        }}
+        onConfirm={async () => {
+          if (!pendingLeaveOverride) return;
+          setSavingLeaveOverride(true);
+          await saveCell(
+            pendingLeaveOverride.uid,
+            pendingLeaveOverride.date,
+            pendingLeaveOverride.code,
+          );
+          setSavingLeaveOverride(false);
+          setPendingLeaveOverride(null);
+        }}
+      />
     </div>
   );
 }

--- a/packages/server/src/api/routes/attendance.routes.ts
+++ b/packages/server/src/api/routes/attendance.routes.ts
@@ -758,6 +758,7 @@ router.put("/cell", authenticate, requirePermission("attendance:manage"), async 
     const result = await attendanceService.updateAttendanceCell(req.user!.org_id, {
       userId: Number(user_id),
       date: String(date),
+      actorUserId: req.user!.sub,
       code: String(code ?? ""),
     });
     sendSuccess(res, result);

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -1637,7 +1637,7 @@ export async function getMonthlyGrid(
 // directly settable -- they're calendar-derived defaults.
 export async function updateAttendanceCell(
   orgId: number,
-  params: { userId: number; date: string; code: string },
+  params: { userId: number; date: string; code: string; actorUserId?: number },
 ) {
   const db = getDB();
   if (!/^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
@@ -1674,6 +1674,107 @@ export async function updateAttendanceCell(
     throw new Error(
       `Unknown status code "${params.code}". Use P / A / H / L / HPL / WOT / HOT / WO / HO.`,
     );
+  }
+  // A Present override is authoritative over an approved leave. Reverse a
+  // application date and restore its balance before saving attendance;
+  // otherwise the monthly grid would merge the approved leave back to L on
+  // every refresh. Multi-day applications are split around the worked date so
+  // the rest of the approved leave remains intact.
+  if (upper === "P") {
+    const approvedLeave = await db("leave_applications")
+      .where({ organization_id: orgId, user_id: params.userId, status: "approved" })
+      .where("start_date", "<=", params.date)
+      .where("end_date", ">=", params.date)
+      .first();
+    if (approvedLeave) {
+      const start = String(approvedLeave.start_date).slice(0, 10);
+      const end = String(approvedLeave.end_date).slice(0, 10);
+      const refundDays = approvedLeave.is_half_day ? 0.5 : 1;
+      await db.transaction(async (trx) => {
+        const now = new Date();
+        await trx("leave_applications").where({ id: approvedLeave.id }).update({
+          status: "cancelled",
+          updated_at: now,
+        });
+        const ranges: Array<{ start_date: string; end_date: string }> = [];
+        const before = new Date(`${params.date}T00:00:00Z`);
+        before.setUTCDate(before.getUTCDate() - 1);
+        const after = new Date(`${params.date}T00:00:00Z`);
+        after.setUTCDate(after.getUTCDate() + 1);
+        const beforeIso = before.toISOString().slice(0, 10);
+        const afterIso = after.toISOString().slice(0, 10);
+        if (start <= beforeIso) ranges.push({ start_date: start, end_date: beforeIso });
+        if (afterIso <= end) ranges.push({ start_date: afterIso, end_date: end });
+
+        // Preserve the remaining approved dates as up to two applications.
+        // Allocate the original debit minus the one restored day across the
+        // chronological segments; the final segment receives the exact
+        // remainder, keeping total leave usage unchanged except for this day.
+        let remainingDays = Math.max(0, Number(approvedLeave.days_count) - refundDays);
+        const calendarDays = ranges.map(
+          (range) => Math.floor((Date.parse(range.end_date) - Date.parse(range.start_date)) / 86400000) + 1,
+        );
+        let remainingCalendarDays = calendarDays.reduce((total, days) => total + days, 0);
+        for (let index = 0; index < ranges.length && remainingDays > 0; index += 1) {
+          const segmentDays = index === ranges.length - 1
+            ? remainingDays
+            : Math.min(
+                remainingDays,
+                Math.round((remainingDays * calendarDays[index] / remainingCalendarDays) * 2) / 2,
+              );
+          remainingDays = Math.max(0, remainingDays - segmentDays);
+          remainingCalendarDays -= calendarDays[index];
+          if (segmentDays <= 0) continue;
+          const {
+            id: _id,
+            created_at: _createdAt,
+            updated_at: _updatedAt,
+            ...applicationCopy
+          } = approvedLeave;
+          await trx("leave_applications").insert({
+            ...applicationCopy,
+            ...ranges[index],
+            days_count: segmentDays,
+            status: "approved",
+            reason: `${approvedLeave.reason} [Attendance override on ${params.date}]`,
+            created_at: now,
+            updated_at: now,
+          });
+        }
+        const balance = await trx("leave_balances")
+          .where({
+            organization_id: orgId,
+            user_id: params.userId,
+            leave_type_id: approvedLeave.leave_type_id,
+          })
+          .orderBy("year", "desc")
+          .first()
+          .forUpdate();
+        if (!balance) throw new ValidationError("Leave balance not found; override was not saved.");
+        await trx("leave_balances").where({ id: balance.id }).update({
+          total_used: Math.max(0, Number(balance.total_used) - refundDays),
+          balance: Number(balance.balance) + refundDays,
+          period_used: Math.max(0, Number(balance.period_used || 0) - refundDays),
+          updated_at: now,
+        });
+        const attendance = await trx("attendance_records")
+          .where({ user_id: params.userId, organization_id: orgId, date: params.date })
+          .first();
+        if (attendance) {
+          await trx("attendance_records").where({ id: attendance.id }).update({ status, updated_at: now });
+        } else {
+          await trx("attendance_records").insert({
+            user_id: params.userId,
+            organization_id: orgId,
+            date: params.date,
+            status,
+            created_at: now,
+            updated_at: now,
+          });
+        }
+      });
+      return { ok: true, action: "updated", status, reversed_leave: true };
+    }
   }
   const existing = await db("attendance_records")
     .where({ user_id: params.userId, organization_id: orgId, date: params.date })


### PR DESCRIPTION
## What & why

When an employee had an approved leave but later worked, HR could mark the Attendance Grid cell as Present only temporarily. After refresh, the approved leave merge took precedence and the cell returned to CL/on-leave.

## Changes

- Add the standard EMP Cloud confirmation dialog before replacing approved leave with Present.
- Make a Present override cancel the selected approved leave date and restore the deducted balance.
- Split multi-day approved leave around the worked date so surrounding leave dates remain approved.
- Save attendance, leave, and balance changes atomically in one transaction.
- Pass the acting user through the attendance cell route for future audit enrichment.

## Verification

- Client `tsc --noEmit` passes.
- Server `tsc --noEmit` passes.
- Local API health returns HTTP 200.
- Verified local data for the reported July scenario: overridden dates remain Present and the remaining date stays approved CL after refresh.

## Review notes

Draft requested because regression review identified follow-up hardening areas before merge:

- Preserve approval-history attribution on split leave records.
- Restore balances against the exact fiscal year/accrual period for historical leave.
- Recalculate split `days_count` using shift week-offs and mandatory holidays.
- Add focused regression tests for single-day, multi-day, half-day, and historical overrides.

Existing test limitations: four pre-existing attendance mock-test failures remain; DB-backed leave tests cannot authenticate with their configured test database credentials.