### PR TITLE
fix(attendance): show leave override cancellation audit

### DIFF
--- a/packages/client/src/pages/attendance/AttendanceGridPage.tsx
+++ b/packages/client/src/pages/attendance/AttendanceGridPage.tsx
@@ -250,6 +250,7 @@ export default function AttendanceGridPage() {
         code: newCode,
       });
       qc.invalidateQueries({ queryKey });
+      qc.invalidateQueries({ queryKey: ["grid-leave-context", uid, date] });
       setStatus({ kind: "ok", text: t("attendance.grid.savedToast", { code: newCode || "—", date }) });
     } catch (err: any) {
       // Roll the override back on failure.
@@ -919,6 +920,7 @@ function CellEditor({
     days_count: number;
     is_half_day: boolean;
     half_day_type: "first_half" | "second_half" | null;
+    cancelled_by_name: string | null;
   }> = ctxRes?.existingApplications ?? [];
 
   useEffect(() => {
@@ -998,11 +1000,18 @@ function CellEditor({
 
       {existingApplications.length > 0 && (
         <div className="mb-3 rounded-md border border-blue-200 bg-blue-50 p-2 text-xs text-blue-900 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200">
-          <p className="mb-1 font-semibold">{t("attendance.grid.editor.existingLeave")}</p>
+          <p className="mb-1 font-semibold">
+            {existingApplications.every((application) => application.status === "cancelled")
+              ? "Leave cancellation history"
+              : t("attendance.grid.editor.existingLeave")}
+          </p>
           <ul className="space-y-0.5">
             {existingApplications.map((a) => (
               <li key={a.id} className="flex items-center justify-between gap-2">
                 <span className="truncate">
+                  {a.status === "cancelled" && a.cancelled_by_name
+                    ? "Leave cancelled by " + a.cancelled_by_name + ": "
+                    : null}
                   {a.leave_type_name}
                   {a.is_half_day && (
                     <span className="ml-1 text-blue-700/70">

--- a/packages/server/src/api/routes/attendance.routes.ts
+++ b/packages/server/src/api/routes/attendance.routes.ts
@@ -793,7 +793,16 @@ router.get(
             "leave_applications.organization_id": orgId,
             "leave_applications.user_id": userId,
           })
-          .whereNotIn("leave_applications.status", ["cancelled", "rejected"])
+          .whereNot("leave_applications.status", "rejected")
+          .andWhere(function () {
+            this.whereNot("leave_applications.status", "cancelled").orWhere(function () {
+              this.where("leave_applications.status", "cancelled").andWhere(
+                "leave_applications.reason",
+                "like",
+                `%[Leave cancelled by % via Attendance Grid on ${date}]%`,
+              );
+            });
+          })
           .where("leave_applications.start_date", "<=", date)
           .where("leave_applications.end_date", ">=", date)
           .select(
@@ -831,7 +840,17 @@ router.get(
         };
       });
 
-      sendSuccess(res, { leaveTypes: merged, existingApplications: existing });
+      const existingWithAudit = existing.map((application: any) => {
+        const match = String(application.reason || "").match(
+          /\[Leave cancelled by (.+?) via Attendance Grid on \d{4}-\d{2}-\d{2}\]/,
+        );
+        return {
+          ...application,
+          cancelled_by_name: match?.[1] || null,
+        };
+      });
+
+      sendSuccess(res, { leaveTypes: merged, existingApplications: existingWithAudit });
     } catch (err) {
       next(err);
     }

--- a/packages/server/src/services/attendance/attendance.service.ts
+++ b/packages/server/src/services/attendance/attendance.service.ts
@@ -1766,6 +1766,16 @@ export async function updateAttendanceCell(
       .where("end_date", ">=", params.date)
       .first();
     if (approvedLeave) {
+      const actor = params.actorUserId
+        ? await db("users")
+            .where({ id: params.actorUserId, organization_id: orgId })
+            .select("first_name", "last_name")
+            .first()
+        : null;
+      const actorName = actor
+        ? `${actor.first_name || ""} ${actor.last_name || ""}`.trim() || `User #${params.actorUserId}`
+        : "an administrator";
+      const cancellationAudit = `[Leave cancelled by ${actorName} via Attendance Grid on ${params.date}]`;
       const start = String(approvedLeave.start_date).slice(0, 10);
       const end = String(approvedLeave.end_date).slice(0, 10);
       const refundDays = approvedLeave.is_half_day ? 0.5 : 1;
@@ -1773,6 +1783,7 @@ export async function updateAttendanceCell(
         const now = new Date();
         await trx("leave_applications").where({ id: approvedLeave.id }).update({
           status: "cancelled",
+          reason: `${approvedLeave.reason ? `${approvedLeave.reason} ` : ""}${cancellationAudit}`,
           updated_at: now,
         });
         const ranges: Array<{ start_date: string; end_date: string }> = [];


### PR DESCRIPTION
## Summary
- refresh leave context after overriding approved leave from the attendance grid
- show cancellation history instead of an approved-leave message after the override
- record and display the administrator who cancelled the leave

## Validation
- pnpm --filter @empcloud/client typecheck
- pnpm --filter @empcloud/server typecheck
- git diff --check