### PR TITLE
fix(attendance): persist absent override for approved leave

### DIFF
--- a/packages/client/src/pages/attendance/AttendanceGridPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceGridPage.tsx
@@ -232,7 +232,7 @@ export default function AttendanceGridPage() {
   async function commitCell(uid: number, date: string, newCode: string) {
     const employee = data.employees.find((item) => item.user_id === uid);
     const approvedLeave = employee?.leaves?.[date];
-    if (newCode === "P" && approvedLeave) {
+    if ((newCode === "P" || newCode === "A") && approvedLeave) {
       setEditing(null);
       setPendingLeaveOverride({ uid, date, code: newCode, leaveCode: approvedLeave.code });
       return;
@@ -826,14 +826,16 @@ export default function AttendanceGridPage() {
 
       <ConfirmDialog
         open={pendingLeaveOverride !== null}
-        title="Replace approved leave with Present?"
+        title={pendingLeaveOverride?.code === "A"
+          ? "Replace approved leave with Absent?"
+          : "Replace approved leave with Present?"}
         description={
           pendingLeaveOverride
             ? `This employee has approved ${pendingLeaveOverride.leaveCode} leave on ${pendingLeaveOverride.date}. ` +
               "The leave for this date will be cancelled and the deducted balance will be restored."
             : undefined
         }
-        confirmText="Mark Present"
+        confirmText={pendingLeaveOverride?.code === "A" ? "Mark Absent" : "Mark Present"}
         cancelText="Keep Leave"
         variant="info"
         loading={savingLeaveOverride}

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -1754,12 +1754,12 @@ export async function updateAttendanceCell(
       `Unknown status code "${params.code}". Use P / A / H / L / HPL / WOT / HOT / WO / HO.`,
     );
   }
-  // A Present override is authoritative over an approved leave. Reverse a
+  // A Present or Absent override is authoritative over an approved leave. Reverse a
   // application date and restore its balance before saving attendance;
   // otherwise the monthly grid would merge the approved leave back to L on
   // every refresh. Multi-day applications are split around the worked date so
   // the rest of the approved leave remains intact.
-  if (upper === "P") {
+  if (upper === "P" || upper === "A") {
     const approvedLeave = await db("leave_applications")
       .where({ organization_id: orgId, user_id: params.userId, status: "approved" })
       .where("start_date", "<=", params.date)


### PR DESCRIPTION
## Summary
- show the same confirmation dialog when replacing approved leave with Absent as the existing Present override flow
- label the actions as **Mark Absent** and **Keep Leave**
- run Absent through the same transactional leave reversal used by Present
- cancel only the affected leave date, preserve remaining multi-day leave dates, restore the deducted balance, and persist attendance as absent

## Validation
- `pnpm --filter @empcloud/server typecheck`
- `pnpm --filter @empcloud/client typecheck`
- `git diff --check`
- local API health: 200 OK
- local client route: 200 OK